### PR TITLE
fix(mcp): use while read for zsh compatibility in super-claude

### DIFF
--- a/.devcontainer/hooks/lifecycle/postCreate.sh
+++ b/.devcontainer/hooks/lifecycle/postCreate.sh
@@ -136,7 +136,8 @@ super-claude() {
     echo "  MCP Servers Configuration"
     echo "═══════════════════════════════════════════════"
 
-    for server in $servers; do
+    while IFS= read -r server; do
+        [ -z "$server" ] && continue
         local cmd
         cmd=$(jq -r ".mcpServers[\"$server\"].command // empty" "$mcp_config")
 
@@ -152,7 +153,7 @@ super-claude() {
             echo "  ✓ $server"
             valid_count=$((valid_count + 1))
         fi
-    done
+    done <<< "$servers"
 
     echo "═══════════════════════════════════════════════"
 


### PR DESCRIPTION
## Bug

La fonction `super-claude` ne détectait pas correctement les serveurs MCP dans zsh. 
L'affichage montrait:
```
✗ codacy
github
taskwarrior (command: null - invalid config)
```
au lieu de lister chaque serveur séparément.

## Root cause

La boucle `for server in $servers` ne fonctionne pas correctement dans zsh car zsh 
n'effectue pas de word splitting sur les variables non-quotées contrairement à bash.

Résultat: `$servers` (contenant `codacy\ngithub\ntaskwarrior`) était traité comme 
une seule chaîne au lieu d'être divisé par newlines.

## Fix

Remplacement de:
```bash
for server in $servers; do
```

Par:
```bash
while IFS= read -r server; do
    [ -z "$server" ] && continue
done <<< "$servers"
```

Cette syntaxe fonctionne correctement dans bash ET zsh.

## Test plan

- [x] Vérifier que les 3 serveurs MCP sont détectés avec ✓
- [x] Tester dans zsh interactif
- [ ] Rebuild container et vérifier super-claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)