### PR TITLE
fix(update): clarify devcontainer scope excludes .github workflows

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -46,7 +46,8 @@
       "extensions": [
         "vscode-icons-team.vscode-icons",
         "redhat.vscode-yaml",
-        "tamasfe.even-better-toml"
+        "tamasfe.even-better-toml",
+        "bierner.markdown-mermaid"
       ]
     }
   },

--- a/.devcontainer/images/.claude/commands/update.md
+++ b/.devcontainer/images/.claude/commands/update.md
@@ -206,12 +206,27 @@ Go (go.mod):
 
 Remplace .devcontainer depuis le template Kodflow.
 
+### ⚠️ IMPORTANT : Scope du téléchargement
+
+**UNIQUEMENT `.devcontainer/` est téléchargé et remplacé.**
+
+Le template `kodflow/devcontainer-template` contient d'autres fichiers à la racine qui sont **EXCLUS** :
+
+| Fichier/Dossier | Action |
+|-----------------|--------|
+| `.devcontainer/` | ✅ **Téléchargé et remplacé** |
+| `.github/` | ❌ **JAMAIS téléchargé** (workflows du projet) |
+| `.gitignore` | ❌ **JAMAIS téléchargé** (config du projet) |
+| `.coderabbit.yaml` | ❌ **JAMAIS téléchargé** (config du projet) |
+| `CLAUDE.md` | ❌ **JAMAIS téléchargé** (doc du projet) |
+| `README.md` | ❌ **JAMAIS téléchargé** (doc du projet) |
+
 ### Workflow
 
 1. Identifier les fichiers protégés (gitignored, .env)
 2. Sauvegarder les fichiers protégés
-3. Télécharger le template depuis GitHub
-4. Remplacer .devcontainer/
+3. Télécharger **UNIQUEMENT** `.devcontainer/` depuis le template GitHub
+4. Remplacer `.devcontainer/` (et rien d'autre)
 5. Restaurer les fichiers protégés
 6. Valider la configuration
 
@@ -236,11 +251,15 @@ Fichiers protégés (préservés):
   ✓ .devcontainer/.env
   ✓ .devcontainer/hooks/shared/.env
 
+Fichiers EXCLUS (jamais téléchargés):
+  ○ .github/ (workflows du projet préservés)
+  ○ .gitignore, CLAUDE.md, README.md
+
 Sauvegarde des fichiers protégés...
   ✓ .devcontainer/.env sauvegardé
 
 Téléchargement de kodflow/devcontainer-template...
-  ✓ Template téléchargé
+  ✓ .devcontainer/ téléchargé (scope limité)
 
 Remplacement de .devcontainer/...
   ✓ .devcontainer/ remplacé
@@ -253,6 +272,9 @@ Validation de la configuration...
 
 ═══════════════════════════════════════════════
   ✓ DevContainer mis à jour
+
+  Note: .github/ et autres fichiers racine
+        n'ont PAS été modifiés.
 
   Prochaine étape:
     Ctrl+Shift+P → 'Rebuild Container'

--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -74,8 +74,8 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
 # =============================================================================
 # Kubernetes Tools (kubectl, Helm)
 # =============================================================================
-ARG KUBECTL_VERSION=1.32.0
-ARG HELM_VERSION=3.16.3
+ARG KUBECTL_VERSION=1.35.0
+ARG HELM_VERSION=4.0.4
 
 RUN ARCH_K8S=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${ARCH_K8S}/kubectl" -o /usr/local/bin/kubectl && \

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -49,10 +49,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'
@@ -77,7 +77,7 @@ jobs:
       # PR: Build only (no push)
       - name: Build image (PR)
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .devcontainer/images
           file: .devcontainer/images/Dockerfile
@@ -91,7 +91,7 @@ jobs:
       - name: Build and push by digest
         if: github.event_name != 'pull_request'
         id: build
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .devcontainer/images
           file: .devcontainer/images/Dockerfile
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload digest
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: digests-${{ steps.platform.outputs.pair }}
           path: /tmp/digests/*
@@ -130,14 +130,14 @@ jobs:
 
     steps:
       - name: Download digests
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to Container Registry
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3


### PR DESCRIPTION
## Summary
- Clarify that `/update --devcontainer` only fetches `.devcontainer/` directory
- Explicitly document that `.github/` and other root files are NEVER downloaded
- Prevent accidental overwrite of project workflows when updating from template

## Changes
| File | Change |
|------|--------|
| `update.md` | Add "Scope du téléchargement" section with excluded files table |
| `update.md` | Update output to show excluded files message |
| `Dockerfile` | Update kubectl 1.32.0 → 1.35.0, helm 3.16.3 → 4.0.4 |
| `docker-images.yml` | Update GitHub Actions to latest versions |
| `devcontainer.json` | Add markdown-mermaid VS Code extension |

## Test plan
- [ ] Run `/update --devcontainer` and verify `.github/` is not modified
- [ ] Verify documentation clearly states the scope limitation
- [ ] Rebuild container to validate Dockerfile changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extension VSCode supplémentaire ajoutée pour la prise en charge des diagrammes Mermaid en Markdown.
  * Versions des outils Kubernetes (kubectl et Helm) mises à jour.
  * Actions GitHub et Docker actualisées aux versions plus récentes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->