### PR TITLE
feat(commands): add CodeRabbit CLI and --help to all commands

### DIFF
--- a/.devcontainer/images/.claude/commands/build.md
+++ b/.devcontainer/images/.claude/commands/build.md
@@ -17,6 +17,29 @@ Génère le contexte du projet pour optimiser les interactions avec Claude :
 | Pattern | Action |
 |---------|--------|
 | `--context` | Génère CLAUDE.md + update versions |
+| `--help` | Affiche l'aide de la commande |
+
+---
+
+## --help
+
+Quand `--help` est passe, afficher :
+
+```
+═══════════════════════════════════════════════
+  /build - Context Generator
+═══════════════════════════════════════════════
+
+Usage: /build [options]
+
+Options:
+  --context       Genere CLAUDE.md + update versions
+  --help          Affiche cette aide
+
+Exemples:
+  /build --context        Genere le contexte complet
+═══════════════════════════════════════════════
+```
 
 ---
 

--- a/.devcontainer/images/.claude/commands/commit.md
+++ b/.devcontainer/images/.claude/commands/commit.md
@@ -59,6 +59,36 @@ Retourne : `owner repo`
 | `--no-pr`         | Skip la creation de PR                         |
 | `--amend`         | Amend le dernier commit (meme branche)         |
 | `--rename <nom>`  | Renomme la branche avant push/PR               |
+| `--help`          | Affiche l'aide de la commande                  |
+
+---
+
+## --help
+
+Quand `--help` est passe, afficher :
+
+```
+═══════════════════════════════════════════════
+  /commit - Git Workflow Automation
+═══════════════════════════════════════════════
+
+Usage: /commit [options]
+
+Options:
+  (vide)            Workflow complet : branch, commit, push, PR
+  --branch <nom>    Force le nom de branche
+  --no-pr           Skip la creation de PR
+  --amend           Amend le dernier commit
+  --rename <nom>    Renomme la branche avant push/PR
+  --help            Affiche cette aide
+
+Exemples:
+  /commit                   Commit + PR automatique
+  /commit --no-pr           Commit sans creer de PR
+  /commit --amend           Amend le dernier commit
+  /commit --branch feat/x   Force le nom de branche
+═══════════════════════════════════════════════
+```
 
 ---
 

--- a/.devcontainer/images/.claude/commands/feature.md
+++ b/.devcontainer/images/.claude/commands/feature.md
@@ -24,6 +24,33 @@ Workflow complet pour développer une nouvelle fonctionnalité avec **suivi Task
 | `<description>` | Nouvelle feature avec ce nom |
 | `--continue` | Reprendre la feature en cours (via session) |
 | `--status` | Afficher le statut de la branche courante |
+| `--help` | Affiche l'aide de la commande |
+
+---
+
+## --help
+
+Quand `--help` est passe, afficher :
+
+```
+═══════════════════════════════════════════════
+  /feature - Developpement de fonctionnalites
+═══════════════════════════════════════════════
+
+Usage: /feature <description> [options]
+
+Options:
+  <description>     Nouvelle feature avec ce nom
+  --continue        Reprendre la feature en cours
+  --status          Afficher le statut de la branche
+  --help            Affiche cette aide
+
+Exemples:
+  /feature add-auth         Cree feat/add-auth
+  /feature --continue       Reprend la derniere session
+  /feature --status         Affiche l'etat de la PR
+═══════════════════════════════════════════════
+```
 
 ---
 

--- a/.devcontainer/images/.claude/commands/fix.md
+++ b/.devcontainer/images/.claude/commands/fix.md
@@ -24,6 +24,33 @@ Workflow complet pour corriger un bug avec **suivi Taskwarrior obligatoire** :
 | `<description>` | Nouveau fix avec ce nom |
 | `--continue` | Reprendre le fix en cours (via session) |
 | `--status` | Afficher le statut de la branche courante |
+| `--help` | Affiche l'aide de la commande |
+
+---
+
+## --help
+
+Quand `--help` est passe, afficher :
+
+```
+═══════════════════════════════════════════════
+  /fix - Correction de bugs
+═══════════════════════════════════════════════
+
+Usage: /fix <description> [options]
+
+Options:
+  <description>     Nouveau fix avec ce nom
+  --continue        Reprendre le fix en cours
+  --status          Afficher le statut de la branche
+  --help            Affiche cette aide
+
+Exemples:
+  /fix login-error          Cree fix/login-error
+  /fix --continue           Reprend la derniere session
+  /fix --status             Affiche l'etat de la PR
+═══════════════════════════════════════════════
+```
 
 ---
 

