### PR TITLE
fix(cli): restore ktn-linter and status-line after rebuild

### DIFF
--- a/.devcontainer/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/hooks/lifecycle/postStart.sh
@@ -70,6 +70,18 @@ if [ -d "$KODFLOW_BACKUP/.oh-my-zsh" ]; then
     fi
 fi
 
+# Restore Kodflow binaries (ktn-linter, status-line) if missing
+if [ -d "$KODFLOW_BACKUP/bin" ]; then
+    mkdir -p "$HOME/.local/bin"
+    for binary in ktn-linter status-line; do
+        if [ -f "$KODFLOW_BACKUP/bin/$binary" ] && [ ! -f "$HOME/.local/bin/$binary" ]; then
+            cp "$KODFLOW_BACKUP/bin/$binary" "$HOME/.local/bin/$binary"
+            chmod +x "$HOME/.local/bin/$binary"
+            log_success "$binary restored"
+        fi
+    done
+fi
+
 # Restore NVM symlinks (node, npm, npx, claude)
 NVM_DIR="${NVM_DIR:-$HOME/.cache/nvm}"
 if [ -d "$NVM_DIR/versions/node" ]; then


### PR DESCRIPTION
## Summary

- Fix ktn-linter and status-line missing after container rebuild
- Add restoration from /opt/kodflow/bin/ backup

## Bug

After rebuilding a project with Go feature enabled:
```
❯ ktn-linter lint ./...
zsh: command not found: ktn-linter
```

## Root cause

The `local-bin:/home/vscode/.local/bin` volume in docker-compose.yml overwrites the image content. The binaries (ktn-linter, status-line) stored in `/opt/kodflow/bin/` were not being restored in postStart.sh.

## Fix

Add restoration logic in postStart.sh to copy missing binaries from the backup location (`/opt/kodflow/bin/`), following the same pattern already used for oh-my-zsh and Claude configuration.

## Test plan

- [ ] Rebuild container in a project with Go feature enabled
- [ ] Verify `ktn-linter lint ./...` works
- [ ] Verify `status-line` works