### PR TITLE
fix(claude): auto-install Taskwarrior and graceful fallback

### DIFF
--- a/.devcontainer/features/claude/.claude/scripts/task-init.sh
+++ b/.devcontainer/features/claude/.claude/scripts/task-init.sh
@@ -4,6 +4,21 @@
 
 set -euo pipefail
 
+# Vérifier que Taskwarrior est installé
+if ! command -v task &>/dev/null; then
+    echo "❌ Taskwarrior non installé !"
+    echo ""
+    echo "Installation requise pour /feature et /fix :"
+    echo ""
+    echo "  Ubuntu/Debian : sudo apt-get install taskwarrior"
+    echo "  Alpine        : sudo apk add task"
+    echo "  macOS         : brew install task"
+    echo "  Arch          : sudo pacman -S task"
+    echo ""
+    echo "Ou exécutez: /update"
+    exit 1
+fi
+
 TYPE="$1"        # feature ou fix
 DESC="$2"        # Description
 

--- a/.devcontainer/features/claude/.claude/scripts/task-validate.sh
+++ b/.devcontainer/features/claude/.claude/scripts/task-validate.sh
@@ -5,6 +5,13 @@
 
 set -euo pipefail
 
+# Vérifier que Taskwarrior est installé
+if ! command -v task &>/dev/null; then
+    echo "⚠️  Taskwarrior non installé - validation désactivée"
+    echo "→ Pour activer le suivi obligatoire: /update"
+    exit 0  # Autoriser quand même (dégradé graceful)
+fi
+
 # Lire l'input JSON de Claude
 INPUT=$(cat)
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')

--- a/.devcontainer/features/claude/install.sh
+++ b/.devcontainer/features/claude/install.sh
@@ -27,39 +27,60 @@ if ! command -v claude &>/dev/null; then
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────
-# 2. Créer les dossiers
+# 2. Installer Taskwarrior (obligatoire pour /feature et /fix)
+# ─────────────────────────────────────────────────────────────────────────────
+echo "→ Installing Taskwarrior..."
+if ! command -v task &>/dev/null; then
+    if command -v apt-get &>/dev/null; then
+        sudo apt-get update -qq && sudo apt-get install -y -qq taskwarrior && echo "  ✓ taskwarrior"
+    elif command -v apk &>/dev/null; then
+        sudo apk add --no-cache task && echo "  ✓ taskwarrior"
+    elif command -v brew &>/dev/null; then
+        brew install task && echo "  ✓ taskwarrior"
+    elif command -v pacman &>/dev/null; then
+        sudo pacman -S --noconfirm task && echo "  ✓ taskwarrior"
+    else
+        echo "  ⚠ taskwarrior (manual install required: https://taskwarrior.org/download/)"
+    fi
+else
+    echo "  ✓ taskwarrior (already installed)"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Créer les dossiers
 # ─────────────────────────────────────────────────────────────────────────────
 echo "→ Setting up $TARGET/.claude/..."
 mkdir -p "$TARGET/.claude/commands"
 mkdir -p "$TARGET/.claude/scripts"
+mkdir -p "$TARGET/.claude/sessions"
 
 # ─────────────────────────────────────────────────────────────────────────────
-# 3. Télécharger les commandes
+# 4. Télécharger les commandes
 # ─────────────────────────────────────────────────────────────────────────────
 echo "→ Downloading commands..."
-for cmd in build run commit secret install update; do
+for cmd in build commit secret install update feature fix; do
     curl -sL "$BASE/.claude/commands/$cmd.md" -o "$TARGET/.claude/commands/$cmd.md" 2>/dev/null && echo "  ✓ /$cmd"
 done
 
 # ─────────────────────────────────────────────────────────────────────────────
-# 4. Télécharger les scripts
+# 5. Télécharger les scripts (hooks + Taskwarrior)
 # ─────────────────────────────────────────────────────────────────────────────
 echo "→ Downloading scripts..."
-for script in format imports lint post-edit pre-validate security test typecheck; do
+for script in format imports lint post-edit pre-validate security test typecheck task-validate task-log task-init task-subtasks; do
     curl -sL "$BASE/.claude/scripts/$script.sh" -o "$TARGET/.claude/scripts/$script.sh" 2>/dev/null && \
     chmod +x "$TARGET/.claude/scripts/$script.sh"
 done
-echo "  ✓ hooks (format, lint, security...)"
+echo "  ✓ hooks (format, lint, security, taskwarrior...)"
 
 # ─────────────────────────────────────────────────────────────────────────────
