### PR TITLE
fix(docker): add libsecret packages for credential storage

### DIFF
--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -35,6 +35,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         libffi-dev libbz2-dev libreadline-dev libsqlite3-dev \
         libncurses5-dev libncursesw5-dev liblzma-dev zlib1g-dev \
         libgdbm-dev libyaml-dev \
+        libsecret-1-0 libsecret-1-dev dbus-x11 \
         taskwarrior && \
     apt-get clean
 


### PR DESCRIPTION
## Bug

Erreur lors de l'authentification :
```
Authentication failed: unable to store credentials in secured storage
Error [ERR_SECRETS_PLATFORM_ERROR]: libsecret not available
```

## Root cause

Le Dockerfile ne contient pas les packages `libsecret` nécessaires au stockage sécurisé des credentials dans un environnement Linux headless (DevContainer).

Ces packages sont requis par :
- VS Code (keytar)
- GitHub CLI (`gh auth`)
- Claude Code (authentication)

## Fix

- `.devcontainer/images/Dockerfile` : Ajout de `libsecret-1-0`, `libsecret-1-dev` et `dbus-x11`

## Test plan

- [ ] Rebuild du DevContainer
- [ ] Vérifier que `gh auth login` fonctionne
- [ ] Vérifier que Claude Code peut stocker les credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)