### PR TITLE
feat(ci): add repository_dispatch trigger for ktn-linter releases

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -15,6 +15,8 @@ on:
     # Daily build at 4:00 AM UTC
     - cron: '0 4 * * *'
   workflow_dispatch:
+  repository_dispatch:
+    types: [ktn-linter-release]
 
 # Cancel in-progress runs when a new run is triggered
 concurrency:


### PR DESCRIPTION
## Summary
- Accept repository_dispatch events with type ktn-linter-release
- Automatically rebuild devcontainer when ktn-linter is updated

## How it works
When ktn-linter creates a new release, it will send a repository_dispatch event to trigger a rebuild of the devcontainer image with the latest linter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)