### PR TITLE
fix(nodejs): set NVM directory ownership for vscode user

### DIFF
--- a/.devcontainer/features/languages/nodejs/install.sh
+++ b/.devcontainer/features/languages/nodejs/install.sh
@@ -221,6 +221,14 @@ else
     log_warning "Could not determine NVM node directory, skipping symlink creation"
 fi
 
+# Ensure vscode user can update NVM files (especially the 'current' symlink)
+# This is required because NVM_SYMLINK_CURRENT=true needs write access
+log_info "Setting NVM directory ownership for vscode user..."
+if [ -d "$NVM_DIR" ]; then
+    sudo chown -R vscode:vscode "$NVM_DIR" 2>/dev/null || true
+    log_success "NVM directory ownership set to vscode"
+fi
+
 # Add NVM to zshrc for interactive shells
 ZSHRC="/home/vscode/.zshrc"
 if [ -f "$ZSHRC" ]; then


### PR DESCRIPTION
## Summary

- Fix permission denied error when NVM tries to update the `current` symlink
- Add `chown -R vscode:vscode "$NVM_DIR"` after NVM installation

## Changes

- `.devcontainer/features/languages/nodejs/install.sh`: Added ownership change for NVM directory

## Root cause

The NVM directory `/usr/local/share/nvm/` was created by root during Docker build, but `NVM_SYMLINK_CURRENT=true` requires the vscode user to have write access to update the `current` symlink.

## Test plan

- Rebuild the devcontainer
- Run `nvm use <version>` to verify no permission error
- Verify `/usr/local/share/nvm/current` symlink updates correctly