### PR TITLE
feat(devcontainer): add persistent Claude Code config preferences

### DIFF
--- a/.devcontainer/hooks/lifecycle/postCreate.sh
+++ b/.devcontainer/hooks/lifecycle/postCreate.sh
@@ -18,6 +18,18 @@ echo -e "${CYAN}   Kodflow DevContainer Setup${NC}"
 echo -e "${CYAN}=========================================${NC}"
 echo ""
 
+# ============================================================================
+# Git Safe Directory Configuration (ALWAYS run, even if already initialized)
+# ============================================================================
+# Prevents "dubious ownership" errors when container user differs from
+# directory owner (common in Docker where /workspace may be owned by root)
+if ! git config --global --get-all safe.directory | grep -q "^/workspace$"; then
+    git config --global --add safe.directory /workspace
+    log_success "Git safe.directory configured for /workspace"
+else
+    log_info "Git safe.directory already configured"
+fi
+
 # Note: Tools (status-line, ktn-linter) are now baked into the Docker image
 # No longer need to update on each rebuild
 

--- a/.devcontainer/images/.claude/.claude.json
+++ b/.devcontainer/images/.claude/.claude.json
@@ -1,0 +1,5 @@
+{
+  "verbose": false,
+  "respectGitignore": false,
+  "hasCompletedOnboarding": true
+}

--- a/.devcontainer/images/.claude/settings.json
+++ b/.devcontainer/images/.claude/settings.json
@@ -1,6 +1,10 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "model": "opus",
   "alwaysThinkingEnabled": true,
+  "spinnerTipsEnabled": false,
+  "promptSuggestionEnabled": true,
+  "outputStyle": "default",
   "cleanupPeriodDays": 30,
   "statusLine": {
     "type": "command",
@@ -13,6 +17,7 @@
     "MAX_MCP_OUTPUT_TOKENS": "25000"
   },
   "permissions": {
+    "defaultMode": "acceptEdits",
     "allow": [
       "Bash(npm:*)",
       "Bash(pnpm:*)",


### PR DESCRIPTION
## Summary
- Add persistent `git safe.directory` configuration to prevent "dubious ownership" errors in DevContainers
- Configure Claude Code UI preferences for consistent developer experience
- Create runtime preferences file for Claude Code state

## Changes
| File | Description |
|------|-------------|
| `.devcontainer/hooks/lifecycle/postCreate.sh` | Add git safe.directory /workspace config |
| `.devcontainer/images/.claude/settings.json` | Add UI preferences (tips, suggestions, outputStyle, defaultMode) |
| `.devcontainer/images/.claude/.claude.json` | **New** - Runtime preferences (verbose, respectGitignore) |

## Configuration Applied

| Setting | Value | File |
|---------|-------|------|
| Show tips | `false` | settings.json |
| Thinking mode | `true` | settings.json |
| Prompt suggestions | `true` | settings.json |
| Default permission mode | `acceptEdits` | settings.json |
| Output style | `default` | settings.json |
| Verbose output | `false` | .claude.json |
| Respect .gitignore | `false` | .claude.json |

## Test plan
- [ ] Rebuild DevContainer
- [ ] Verify `git config --global --get-all safe.directory` includes `/workspace`
- [ ] Verify Claude Code loads preferences from injected config files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Chores**
  * Amélioration de la configuration de l'environnement de développement avec l'ajout d'une configuration Git pour les répertoires sécurisés lors du démarrage du conteneur de développement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->