### PR TITLE
fix(docker): remove unused pull_policy from docker-compose.yml

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   devcontainer:
-    # Use pre-built image from GitHub Container Registry
-    pull_policy: always
+    # Build from Dockerfile (uses GHCR base image)
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary
- Remove `pull_policy: always` which has no effect without an `image:` attribute
- Simplify docker-compose.yml configuration

## Context
Per [Docker Compose docs](https://docs.docker.com/reference/compose-file/build/), `pull_policy` only applies when both `build:` and `image:` are present. Since we only have `build:`, the setting was ignored.

## Image freshness is ensured by:
1. `docker pull` in `initialize.sh` (runs before build)
2. `build: pull: true` (pulls FROM images during build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)