### PR TITLE
fix(mcp): make rust-analyzer MCP conditional to Rust feature

### DIFF
--- a/.devcontainer/images/mcp.json.tpl
+++ b/.devcontainer/images/mcp.json.tpl
@@ -18,11 +18,6 @@
       "command": "npx",
       "args": ["-y", "mcp-server-taskwarrior"],
       "env": {}
-    },
-    "rust-analyzer": {
-      "command": "/home/vscode/.cache/cargo/bin/rust-analyzer-mcp",
-      "args": [],
-      "env": {}
     }
   }
 }


### PR DESCRIPTION
## Summary

- Remove `rust-analyzer` from static `mcp.json.tpl` template (MCPs should only exist if their features are enabled)
- Add conditional MCP detection in `postStart.sh` based on binary existence
- MCPs are now added dynamically only if their binaries are installed
- Pattern is extensible for future language-specific MCPs (Go, Python, etc.)

## Bug Fixed

The MCP `rust-analyzer` was always included in `.mcp.json` even when the Rust feature was not enabled in `devcontainer.json`. This caused Claude Code to try to launch a non-existent binary.

## Changes

| File | Change |
|------|--------|
| `.devcontainer/images/mcp.json.tpl` | Remove `rust-analyzer` from base template |
| `.devcontainer/hooks/lifecycle/postStart.sh` | Add `add_optional_mcp()` function for conditional MCPs |
| `.devcontainer/images/.claude/scripts/task-validate.sh` | Fix Taskwarrior commands (`_status` → `export \| jq`) |

## Test plan

- [x] Without Rust feature: `.mcp.json` does NOT contain `rust-analyzer`
- [ ] With Rust feature enabled: `.mcp.json` SHOULD contain `rust-analyzer`
- [x] Base MCPs (codacy, github, taskwarrior) always present

🤖 Generated with [Claude Code](https://claude.com/claude-code)