### PR TITLE
refactor(devcontainer): simplify volumes and remove backup mechanism

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -12,26 +12,21 @@ services:
     volumes:
       # Mount workspace
       - ..:/workspace:cached
+
       # Named volumes for persistence (survive rebuilds)
+      # Only persist USER DATA, not tools/binaries (those come from image)
       - zsh-history:/home/vscode/.zsh_history_dir
       - package-cache:/home/vscode/.cache
-      - config-dir:/home/vscode/.config
-      - local-bin:/home/vscode/.local/bin
-
-      # npm global packages persistence (survives rebuilds)
       - npm-global:/home/vscode/.local/share/npm-global
 
-      # Claude CLI session persistence (survives rebuilds)
-      - claude-config:/home/vscode/.claude
-      - anthropic-config:/home/vscode/.config/@anthropic
-      - anthropic-cache:/home/vscode/.cache/@anthropic
-      - anthropic-data:/home/vscode/.local/share/@anthropic
+      # Claude sessions only (commands/scripts come from image)
+      - claude-sessions:/home/vscode/.claude/sessions
 
-      # 1Password CLI session persistence (survives rebuilds)
+      # 1Password CLI session persistence
       - op-config:/home/vscode/.config/op
       - op-cache:/home/vscode/.op
 
-      # Docker socket for Docker-from-Docker (use host Docker daemon)
+      # Docker socket for Docker-from-Docker
       - /var/run/docker.sock:/var/run/docker.sock
 
     # Network configuration
@@ -133,16 +128,8 @@ services:
 volumes:
   zsh-history:
   package-cache:
-  config-dir:
-  local-bin:
-  # npm global packages volume
   npm-global:
-  # Claude CLI volumes (persist sessions across rebuilds)
-  claude-config:
-  anthropic-config:
-  anthropic-cache:
-  anthropic-data:
-  # 1Password CLI volumes (persist sessions across rebuilds)
+  claude-sessions:
   op-config:
   op-cache:
 

--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -161,25 +161,11 @@ RUN curl -fsSL https://cli.coderabbit.ai/install.sh | sh && \
     ln -sf /home/vscode/.coderabbit/bin/coderabbit ~/.local/bin/cr
 
 # =============================================================================
-# Claude Configuration (baked into image)
+# Claude Configuration (installed directly - no backup needed)
 # =============================================================================
-# Store in /opt/kodflow/ as backup (volumes will overwrite /home/vscode/.claude/)
-USER root
-RUN mkdir -p /opt/kodflow
-COPY --chown=vscode:vscode .claude/ /opt/kodflow/.claude/
-RUN chmod -R 755 /opt/kodflow/.claude/scripts/ && \
-    mkdir -p /opt/kodflow/.claude/sessions
-USER vscode
-
-# =============================================================================
-# Oh My Zsh Backup (for restoration after rebuild)
-# =============================================================================
-# Base image may have incomplete oh-my-zsh, backup our complete installation
-USER root
-RUN cp -r /home/vscode/.oh-my-zsh /opt/kodflow/.oh-my-zsh && \
-    cp /home/vscode/.p10k.zsh /opt/kodflow/.p10k.zsh && \
-    chown -R vscode:vscode /opt/kodflow/.oh-my-zsh /opt/kodflow/.p10k.zsh
-USER vscode
+COPY --chown=vscode:vscode .claude/ /home/vscode/.claude/
+RUN chmod -R 755 /home/vscode/.claude/scripts/ && \
+    mkdir -p /home/vscode/.claude/sessions
 
 # =============================================================================
 # MCP Template (secrets injected at runtime via postStart.sh)
@@ -190,19 +176,15 @@ COPY --chown=vscode:vscode mcp.json.tpl /etc/mcp/mcp.json.tpl
 USER vscode
 
 # =============================================================================
-# Status Line & ktn-linter (downloaded during build)
+# Status Line & ktn-linter (installed directly to ~/.local/bin/)
 # =============================================================================
-# Store in /opt/kodflow/bin/ as backup (volumes will overwrite ~/.local/bin/)
-USER root
-RUN mkdir -p /opt/kodflow/bin && chown vscode:vscode /opt/kodflow/bin
-USER vscode
 RUN ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL "https://github.com/kodflow/status-line/releases/latest/download/status-line-linux-${ARCH}" \
-      -o /opt/kodflow/bin/status-line && \
-    chmod +x /opt/kodflow/bin/status-line && \
+      -o ~/.local/bin/status-line && \
+    chmod +x ~/.local/bin/status-line && \
     curl -fsSL "https://github.com/kodflow/ktn-linter/releases/latest/download/ktn-linter-linux-${ARCH}" \
-      -o /opt/kodflow/bin/ktn-linter && \
-    chmod +x /opt/kodflow/bin/ktn-linter
+      -o ~/.local/bin/ktn-linter && \
+    chmod +x ~/.local/bin/ktn-linter
 
 # =============================================================================
 # Environment Variables


### PR DESCRIPTION
## Summary

- Refactor volume architecture: image contains everything, volumes only persist user data
- Remove /opt/kodflow/ backup mechanism entirely
- Simplify postStart.sh significantly (-74 lines)

## Architecture change

### Before (backup/restore pattern)
- Volumes overwrote image content
- /opt/kodflow/ stored backups
- postStart.sh restored files on each start

### After (direct installation)
- Binaries installed directly to ~/.local/bin/
- Claude config installed directly to ~/.claude/
- Only user data persists via volumes (sessions, caches)

## Volumes removed
| Volume | Reason |
|--------|--------|
| `local-bin` | Binaries come from image |
| `config-dir` | Too broad, replaced by specific mounts |
| `claude-config` | Replaced by `claude-sessions` (only sessions) |
| `anthropic-*` | Inside package-cache, no separate mount needed |

## Volumes added
| Volume | Path | Content |
|--------|------|---------|
| `claude-sessions` | `~/.claude/sessions/` | Only Claude sessions |

## Files changed
- `.devcontainer/images/Dockerfile`: Direct installation, no backups
- `.devcontainer/docker-compose.yml`: Simplified volumes
- `.devcontainer/hooks/lifecycle/postStart.sh`: Removed restoration logic

## Test plan
- [ ] Build image with `docker buildx build`
- [ ] Verify `ktn-linter --help` works
- [ ] Verify `status-line` works
- [ ] Verify oh-my-zsh + p10k work
- [ ] Verify Claude commands available
- [ ] Rebuild container and verify persistence