### PR TITLE
feat(rust): add Tauri desktop framework support

### DIFF
--- a/.devcontainer/features/languages/rust/install.sh
+++ b/.devcontainer/features/languages/rust/install.sh
@@ -15,7 +15,8 @@ NC='\033[0m' # No Color
 export CARGO_HOME="${CARGO_HOME:-$HOME/.cache/cargo}"
 export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.cache/rustup}"
 
-# Install dependencies (includes Tauri/WebKitGTK support)
+# Install dependencies
+# Includes Tauri/WebKitGTK dependencies for Linux desktop apps
 echo -e "${YELLOW}Installing dependencies...${NC}"
 sudo apt-get update && sudo apt-get install -y \
     curl \
@@ -25,7 +26,6 @@ sudo apt-get update && sudo apt-get install -y \
     cmake \
     pkg-config \
     libssl-dev \
-    # Tauri dependencies (WebKitGTK for Linux desktop apps)
     libwebkit2gtk-4.1-dev \
     libxdo-dev \
     libayatana-appindicator3-dev \


### PR DESCRIPTION
## Summary
- Add WebKitGTK system dependencies for Tauri desktop apps on Linux
- Add `tauri-cli` to Rust cargo tools for building Tauri applications

## Changes
- `.devcontainer/features/languages/rust/install.sh`:
  - Added `libwebkit2gtk-4.1-dev` (WebView rendering)
  - Added `libxdo-dev` (X11 automation)
  - Added `libayatana-appindicator3-dev` (system tray icons)
  - Added `librsvg2-dev` (SVG support)
  - Added `tauri-cli` to CARGO_TOOLS array

## Usage
Enable the rust feature in `devcontainer.json`:
```json
"./features/languages/rust": {},
```

Then after container rebuild:
```bash
cargo tauri init
cargo tauri dev
cargo tauri build
```

## Test plan
- [ ] Rebuild devcontainer with rust feature enabled
- [ ] Verify WebKitGTK packages install without errors
- [ ] Verify `cargo tauri --version` works
- [ ] Test `cargo tauri init` creates a new project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Chores**
  * Ajout de dépendances pour la prise en charge de Tauri et WebKitGTK dans l'environnement de développement Linux.
  * Intégration de tauri-cli aux outils de développement Rust fournis.
  * Mise à jour des résumés pour inclure tauri-cli parmi les outils installés.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->