### PR TITLE
fix(docker): add gnome-keyring for Secret Service API support

### DIFF
--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -35,7 +35,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         libffi-dev libbz2-dev libreadline-dev libsqlite3-dev \
         libncurses5-dev libncursesw5-dev liblzma-dev zlib1g-dev \
         libgdbm-dev libyaml-dev \
-        libsecret-1-0 libsecret-1-dev dbus-x11 \
+        libsecret-1-0 libsecret-1-dev dbus-x11 gnome-keyring \
         taskwarrior && \
     apt-get clean
 


### PR DESCRIPTION
## Summary

- Add `gnome-keyring` package to Dockerfile to provide D-Bus Secret Service daemon
- Add `setup_gnome_keyring()` function in postStart.sh to start the daemon in headless mode
- Export keyring environment variables to `~/.kodflow-env.sh` for shell availability

## Root cause

The CodeRabbit CLI (and other tools using libsecret) requires a running D-Bus Secret Service (`org.freedesktop.secrets`) to store credentials. The previous fix (#50) added `libsecret-1-0` (client library) but not the daemon that implements the service.

## Fix

This PR adds:
1. **Dockerfile**: Install `gnome-keyring` package alongside existing libsecret packages
2. **postStart.sh**: Start `gnome-keyring-daemon` with secrets component in headless mode
3. **Environment**: Export `DBUS_SESSION_BUS_ADDRESS` and `GNOME_KEYRING_CONTROL` for all shells

## Affected tools

- CodeRabbit CLI (OAuth token storage)
- GitHub CLI (gh auth)
- VS Code (keytar credential storage)
- Any tool using freedesktop.org Secret Service API

## Test plan

- [ ] Rebuild DevContainer image with new Dockerfile
- [ ] Verify `gnome-keyring-daemon` starts on container startup
- [ ] Test `coderabbit auth login` completes without credential storage error
- [ ] Verify credentials persist across shell sessions

## Platform support

Works on all host platforms (Mac/Windows/Linux/WSL) since the container runtime is always Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)