### PR TITLE
fix(shell): ensure oh-my-zsh persists after container rebuild

### DIFF
--- a/.devcontainer/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/hooks/lifecycle/postStart.sh
@@ -53,6 +53,23 @@ if [ -d "$KODFLOW_BACKUP/.claude" ]; then
     mkdir -p "$HOME/.claude/sessions"
 fi
 
+# Restore Oh My Zsh if missing or incomplete (base image may have empty/broken oh-my-zsh)
+if [ -d "$KODFLOW_BACKUP/.oh-my-zsh" ]; then
+    # Check if oh-my-zsh is missing or incomplete (missing oh-my-zsh.sh is the key indicator)
+    if [ ! -f "$HOME/.oh-my-zsh/oh-my-zsh.sh" ]; then
+        log_info "Restoring Oh My Zsh from image (missing or incomplete)..."
+        rm -rf "$HOME/.oh-my-zsh"
+        cp -r "$KODFLOW_BACKUP/.oh-my-zsh" "$HOME/.oh-my-zsh"
+        log_success "Oh My Zsh restored"
+    fi
+
+    # Restore p10k config if missing
+    if [ -f "$KODFLOW_BACKUP/.p10k.zsh" ] && [ ! -f "$HOME/.p10k.zsh" ]; then
+        cp "$KODFLOW_BACKUP/.p10k.zsh" "$HOME/.p10k.zsh"
+        log_success "Powerlevel10k config restored"
+    fi
+fi
+
 # Restore NVM symlinks (node, npm, npx, claude)
 NVM_DIR="${NVM_DIR:-$HOME/.cache/nvm}"
 if [ -d "$NVM_DIR/versions/node" ]; then

--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -120,15 +120,11 @@ RUN mkdir -p .cache .config .local/bin .local/share .zsh_history_dir \
     .config/{aws,gcloud,azure} .kube \
     .claude .config/@anthropic .cache/@anthropic .local/share/@anthropic
 
-# Oh My Zsh + Powerlevel10k (skip if already installed in base image)
-RUN if [ ! -d "$HOME/.oh-my-zsh" ]; then \
-        sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended; \
-    fi && \
-    rm -rf ~/.oh-my-zsh/custom/themes/powerlevel10k && \
+# Oh My Zsh + Powerlevel10k (force fresh install to ensure completeness)
+RUN rm -rf ~/.oh-my-zsh && \
+    sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended && \
     git clone --depth=1 https://github.com/romkatv/powerlevel10k.git ~/.oh-my-zsh/custom/themes/powerlevel10k && \
-    rm -rf ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions && \
     git clone --depth=1 https://github.com/zsh-users/zsh-autosuggestions.git ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions && \
-    rm -rf ~/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting && \
     git clone --depth=1 https://github.com/zsh-users/zsh-syntax-highlighting.git ~/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting
 
 # Copy p10k configuration
@@ -173,6 +169,16 @@ RUN mkdir -p /opt/kodflow
 COPY --chown=vscode:vscode .claude/ /opt/kodflow/.claude/
 RUN chmod -R 755 /opt/kodflow/.claude/scripts/ && \
     mkdir -p /opt/kodflow/.claude/sessions
+USER vscode
+
+# =============================================================================
+# Oh My Zsh Backup (for restoration after rebuild)
+# =============================================================================
+# Base image may have incomplete oh-my-zsh, backup our complete installation
+USER root
+RUN cp -r /home/vscode/.oh-my-zsh /opt/kodflow/.oh-my-zsh && \
+    cp /home/vscode/.p10k.zsh /opt/kodflow/.p10k.zsh && \
+    chown -R vscode:vscode /opt/kodflow/.oh-my-zsh /opt/kodflow/.p10k.zsh
 USER vscode
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Fix oh-my-zsh being missing or incomplete after container rebuild
- Add backup/restore mechanism similar to Claude configuration

## Bug

After a container rebuild, zsh fails with:
```
/home/vscode/.zshrc:source:75: no such file or directory: /home/vscode/.oh-my-zsh/oh-my-zsh.sh
```

## Root cause

The base image `mcr.microsoft.com/devcontainers/base:ubuntu-24.04` may contain an empty or incomplete `.oh-my-zsh` directory. The Dockerfile's conditional check `if [ ! -d "$HOME/.oh-my-zsh" ]` then skips installation because the directory exists (even though it's empty/broken).

## Fix

1. **Dockerfile**: Force fresh oh-my-zsh installation (remove conditional)
2. **Dockerfile**: Backup complete oh-my-zsh + p10k config to `/opt/kodflow/`
3. **postStart.sh**: Restore from backup if `oh-my-zsh.sh` is missing

This follows the same pattern already used for Claude configuration backup.

## Test plan

- [ ] Rebuild container with `docker compose -f .devcontainer/docker-compose.yml build --no-cache`
- [ ] Verify zsh loads without errors
- [ ] Verify powerlevel10k theme works
- [ ] Simulate missing oh-my-zsh by deleting `~/.oh-my-zsh/oh-my-zsh.sh` and restarting container

🤖 Generated with [Claude Code](https://claude.com/claude-code)