### PR TITLE
fix(docker): add dynamic D-Bus session detection for keyring support

### DIFF
--- a/.devcontainer/hooks/lifecycle/postCreate.sh
+++ b/.devcontainer/hooks/lifecycle/postCreate.sh
@@ -194,6 +194,35 @@ fi
 if command -v gh &> /dev/null; then
     source <(gh completion -s zsh) 2>/dev/null || true
 fi
+
+# ============================================================================
+# D-Bus Session Detection (for credential storage)
+# ============================================================================
+# Dynamically detect D-Bus session for gnome-keyring support
+# Required by: CodeRabbit CLI, GitHub CLI, VS Code credential storage
+_kodflow_init_dbus() {
+    # Skip if D-Bus already configured and socket exists
+    if [ -n "\${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
+        local socket_path="\${DBUS_SESSION_BUS_ADDRESS#unix:path=}"
+        socket_path="\${socket_path%%,*}"
+        [ -S "\$socket_path" ] && return 0
+    fi
+
+    # Find existing D-Bus socket in /tmp
+    local dbus_socket
+    dbus_socket=\$(find /tmp -maxdepth 1 -name 'dbus-*' -type s -user "\$(id -u)" 2>/dev/null | head -1)
+    if [ -n "\$dbus_socket" ] && [ -S "\$dbus_socket" ]; then
+        export DBUS_SESSION_BUS_ADDRESS="unix:path=\$dbus_socket"
+    fi
+
+    # Find existing keyring control socket
+    if [ -z "\${GNOME_KEYRING_CONTROL:-}" ]; then
+        local keyring_dir
+        keyring_dir=\$(find "\$HOME/.cache" -maxdepth 1 -name 'keyring-*' -type d 2>/dev/null | head -1)
+        [ -n "\$keyring_dir" ] && [ -S "\$keyring_dir/control" ] && export GNOME_KEYRING_CONTROL="\$keyring_dir"
+    fi
+}
+_kodflow_init_dbus
 ENVEOF
 
 log_success "Environment script created at ~/.kodflow-env.sh"


### PR DESCRIPTION
## Bug

CodeRabbit CLI (`cr`) blocks indefinitely on "keyring unlock" during OAuth authentication because `DBUS_SESSION_BUS_ADDRESS` is not available in the shell session.

## Root cause

`postStart.sh` starts D-Bus and gnome-keyring, then appends the environment variables to `~/.kodflow-env.sh`. However, VS Code terminals are opened **before** `postStart.sh` completes, so they have a stale version of the file without D-Bus variables.

## Fix

Added a `_kodflow_init_dbus()` function to `~/.kodflow-env.sh` that dynamically detects the existing D-Bus socket at shell startup:
- Checks if `DBUS_SESSION_BUS_ADDRESS` is already valid
- Otherwise, finds the D-Bus socket in `/tmp/dbus-*`
- Also detects `GNOME_KEYRING_CONTROL` socket

This ensures credential storage works regardless of when the terminal was opened.

## Test plan

- [ ] Open a new terminal after container start
- [ ] Run `echo $DBUS_SESSION_BUS_ADDRESS` - should show socket path
- [ ] Run `cr` - should complete OAuth without blocking on keyring

🤖 Generated with [Claude Code](https://claude.com/claude-code)