### PR TITLE
fix(postStart): add chmod 755 to agents directory for consistency

### DIFF
--- a/.devcontainer/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/hooks/lifecycle/postStart.sh
@@ -47,6 +47,7 @@ if [ -d "$CLAUDE_DEFAULTS" ]; then
     if [ -d "$CLAUDE_DEFAULTS/agents" ]; then
         mkdir -p "$HOME/.claude/agents"
         cp -r "$CLAUDE_DEFAULTS/agents/"* "$HOME/.claude/agents/" 2>/dev/null || true
+        chmod -R 755 "$HOME/.claude/agents/"
     fi
 
     # Restore settings.json only if it does not exist (user customizations preserved)


### PR DESCRIPTION
## Summary

- Add `chmod -R 755` to agents directory after restoration
- Ensures consistency with scripts directory handling

## Root Cause

The `postStart.sh` script applies `chmod -R 755` to the scripts directory (line 43) but not to the agents directory. While current agents are Markdown files (prompts), future agents may include executable components.

## Fix

Add `chmod -R 755 "$HOME/.claude/agents/"` after copying agents, matching the pattern used for scripts.

## Test Plan

- [ ] Rebuild devcontainer
- [ ] Verify agents directory has 755 permissions
- [ ] Verify agents are restored correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Correction des permissions de répertoire dans l'environnement de développement conteneurisé pour assurer l'accès approprié aux fichiers d'agents restaurés.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->