--- a/.devcontainer/images/.claude/commands/install.md
+++ b/.devcontainer/images/.claude/commands/install.md
@@ -25,8 +25,41 @@ Les hooks fonctionnent même sans ces outils (silencieusement ignorés), mais av
 | `<lang>` | Installe les outils pour un langage spécifique |
 | `security` | Installe uniquement les outils de sécurité |
 | `list` | Liste les outils par catégorie |
+| `--help` | Affiche l'aide de la commande |
 
 **Langages supportés** : `js`, `ts`, `python`, `go`, `rust`, `shell`, `java`, `php`, `ruby`, `c`, `lua`, `sql`, `terraform`, `docker`, `elixir`, `dart`, `kotlin`, `swift`, `zig`, `nim`, `toml`, `protobuf`
+
+---
+
+## --help
+
+Quand `--help` est passe, afficher :
+
+```
+═══════════════════════════════════════════════
+  /install - Development Tools Installer
+═══════════════════════════════════════════════
+
+Usage: /install [lang|option]
+
+Options:
+  (vide) ou all     Installe tous les outils
+  <lang>            Installe pour un langage (js, python, go...)
+  security          Outils de securite uniquement
+  list              Liste les outils disponibles
+  --help            Affiche cette aide
+
+Langages: js, ts, python, go, rust, shell, java, php,
+          ruby, c, lua, sql, terraform, docker, elixir,
+          dart, kotlin, swift, zig, nim, toml, protobuf
+
+Exemples:
+  /install              Installe tout
+  /install python       Outils Python (ruff, black, mypy...)
+  /install security     Outils securite (trivy, gitleaks...)
+  /install list         Liste tous les outils
+═══════════════════════════════════════════════
+```
 
 ---
 

