### PR TITLE
fix(docker): remove obsolete coderabbit symlinks

### DIFF
--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -147,9 +147,7 @@ RUN curl -fsSL https://claude.ai/install.sh | bash
 # =============================================================================
 # CodeRabbit CLI (AI Code Reviews)
 # =============================================================================
-RUN curl -fsSL https://cli.coderabbit.ai/install.sh | sh && \
-    ln -sf /home/vscode/.coderabbit/bin/coderabbit ~/.local/bin/coderabbit && \
-    ln -sf /home/vscode/.coderabbit/bin/coderabbit ~/.local/bin/cr
+RUN curl -fsSL https://cli.coderabbit.ai/install.sh | sh
 
 # =============================================================================
 # Claude Configuration (backup to /etc/claude-defaults/ for volume restoration)


### PR DESCRIPTION
## Bug

`coderabbit` command not found - broken symlink pointing to deprecated path.

## Root cause

The CodeRabbit CLI installer script has changed:
- **Old path**: `~/.coderabbit/bin/coderabbit`
- **New path**: `~/.local/bin/coderabbit` (installed directly)

The Dockerfile was creating symlinks (`ln -sf`) that **overwrote the actual binary** with broken symlinks pointing to the old path.

## Fix

- `.devcontainer/images/Dockerfile`: Remove obsolete `ln -sf` commands - the installer handles everything correctly now

## Test plan

- [ ] Rebuild container with updated Dockerfile
- [ ] Verify `coderabbit --version` works
- [ ] Verify `cr --version` alias works

🤖 Generated with [Claude Code](https://claude.com/claude-code)