### PR TITLE
fix(hooks): add timeouts to curl commands in postStart.sh

### DIFF
--- a/.devcontainer/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/hooks/lifecycle/postStart.sh
@@ -71,7 +71,7 @@ download_latest_binary() {
 
     # Get latest version from GitHub API
     local latest_version
-    latest_version=$(curl -fsSL "https://api.github.com/repos/$full_repo/releases/latest" 2>/dev/null | jq -r '.tag_name // empty')
+    latest_version=$(curl -fsSL --connect-timeout 5 --max-time 15 "https://api.github.com/repos/$full_repo/releases/latest" 2>/dev/null | jq -r '.tag_name // empty')
 
     if [ -z "$latest_version" ]; then
         log_warning "Failed to get latest version for $binary"
@@ -93,7 +93,7 @@ download_latest_binary() {
         log_info "Updating $binary: ${current_version:-none} -> $latest_version"
         local url="https://github.com/$full_repo/releases/latest/download/$binary-linux-$arch"
 
-        if curl -fsSL "$url" -o "$target.tmp" 2>/dev/null; then
+        if curl -fsSL --connect-timeout 10 --max-time 60 "$url" -o "$target.tmp" 2>/dev/null; then
             mv "$target.tmp" "$target"
             chmod +x "$target"
             log_success "$binary updated to $latest_version"


### PR DESCRIPTION
## Summary
- Add connection and max timeouts to curl commands in `download_latest_binary()`
- Prevents container startup from hanging indefinitely when GitHub API or downloads are slow

## Changes
- API calls: `--connect-timeout 5 --max-time 15`
- Binary downloads: `--connect-timeout 10 --max-time 60`

## Test plan
- [x] Verified GitHub API endpoints are accessible
- [x] Verified binary downloads work correctly
- [x] Timeouts will gracefully fail with warning instead of blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)