### PR TITLE
fix(features): move binary installations to their respective features

### DIFF
--- a/.devcontainer/features/languages/go/install.sh
+++ b/.devcontainer/features/languages/go/install.sh
@@ -82,8 +82,19 @@ mkdir -p "$GOPATH/src"
 mkdir -p "$GOCACHE"
 mkdir -p "$GOMODCACHE"
 
-# ktn-linter - Moved to postCreate.sh for automatic updates
-# Installed by: .devcontainer/hooks/shared/update-tools.sh
+# ─────────────────────────────────────────────────────────────────────────────
+# Install ktn-linter (Go-specific linter)
+# ─────────────────────────────────────────────────────────────────────────────
+echo -e "${YELLOW}Installing ktn-linter...${NC}"
+mkdir -p "$HOME/.local/bin"
+
+KTN_URL="https://github.com/kodflow/ktn-linter/releases/latest/download/ktn-linter-linux-${GO_ARCH}"
+if curl -fsSL --connect-timeout 10 --max-time 60 "$KTN_URL" -o "$HOME/.local/bin/ktn-linter" 2>/dev/null; then
+    chmod +x "$HOME/.local/bin/ktn-linter"
+    echo -e "${GREEN}✓ ktn-linter installed${NC}"
+else
+    echo -e "${YELLOW}⚠ ktn-linter download failed (optional)${NC}"
+fi
 
 echo ""
 echo -e "${GREEN}=========================================${NC}"
@@ -93,8 +104,7 @@ echo ""
 echo "Installed components:"
 echo "  - ${GO_INSTALLED}"
 echo "  - Go Modules (package manager)"
-echo ""
-echo "Note: ktn-linter is installed via postCreate.sh for automatic updates"
+echo "  - ktn-linter (Go linter)"
 echo ""
 echo "Cache directories:"
 echo "  - GOPATH: $GOPATH"

--- a/.devcontainer/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/hooks/lifecycle/postStart.sh
@@ -53,65 +53,6 @@ if [ -d "$KODFLOW_BACKUP/.claude" ]; then
     mkdir -p "$HOME/.claude/sessions"
 fi
 
-# ============================================================================
-# Download latest binaries from GitHub (bypass Docker cache issues)
-# ============================================================================
-download_latest_binary() {
-    local full_repo="$1"  # Format: owner/repo (e.g., kodflow/status-line)
-    local binary="$2"
-    local target="$HOME/.local/bin/$binary"
-
-    # Detect architecture
-    local arch
-    arch=$(uname -m)
-    case "$arch" in
-        x86_64)  arch="amd64" ;;
-        aarch64) arch="arm64" ;;
-    esac
-
-    # Get latest version from GitHub API
-    local latest_version
-    latest_version=$(curl -fsSL --connect-timeout 5 --max-time 15 "https://api.github.com/repos/$full_repo/releases/latest" 2>/dev/null | jq -r '.tag_name // empty')
-
-    if [ -z "$latest_version" ]; then
-        log_warning "Failed to get latest version for $binary"
-        return 1
-    fi
-
-    # Check current version (if binary exists)
-    local current_version=""
-    if [ -x "$target" ]; then
-        # Try --version first, fallback to parsing help output
-        current_version=$("$target" --version 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-        if [ -z "$current_version" ]; then
-            current_version=$("$target" 2>&1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-        fi
-    fi
-
-    # Download if version differs or binary missing
-    if [ "$current_version" != "$latest_version" ]; then
-        log_info "Updating $binary: ${current_version:-none} -> $latest_version"
-        local url="https://github.com/$full_repo/releases/latest/download/$binary-linux-$arch"
-
-        if curl -fsSL --connect-timeout 10 --max-time 60 "$url" -o "$target.tmp" 2>/dev/null; then
-            mv "$target.tmp" "$target"
-            chmod +x "$target"
-            log_success "$binary updated to $latest_version"
-        else
-            rm -f "$target.tmp"
-            log_warning "Failed to download $binary"
-            return 1
-        fi
-    else
-        log_info "$binary already at $latest_version"
-    fi
-}
-
-mkdir -p "$HOME/.local/bin"
-log_info "Checking for latest binaries..."
-download_latest_binary "kodflow/status-line" "status-line"
-download_latest_binary "kodflow/ktn-linter" "ktn-linter"
-
 # Restore NVM symlinks (node, npm, npx, claude)
 NVM_DIR="${NVM_DIR:-$HOME/.cache/nvm}"
 if [ -d "$NVM_DIR/versions/node" ]; then


### PR DESCRIPTION
## Summary
- Move `ktn-linter` installation to Go feature
- Remove duplicate binary downloads from `postStart.sh`
- Binaries only installed when their feature is enabled

## Changes
| Binary | Before | After |
|--------|--------|-------|
| `ktn-linter` | postStart.sh (always) | `features/languages/go/install.sh` |
| `status-line` | postStart.sh + claude feature | `features/claude/install.sh` only |

## Benefits
- No unnecessary downloads if feature not enabled
- No GitHub API calls on every container start
- Faster container startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)