### PR TITLE
fix(docker): remove incorrect escaping in heredoc for D-Bus function

### DIFF
--- a/.devcontainer/hooks/lifecycle/postCreate.sh
+++ b/.devcontainer/hooks/lifecycle/postCreate.sh
@@ -202,24 +202,24 @@ fi
 # Required by: CodeRabbit CLI, GitHub CLI, VS Code credential storage
 _kodflow_init_dbus() {
     # Skip if D-Bus already configured and socket exists
-    if [ -n "\${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
-        local socket_path="\${DBUS_SESSION_BUS_ADDRESS#unix:path=}"
-        socket_path="\${socket_path%%,*}"
-        [ -S "\$socket_path" ] && return 0
+    if [ -n "${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
+        local socket_path="${DBUS_SESSION_BUS_ADDRESS#unix:path=}"
+        socket_path="${socket_path%%,*}"
+        [ -S "$socket_path" ] && return 0
     fi
 
     # Find existing D-Bus socket in /tmp
     local dbus_socket
-    dbus_socket=\$(find /tmp -maxdepth 1 -name 'dbus-*' -type s -user "\$(id -u)" 2>/dev/null | head -1)
-    if [ -n "\$dbus_socket" ] && [ -S "\$dbus_socket" ]; then
-        export DBUS_SESSION_BUS_ADDRESS="unix:path=\$dbus_socket"
+    dbus_socket=$(find /tmp -maxdepth 1 -name 'dbus-*' -type s -user "$(id -u)" 2>/dev/null | head -1)
+    if [ -n "$dbus_socket" ] && [ -S "$dbus_socket" ]; then
+        export DBUS_SESSION_BUS_ADDRESS="unix:path=$dbus_socket"
     fi
 
     # Find existing keyring control socket
-    if [ -z "\${GNOME_KEYRING_CONTROL:-}" ]; then
+    if [ -z "${GNOME_KEYRING_CONTROL:-}" ]; then
         local keyring_dir
-        keyring_dir=\$(find "\$HOME/.cache" -maxdepth 1 -name 'keyring-*' -type d 2>/dev/null | head -1)
-        [ -n "\$keyring_dir" ] && [ -S "\$keyring_dir/control" ] && export GNOME_KEYRING_CONTROL="\$keyring_dir"
+        keyring_dir=$(find "$HOME/.cache" -maxdepth 1 -name 'keyring-*' -type d 2>/dev/null | head -1)
+        [ -n "$keyring_dir" ] && [ -S "$keyring_dir/control" ] && export GNOME_KEYRING_CONTROL="$keyring_dir"
     fi
 }
 _kodflow_init_dbus


### PR DESCRIPTION
## Summary

- Fix shell parse error at line 179 in `~/.kodflow-env.sh`
- Remove incorrect `\$` escaping in quoted heredoc

## Root cause

The `_kodflow_init_dbus` function used `\$` inside a quoted heredoc (`<< 'ENVEOF'`), causing backslashes to be written literally.

## Changes

- `.devcontainer/hooks/lifecycle/postCreate.sh`: Remove escaping in `_kodflow_init_dbus` function

## Test plan

- [x] `bash -n` syntax check
- [x] `zsh -n` syntax check  
- [x] Source file without error