### PR TITLE
fix(hooks): download binaries from GitHub releases instead of Docker image

### DIFF
--- a/.devcontainer/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/hooks/lifecycle/postStart.sh
@@ -57,7 +57,7 @@ fi
 # Download latest binaries from GitHub (bypass Docker cache issues)
 # ============================================================================
 download_latest_binary() {
-    local repo="$1"
+    local full_repo="$1"  # Format: owner/repo (e.g., kodflow/status-line)
     local binary="$2"
     local target="$HOME/.local/bin/$binary"
 
@@ -71,7 +71,7 @@ download_latest_binary() {
 
     # Get latest version from GitHub API
     local latest_version
-    latest_version=$(curl -fsSL "https://api.github.com/repos/kodflow/$repo/releases/latest" 2>/dev/null | jq -r '.tag_name // empty')
+    latest_version=$(curl -fsSL "https://api.github.com/repos/$full_repo/releases/latest" 2>/dev/null | jq -r '.tag_name // empty')
 
     if [ -z "$latest_version" ]; then
         log_warning "Failed to get latest version for $binary"
@@ -91,7 +91,7 @@ download_latest_binary() {
     # Download if version differs or binary missing
     if [ "$current_version" != "$latest_version" ]; then
         log_info "Updating $binary: ${current_version:-none} -> $latest_version"
-        local url="https://github.com/kodflow/$repo/releases/latest/download/$binary-linux-$arch"
+        local url="https://github.com/$full_repo/releases/latest/download/$binary-linux-$arch"
 
         if curl -fsSL "$url" -o "$target.tmp" 2>/dev/null; then
             mv "$target.tmp" "$target"
@@ -109,8 +109,8 @@ download_latest_binary() {
 
 mkdir -p "$HOME/.local/bin"
 log_info "Checking for latest binaries..."
-download_latest_binary "status-line" "status-line"
-download_latest_binary "ktn-linter" "ktn-linter"
+download_latest_binary "kodflow/status-line" "status-line"
+download_latest_binary "kodflow/ktn-linter" "ktn-linter"
 
 # Restore NVM symlinks (node, npm, npx, claude)
 NVM_DIR="${NVM_DIR:-$HOME/.cache/nvm}"


### PR DESCRIPTION
## Summary

- Replace copying binaries from `/opt/kodflow/bin/` with direct download from GitHub releases
- Bypass Docker layer cache issues that caused outdated versions (e.g., ktn-linter 1.3.67 instead of 1.3.69)
- Download only when local version differs from latest release

## Changes

- `.devcontainer/hooks/lifecycle/postStart.sh`: Add `download_latest_binary()` function that:
  - Fetches latest version from GitHub API
  - Compares with locally installed version
  - Downloads only when update needed
  - Supports version detection via `--version` flag or help output

## Test plan

- [ ] Rebuild devcontainer
- [ ] Verify ktn-linter and status-line are at latest versions
- [ ] Re-run postStart.sh and confirm "already at" message appears