### PR TITLE
feat(update): add taskwarrior and MCP auto-installation

### DIFF
--- a/.devcontainer/features/claude/.claude/commands/build.md
+++ b/.devcontainer/features/claude/.claude/commands/build.md
@@ -23,6 +23,41 @@ BASE="https://raw.githubusercontent.com/$REPO/main/.devcontainer/features"
 
 ---
 
+## Prérequis (auto-check)
+
+Avant toute action, vérifier et configurer automatiquement :
+
+```bash
+# 1. Vérifier taskwarrior
+if ! command -v task &>/dev/null; then
+    echo "⚠ Taskwarrior non installé. Exécuter /update d'abord."
+    exit 1
+fi
+
+# 2. Configurer UDAs si absents
+if ! task _get rc.uda.model.type &>/dev/null 2>&1; then
+    echo "Configuring taskwarrior UDAs..."
+    task config uda.model.type string
+    task config uda.model.values opus,sonnet,haiku
+    task config uda.model.default sonnet
+    task config uda.parallel.type string
+    task config uda.parallel.values yes,no
+    task config uda.parallel.default no
+    task config uda.phase.type numeric
+    task config uda.phase.default 1
+    echo "✓ UDAs configured"
+fi
+
+# 3. Vérifier MCP taskwarrior
+if [ -f ".mcp.json" ]; then
+    if ! grep -q "taskwarrior" .mcp.json 2>/dev/null; then
+        echo "⚠ MCP taskwarrior manquant. Exécuter /update."
+    fi
+fi
+```
+
+---
+
 ## Détection
 
 - **SI `/src` n'existe PAS** → Assistant d'initialisation

--- a/.devcontainer/features/claude/.mcp.json
+++ b/.devcontainer/features/claude/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "taskwarrior": {
+      "command": "npx",
+      "args": ["-y", "mcp-server-taskwarrior"],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Automatic installation and configuration of Taskwarrior + MCP for the `/build` workflow.

## Changes

### `/update` now:
- Installs **taskwarrior** if missing (apt/brew/apk depending on OS)
- Downloads `.mcp.json` with taskwarrior MCP server config
- **Merges** MCP config with existing (preserves user's other servers)

### `/build` now:
- Auto-checks taskwarrior is installed (warns if missing)
- Auto-configures **UDAs** if missing:
  - `model`: opus, sonnet, haiku
  - `parallel`: yes, no
  - `phase`: numeric
- Warns if MCP taskwarrior is not configured

### New file: `.mcp.json`
Template with taskwarrior MCP server (no secrets, safe to distribute)

## Test plan

- [ ] Run `/update` → taskwarrior installed
- [ ] Run `/update` → .mcp.json created/merged
- [ ] Run `/build` → UDAs auto-configured
- [ ] Verify status-line shows taskwarrior info

🤖 Generated with [Claude Code](https://claude.com/claude-code)