-# 5. Télécharger settings.json
+# 6. Télécharger settings.json
 # ─────────────────────────────────────────────────────────────────────────────
 echo "→ Downloading settings..."
 curl -sL "$BASE/.claude/settings.json" -o "$TARGET/.claude/settings.json" 2>/dev/null
 echo "  ✓ settings.json"
 
 # ─────────────────────────────────────────────────────────────────────────────
-# 6. Télécharger CLAUDE.md (si pas existant)
+# 7. Télécharger CLAUDE.md (si pas existant)
 # ─────────────────────────────────────────────────────────────────────────────
 if [ ! -f "$TARGET/CLAUDE.md" ]; then
     curl -sL "$BASE/CLAUDE.md" -o "$TARGET/CLAUDE.md" 2>/dev/null
@@ -67,7 +88,27 @@ if [ ! -f "$TARGET/CLAUDE.md" ]; then
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────
-# 7. Installer status-line (binaire officiel)
+# 8. Configurer MCP (Taskwarrior)
+# ─────────────────────────────────────────────────────────────────────────────
+echo "→ Configuring MCP..."
+MCP_FILE="$TARGET/.mcp.json"
+TASKWARRIOR_MCP='{"taskwarrior":{"command":"npx","args":["-y","mcp-server-taskwarrior"]}}'
+
+if [ -f "$MCP_FILE" ]; then
+    # Merge with existing
+    if command -v jq &>/dev/null; then
+        jq --argjson tw "$TASKWARRIOR_MCP" '.mcpServers += $tw' "$MCP_FILE" > "$MCP_FILE.tmp" && mv "$MCP_FILE.tmp" "$MCP_FILE"
+        echo "  ✓ .mcp.json (merged + taskwarrior)"
+    else
+        echo "  ⚠ .mcp.json (jq not found, manual config needed)"
+    fi
+else
+    echo "{\"mcpServers\":$TASKWARRIOR_MCP}" > "$MCP_FILE"
+    echo "  ✓ .mcp.json (created + taskwarrior)"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 9. Installer status-line (binaire officiel)
 # ─────────────────────────────────────────────────────────────────────────────
 echo "→ Installing status-line..."
 mkdir -p "$HOME/.local/bin"
@@ -116,10 +157,13 @@ echo "════════════════════════�
 echo "  ✓ Installation complete!"
 echo ""
 echo "  Commandes disponibles:"
-echo "    /build   - Planifier un projet"
-echo "    /run     - Exécuter des tâches"
+echo "    /feature - Développer une fonctionnalité"
+echo "    /fix     - Corriger un bug"
+echo "    /build   - Générer le contexte"
 echo "    /commit  - Workflow git"
 echo "    /update  - Mettre à jour depuis GitHub"
+echo ""
+echo "  Taskwarrior: $(command -v task &>/dev/null && echo '✓ Installé' || echo '⚠ Non installé')"
 echo ""
 echo "  → Relance 'claude' pour charger les commandes"
 echo "═══════════════════════════════════════════"


### PR DESCRIPTION
## Bug

Taskwarrior n'était pas installé automatiquement lors du one-liner install, causant des erreurs quand `/feature` ou `/fix` était utilisé.

## Root cause

Le script `install.sh` ne contenait pas :
- L'installation de Taskwarrior
- Le téléchargement des scripts `task-*.sh`
- La création du dossier `.claude/sessions/`
- La configuration MCP pour Taskwarrior

## Fix

### install.sh
- Ajout installation Taskwarrior (apt/apk/brew/pacman)
- Téléchargement de `/feature` et `/fix` commands
- Téléchargement des scripts `task-validate`, `task-log`, `task-init`, `task-subtasks`
- Création du dossier `.claude/sessions/`
- Configuration MCP avec `mcp-server-taskwarrior`

### task-validate.sh
- Ajout fallback gracieux quand Taskwarrior n'est pas installé
- Affiche un warning mais autorise l'opération (dégradé graceful)

### task-init.sh
- Ajout message d'erreur clair avec instructions d'installation

## Test plan

- [ ] One-liner install sur système vierge
- [ ] Vérifier que Taskwarrior est installé
- [ ] Vérifier `/feature test` fonctionne
- [ ] Vérifier fallback sans Taskwarrior (warning affiché)

🤖 Generated with [Claude Code](https://claude.com/claude-code)