### PR TITLE
chore(docker): use registry image with pull_policy always

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,13 +1,9 @@
 services:
   devcontainer:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      # Always pull latest base image on rebuild
-      pull: true
-      # Build arguments for optimization
-      args:
-        BUILDKIT_INLINE_CACHE: 1
+    # Use pre-built image from GitHub Container Registry
+    image: ghcr.io/kodflow/devcontainer-template:latest
+    # Always pull latest image on container creation/rebuild
+    pull_policy: always
 
     env_file:
       - .env


### PR DESCRIPTION
## Summary

- Switch from local Dockerfile build to pre-built ghcr.io image
- Add `pull_policy: always` to ensure latest image on every rebuild

## Changes

- `.devcontainer/docker-compose.yml`: Replace `build:` block with `image:` + `pull_policy`

## Benefits

- Faster container startup (no local build)
- Consistent environment across all users
- Automatic updates when image is republished