### PR TITLE
refactor(docker): simplify Claude Code install with official script

### DIFF
--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -3,8 +3,8 @@
 # =============================================================================
 # Kodflow Base Development Image
 # =============================================================================
-# Single base image with all tools + Node.js (for Claude Code)
-# Languages are added via devcontainer features at runtime
+# Single base image with all tools + Claude Code (standalone)
+# Languages (including Node.js) are added via devcontainer features at runtime
 #
 # Build:
 #   docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/kodflow/devcontainer-template:latest .
@@ -116,7 +116,7 @@ WORKDIR /home/vscode
 
 # Create cache and config directories
 RUN mkdir -p .cache .config .local/bin .local/share .zsh_history_dir \
-    .cache/{terraform,helm,aws,bazel,npm,yarn,pnpm,nvm} \
+    .cache/{terraform,helm,aws,bazel} \
     .config/{aws,gcloud,azure} .kube \
     .claude .config/@anthropic .cache/@anthropic .local/share/@anthropic
 
@@ -136,22 +136,13 @@ RUN sed -i 's/^ZSH_THEME=.*/ZSH_THEME="powerlevel10k\/powerlevel10k"/' ~/.zshrc 
     printf '\n[[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh\nexport HISTFILE=~/.zsh_history_dir/.zsh_history\nexport HISTSIZE=50000\nexport SAVEHIST=50000\n[[ -f ~/.kodflow-env.sh ]] && source ~/.kodflow-env.sh\n' >> ~/.zshrc
 
 # =============================================================================
-# Node.js + Claude Code
+# Claude Code (standalone installation - no Node.js required)
 # =============================================================================
-ENV NVM_DIR=/home/vscode/.cache/nvm \
-    npm_config_cache=/home/vscode/.cache/npm
-
-RUN mkdir -p $NVM_DIR && \
-    curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash && \
-    . "$NVM_DIR/nvm.sh" && \
-    nvm install lts/* && \
-    nvm use lts/* && \
-    nvm alias default lts/* && \
-    npm install -g npm@latest @anthropic-ai/claude-code && \
-    ln -sf "$NVM_DIR/versions/node/$(ls $NVM_DIR/versions/node | head -1)/bin/node" ~/.local/bin/node && \
-    ln -sf "$NVM_DIR/versions/node/$(ls $NVM_DIR/versions/node | head -1)/bin/npm" ~/.local/bin/npm && \
-    ln -sf "$NVM_DIR/versions/node/$(ls $NVM_DIR/versions/node | head -1)/bin/npx" ~/.local/bin/npx && \
-    ln -sf "$NVM_DIR/versions/node/$(ls $NVM_DIR/versions/node | head -1)/bin/claude" ~/.local/bin/claude
+# Using official installer: https://claude.ai/install.sh
+# This avoids requiring Node.js/npm in the base image.
+# If you need Node.js for your project, enable the "nodejs" feature.
+RUN curl -fsSL https://claude.ai/install.sh | bash && \
+    ln -sf ~/.claude/local/bin/claude ~/.local/bin/claude
 
 # =============================================================================
 # CodeRabbit CLI (AI Code Reviews)


### PR DESCRIPTION
## Summary
- Replace Node.js/npm installation with the official Claude Code installer
- Reduce base image size by removing Node.js runtime
- Make the "nodejs" feature relevant for Node.js projects

## Changes
- `.devcontainer/images/Dockerfile`:
  - Remove NVM + Node.js LTS installation
  - Use `curl -fsSL https://claude.ai/install.sh | bash` instead
  - Remove npm/nvm cache directories

## Before
```dockerfile
# Node.js + Claude Code (17 lines)
ENV NVM_DIR=/home/vscode/.cache/nvm
RUN mkdir -p $NVM_DIR && \
    curl -fsSL nvm/install.sh | bash && \
    nvm install lts/* && \
    npm install -g @anthropic-ai/claude-code
```

## After
```dockerfile
# Claude Code (standalone - 2 lines)
RUN curl -fsSL https://claude.ai/install.sh | bash && \
    ln -sf ~/.claude/local/bin/claude ~/.local/bin/claude
```

## Benefits
- **Smaller image**: No Node.js runtime in base image
- **Simpler installation**: Single curl command
- **Independent updates**: Claude Code updates separately from npm
- **Clean architecture**: Node.js only when needed via feature

## Test plan
- [ ] Rebuild devcontainer
- [ ] Verify `claude --version` works
- [ ] Verify Node.js is NOT in base image (`node --version` should fail)
- [ ] Enable nodejs feature and verify it installs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)