### PR TITLE
fix(scripts): harmonize session key name to currentTask

### DIFF
--- a/.devcontainer/images/.claude/scripts/task-log.sh
+++ b/.devcontainer/images/.claude/scripts/task-log.sh
@@ -27,7 +27,8 @@ if [[ ! -f "$SESSION_FILE" ]]; then
     exit 0
 fi
 
-TASK_UUID=$(jq -r '.current_task_uuid // empty' "$SESSION_FILE")
+# Schéma v2: currentTask (avec fallback sur current_task_uuid pour compatibilité)
+TASK_UUID=$(jq -r '.currentTask // .current_task_uuid // empty' "$SESSION_FILE")
 [[ -z "$TASK_UUID" ]] && exit 0
 
 TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)


### PR DESCRIPTION
## Summary

Corrige une incohérence entre les scripts Taskwarrior qui utilisaient des noms de clés différents pour lire l'UUID de la task courante dans les fichiers de session.

## Problème

| Script | Clé utilisée (avant) |
|--------|---------------------|
| `task-validate.sh` | `current_task_uuid` ❌ |
| `task-log.sh` | `current_task_uuid` ❌ |
| `task-start.sh` | `currentTask` ✅ |
| `task-done.sh` | `currentTask` ✅ |
| `task-init.sh` | `currentTask` ✅ |
| `post-edit.sh` | `currentTask` ✅ |
| `task-check-locks.sh` | `currentTask` ✅ |

## Symptôme

Les opérations Write/Edit étaient bloquées avec l'erreur :
```
❌ BLOQUÉ: Session corrompue - aucune tâche courante
```
Même quand une task était correctement démarrée avec `task-start.sh`.

## Solution

Harmonisation de tous les scripts pour utiliser `currentTask` (camelCase).

## Fichiers modifiés

- `.devcontainer/images/.claude/scripts/task-validate.sh`
- `.devcontainer/images/.claude/scripts/task-log.sh`

## Test plan

- [x] Vérifier qu'aucun script n'utilise plus `current_task_uuid`
- [ ] Tester le workflow /feature complet après rebuild du devcontainer
