### PR TITLE
fix(devcontainer): restore claude session persistence across rebuilds

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -19,8 +19,9 @@ services:
       - package-cache:/home/vscode/.cache
       - npm-global:/home/vscode/.local/share/npm-global
 
-      # Claude sessions only (commands/scripts come from image)
-      - claude-sessions:/home/vscode/.claude/sessions
+      # Claude config persistence (credentials, settings, sessions)
+      # Commands/scripts are restored from image on each start
+      - claude-config:/home/vscode/.claude
 
       # 1Password CLI session persistence
       - op-config:/home/vscode/.config/op
@@ -129,7 +130,7 @@ volumes:
   zsh-history:
   package-cache:
   npm-global:
-  claude-sessions:
+  claude-config:
   op-config:
   op-cache:
 

--- a/.devcontainer/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/hooks/lifecycle/postStart.sh
@@ -15,6 +15,39 @@ source "$SCRIPT_DIR/../shared/utils.sh"
 log_info "postStart: Container starting..."
 
 # ============================================================================
+# Restore Claude commands/scripts from image defaults
+# ============================================================================
+# Volume mounts overwrite image content, so we restore from /etc/claude-defaults/
+CLAUDE_DEFAULTS="/etc/claude-defaults"
+
+if [ -d "$CLAUDE_DEFAULTS" ]; then
+    log_info "Restoring Claude configuration from image defaults..."
+    
+    # Ensure base directory exists
+    mkdir -p "$HOME/.claude"
+    
+    # Restore commands (always overwrite with latest from image)
+    if [ -d "$CLAUDE_DEFAULTS/commands" ]; then
+        mkdir -p "$HOME/.claude/commands"
+        cp -r "$CLAUDE_DEFAULTS/commands/"* "$HOME/.claude/commands/" 2>/dev/null || true
+    fi
+    
+    # Restore scripts (always overwrite with latest from image)
+    if [ -d "$CLAUDE_DEFAULTS/scripts" ]; then
+        mkdir -p "$HOME/.claude/scripts"
+        cp -r "$CLAUDE_DEFAULTS/scripts/"* "$HOME/.claude/scripts/" 2>/dev/null || true
+        chmod -R 755 "$HOME/.claude/scripts/"
+    fi
+    
+    # Restore settings.json only if it does not exist
+    if [ -f "$CLAUDE_DEFAULTS/settings.json" ] && [ \! -f "$HOME/.claude/settings.json" ]; then
+        cp "$CLAUDE_DEFAULTS/settings.json" "$HOME/.claude/settings.json"
+    fi
+    
+    log_success "Claude configuration restored"
+fi
+
+# ============================================================================
 # Ensure Claude sessions directory exists (volume mount point)
 # ============================================================================
 mkdir -p "$HOME/.claude/sessions"

--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -161,11 +161,22 @@ RUN curl -fsSL https://cli.coderabbit.ai/install.sh | sh && \
     ln -sf /home/vscode/.coderabbit/bin/coderabbit ~/.local/bin/cr
 
 # =============================================================================
-# Claude Configuration (installed directly - no backup needed)
+# Claude Configuration (backup to /etc/claude-defaults/ for volume restoration)
 # =============================================================================
 COPY --chown=vscode:vscode .claude/ /home/vscode/.claude/
 RUN chmod -R 755 /home/vscode/.claude/scripts/ && \
     mkdir -p /home/vscode/.claude/sessions
+
+# =============================================================================
+# Claude Defaults Backup (for volume restoration)
+# =============================================================================
+USER root
+RUN mkdir -p /etc/claude-defaults
+COPY --chown=root:root .claude/commands/ /etc/claude-defaults/commands/
+COPY --chown=root:root .claude/scripts/ /etc/claude-defaults/scripts/
+COPY --chown=root:root .claude/settings.json /etc/claude-defaults/settings.json
+RUN chmod -R 755 /etc/claude-defaults/
+USER vscode
 
 # =============================================================================
 # MCP Template (secrets injected at runtime via postStart.sh)


### PR DESCRIPTION
## Summary

- Restore `claude-config` volume to persist full `~/.claude/` directory
- Add backup mechanism for commands/scripts to `/etc/claude-defaults/`
- Restore commands/scripts from image on each container start

## Problem

The refactor in #37 (dc792e7) replaced the full `claude-config:/home/vscode/.claude` volume with only `claude-sessions:/home/vscode/.claude/sessions`. This caused the `.credentials.json` file (containing Claude authentication) to be lost on every container rebuild, requiring re-login each time.

## Solution

1. **docker-compose.yml**: Restore `claude-config` volume mounting full `~/.claude/`
2. **Dockerfile**: Backup commands, scripts, and settings to `/etc/claude-defaults/`
3. **postStart.sh**: Restore commands/scripts from backup on each start (ensures image updates propagate)

The volume now persists:
- `.credentials.json` (authentication) ✅
- `settings.json` (user settings) ✅
- `sessions/` (session data) ✅
- `history.jsonl` (command history) ✅

Commands and scripts are always restored from the image to ensure updates are applied.

## Test plan

- [ ] Rebuild container and verify Claude session persists
- [ ] Verify commands/scripts are restored after rebuild
- [ ] Verify settings.json is preserved if customized

🤖 Generated with [Claude Code](https://claude.com/claude-code)