--- a/.devcontainer/images/.claude/commands/review.md
+++ b/.devcontainer/images/.claude/commands/review.md
@@ -1,0 +1,257 @@
+# Review - AI Code Review avec CodeRabbit
+
+$ARGUMENTS
+
+---
+
+## Description
+
+Effectue une revue de code automatisee avec CodeRabbit CLI. Detecte les bugs, vulnerabilites, problemes de performance et suggere des corrections.
+
+---
+
+## Arguments
+
+| Pattern | Action |
+|---------|--------|
+| (vide) | Review des changements non commites |
+| `--staged` | Review uniquement des changements stages |
+| `--committed` | Review des changements commites (vs base branch) |
+| `--all` | Review complete du projet |
+| `--fix` | Applique les corrections suggerees |
+| `--help` | Affiche l'aide de la commande |
+
+---
+
+## --help
+
+Quand `--help` est passe, afficher :
+
+```
+═══════════════════════════════════════════════
+  /review - AI Code Review avec CodeRabbit
+═══════════════════════════════════════════════
+
+Usage: /review [options]
+
+Options:
+  (vide)          Review des changements non commites
+  --staged        Review uniquement des changements stages
+  --committed     Review des changements commites (vs base)
+  --all           Review complete du projet
+  --fix           Applique les corrections suggerees
+  --help          Affiche cette aide
+
+Exemples:
+  /review                 Review des modifications locales
+  /review --staged        Review avant commit
+  /review --committed     Review de la branche actuelle
+  /review --fix           Review et applique les corrections
+═══════════════════════════════════════════════
+```
+
+---
+
+## Prerequis
+
+### Verification de l'installation
+
+```bash
+command -v coderabbit || command -v cr
+```
+
+Si non installe :
+```
+## Erreur
+
+CodeRabbit CLI n'est pas installe.
+→ Rebuilder le container ou executer: curl -fsSL https://cli.coderabbit.ai/install.sh | sh
+```
+
+### Verification de l'authentification
+
+```bash
+coderabbit auth status 2>/dev/null || cr auth status 2>/dev/null
+```
+
+Si non authentifie :
+```
+## Authentification requise
+
+CodeRabbit necessite une authentification.
+→ Executer: coderabbit auth login (ou cr auth login)
+→ Suivre les instructions dans le navigateur
+```
+
+---
+
+## Workflow principal
+
+### 1. Detection du contexte
+
+```bash
+# Verifier les changements
+git status --porcelain
+git diff --stat
+git diff --cached --stat
+```
+
+Si aucun changement et pas `--all` :
+```
+## Aucun changement
+
+Aucun fichier modifie a analyser.
+→ Utilisez --all pour analyser tout le projet
+```
+
+### 2. Construction de la commande
+
+**Base** : `coderabbit --plain`
+
+**Options additionnelles** :
+
+| Argument | Options ajoutees |
+|----------|------------------|
+| (vide) | `--type uncommitted` |
+| `--staged` | `--type uncommitted` (analyse le cache git) |
+| `--committed` | `--type committed` |
+| `--all` | `--type all` |
+
+**Configuration auto** :
+```bash
+# Si CLAUDE.md existe, l'utiliser comme contexte
+if [[ -f "/workspace/CLAUDE.md" ]]; then
+    CONFIG_OPT="--config /workspace/CLAUDE.md"
+fi
+```
+
+### 3. Execution de la review
+
+```bash
+# Commande complete
+coderabbit --plain $TYPE_OPT $CONFIG_OPT 2>&1
+```
+
+### 4. Traitement des resultats
+
+Afficher les resultats avec mise en forme :
+
+```
+═══════════════════════════════════════════════
+  Review CodeRabbit
+═══════════════════════════════════════════════
+
+[Resultats de la review]
+
+═══════════════════════════════════════════════
+  Resume
+═══════════════════════════════════════════════
+
+Fichiers analyses : X
+Problemes trouves : Y
+  - Critiques : Z
+  - Warnings : W
+  - Info : I
+
+═══════════════════════════════════════════════
+```
+
+---
+
+## --fix : Application des corrections
+
+Quand `--fix` est passe :
+
+1. Executer la review normale
+2. Parser les suggestions de correction
+3. Pour chaque correction suggeree :
+   - Afficher le fichier et la ligne
+   - Afficher le code actuel vs suggere
+   - Appliquer la correction automatiquement
+4. Afficher un resume des corrections appliquees
+
+```bash
+# Note: CodeRabbit --fix n'existe pas nativement
+# Le mode --fix analyse les suggestions et les applique via Edit
+```
+
+**Workflow --fix** :
+
+1. Capturer la sortie de `coderabbit --plain`
+2. Parser les blocs de code suggeres
+3. Appliquer les modifications avec l'outil Edit
+4. Afficher le resume
+
+```
+═══════════════════════════════════════════════
+  Corrections appliquees
+═══════════════════════════════════════════════
+
+| Fichier | Ligne | Type | Status |
+|---------|-------|------|--------|
+| src/api.ts | 42 | Bug fix | ✓ Applique |
+| src/auth.ts | 15 | Security | ✓ Applique |
+
+Total : 2 corrections appliquees
+═══════════════════════════════════════════════
+```
+
+---
+
+## Outputs
+
+### Succes
+
+```
+═══════════════════════════════════════════════
+  ✓ Review terminee
+═══════════════════════════════════════════════
+
+Fichiers analyses : 5
+Problemes trouves : 3
+  - Critiques : 1
+  - Warnings : 2
+  - Info : 0
+
+→ Voir les details ci-dessus
+═══════════════════════════════════════════════
+```
+
+### Aucun probleme
+
+```
+═══════════════════════════════════════════════
+  ✓ Aucun probleme detecte
+═══════════════════════════════════════════════
+
+Fichiers analyses : 5
+Code quality : Excellent
+
+→ Pret pour commit/PR
+═══════════════════════════════════════════════
+```
+
+### Erreur
+
+```
+═══════════════════════════════════════════════
+  ✗ Erreur lors de la review
+═══════════════════════════════════════════════
+
+Message : [erreur de coderabbit]
+
+→ Verifier l'authentification : cr auth status
+→ Verifier la connexion internet
+═══════════════════════════════════════════════
+```
+
+---
+
+## Integration avec autres commandes
+
+| Workflow | Commandes |
+|----------|-----------|
+| Avant commit | `/review --staged` puis `/commit` |
+| Apres dev | `/review` puis `/review --fix` puis `/commit` |
+| PR review | `/review --committed` |
+| Audit complet | `/review --all` |

--- a/.devcontainer/images/.claude/commands/secret.md
+++ b/.devcontainer/images/.claude/commands/secret.md
@@ -76,6 +76,39 @@ VAULT_ID="ypahjj334ixtiyjkytu5hij2im"
 | `add <name> [value]`    | Ajoute un nouveau secret           |
 | `update <name> [value]` | Met a jour un secret existant      |
 | `remove <name>`         | Supprime un secret                 |
