### PR TITLE
fix(docker): remove invalid symlink overwriting Claude CLI install

### DIFF
--- a/.devcontainer/images/.claude/scripts/task-start.sh
+++ b/.devcontainer/images/.claude/scripts/task-start.sh
@@ -45,6 +45,7 @@ if [[ -f "$SESSION_FILE" ]]; then
     jq --arg uuid "$TASK_UUID" --arg epic "$EPIC_NUM" --arg tid "$TASK_ID" '
         .mode = "bypass" |
         .current_task = $tid |
+        .current_task_uuid = $uuid |
         .current_epic = ($epic | tonumber) |
         (.epics[]?.tasks[]? | select(.uuid == $uuid)).status = "WIP"
     ' "$SESSION_FILE" > "$TMP_FILE" 2>/dev/null && mv "$TMP_FILE" "$SESSION_FILE"

--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -141,8 +141,8 @@ RUN sed -i 's/^ZSH_THEME=.*/ZSH_THEME="powerlevel10k\/powerlevel10k"/' ~/.zshrc 
 # Using official installer: https://claude.ai/install.sh
 # This avoids requiring Node.js/npm in the base image.
 # If you need Node.js for your project, enable the "nodejs" feature.
-RUN curl -fsSL https://claude.ai/install.sh | bash && \
-    ln -sf ~/.claude/local/bin/claude ~/.local/bin/claude
+# Note: The official installer creates the symlink at ~/.local/bin/claude automatically.
+RUN curl -fsSL https://claude.ai/install.sh | bash
 
 # =============================================================================
 # CodeRabbit CLI (AI Code Reviews)


### PR DESCRIPTION
## Summary

- Fix Claude CLI not available after container rebuild
- Remove obsolete symlink that was overwriting the correct one created by the official installer
- Fix `task-start.sh` to set `current_task_uuid` (discovered during investigation)

## Root cause

The official Claude CLI installer (`claude.ai/install.sh`) changed its installation path:
- **Old**: `~/.claude/local/bin/claude`
- **New**: `~/.local/share/claude/versions/X.X.X`

The Dockerfile was creating a symlink to the old path, overwriting the correct one:
```dockerfile
# Before (broken)
RUN curl -fsSL https://claude.ai/install.sh | bash && \
    ln -sf ~/.claude/local/bin/claude ~/.local/bin/claude

# After (fixed)
RUN curl -fsSL https://claude.ai/install.sh | bash
```

## Test plan

- [ ] Rebuild devcontainer from scratch
- [ ] Verify `super-claude` command works
- [ ] Verify `claude --version` returns correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)