### PR TITLE
fix(hooks): force docker pull on rebuild to bypass cache

### DIFF
--- a/.devcontainer/hooks/lifecycle/initialize.sh
+++ b/.devcontainer/hooks/lifecycle/initialize.sh
@@ -106,6 +106,13 @@ fi
 echo "All features validated successfully"
 
 # ============================================================================
+# Pull latest Docker image (bypass Docker cache on rebuild)
+# ============================================================================
+echo ""
+echo "Pulling latest devcontainer image..."
+docker pull ghcr.io/kodflow/devcontainer-template:latest 2>/dev/null || echo "Warning: Could not pull latest image, using cached version"
+
+# ============================================================================
 # Clean up existing containers to prevent race conditions during rebuild
 # ============================================================================
 echo ""


### PR DESCRIPTION
## Summary
- Add `docker pull` in `initialize.sh` to force latest image on every rebuild
- Fixes issue where VS Code "Rebuild Container" uses cached image instead of pulling latest

## Changes
- Added docker pull before container cleanup in initialize.sh
- Graceful fallback if pull fails (uses cached version with warning)

## Test plan
- [x] Rebuild will now always pull latest image
- [x] Works even if network is unavailable (uses cache with warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)