+| `--help`                | Affiche l'aide de la commande      |
+
+---
+
+## --help
+
+Quand `--help` est passe, afficher :
+
+```
+═══════════════════════════════════════════════
+  /secret - 1Password Secret Management
+═══════════════════════════════════════════════
+
+Usage: /secret [action] [name] [value]
+
+Actions:
+  (vide) ou list        Liste les secrets disponibles
+  get <name>            Recupere un secret
+  add <name> [value]    Ajoute un secret
+  update <name> [value] Met a jour un secret
+  remove <name>         Supprime un secret
+  --help                Affiche cette aide
+
+Prerequis:
+  OP_SERVICE_ACCOUNT_TOKEN doit etre configure
+
+Exemples:
+  /secret                   Liste tous les secrets
+  /secret get mcp-github    Recupere le token GitHub
+  /secret add my-key        Ajoute un nouveau secret
+  /secret remove old-key    Supprime un secret
+═══════════════════════════════════════════════
+```
 
 ---
 

--- a/.devcontainer/images/.claude/commands/update.md
+++ b/.devcontainer/images/.claude/commands/update.md
@@ -1,6 +1,50 @@
 # Update - Mise à jour depuis la Marketplace
 
+$ARGUMENTS
+
+---
+
+## Description
+
 Mettre à jour les commandes, scripts, binaires et Taskwarrior depuis GitHub.
+
+---
+
+## Arguments
+
+| Pattern | Action |
+|---------|--------|
+| (vide) | Met a jour depuis le repository Kodflow |
+| `--help` | Affiche l'aide de la commande |
+
+---
+
+## --help
+
+Quand `--help` est passe, afficher :
+
+```
+═══════════════════════════════════════════════
+  /update - Mise a jour depuis la Marketplace
+═══════════════════════════════════════════════
+
+Usage: /update [options]
+
+Options:
+  (vide)          Met a jour tout depuis GitHub
+  --help          Affiche cette aide
+
+Elements mis a jour:
+  - Commandes (/build, /commit, /feature, etc.)
+  - Scripts (format, lint, security...)
+  - Binaires (status-line, ktn-linter)
+  - Configuration MCP
+  - Taskwarrior
+
+Exemples:
+  /update         Telecharge les dernieres versions
+═══════════════════════════════════════════════
+```
 
 ---
 

--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -158,6 +158,13 @@ RUN mkdir -p $NVM_DIR && \
     ln -sf "$NVM_DIR/versions/node/$(ls $NVM_DIR/versions/node | head -1)/bin/claude" ~/.local/bin/claude
 
 # =============================================================================
+# CodeRabbit CLI (AI Code Reviews)
+# =============================================================================
+RUN curl -fsSL https://cli.coderabbit.ai/install.sh | sh && \
+    ln -sf /home/vscode/.coderabbit/bin/coderabbit ~/.local/bin/coderabbit && \
+    ln -sf /home/vscode/.coderabbit/bin/coderabbit ~/.local/bin/cr
+
+# =============================================================================
 # Claude Configuration (baked into image)
 # =============================================================================
 # Store in /opt/kodflow/ as backup (volumes will overwrite /home/vscode/.claude/)


### PR DESCRIPTION
## Summary

- Add CodeRabbit CLI installation in Dockerfile for AI-powered code reviews
- Create new `/review` command with multiple options (`--staged`, `--committed`, `--all`, `--fix`)
- Add `--help` argument to all 8 slash commands for better discoverability

## Changes

| File | Description |
|------|-------------|
| `Dockerfile` | Install CodeRabbit CLI with symlinks to `~/.local/bin/` |
| `review.md` | New command for AI code reviews using CodeRabbit |
| `build.md` | Add `--help` section |
| `commit.md` | Add `--help` section |
| `feature.md` | Add `--help` section |
| `fix.md` | Add `--help` section |
| `install.md` | Add `--help` section |
| `secret.md` | Add `--help` section |
| `update.md` | Add `--help` section |

## Test plan

- [ ] Rebuild container to verify CodeRabbit CLI installation
- [ ] Run `coderabbit --version` or `cr --version` to verify
- [ ] Test `/review` on modified files
- [ ] Test `/<command> --help` for each command