### PR TITLE
fix(scripts): correct actions field type in session schema

### DIFF
--- a/.devcontainer/images/.claude/scripts/task-init.sh
+++ b/.devcontainer/images/.claude/scripts/task-init.sh
@@ -91,7 +91,7 @@ cat > "$SESSION_FILE" << ENDJSON
     "currentEpic": null,
     "lockedPaths": [],
     "epics": [],
-    "actions": 0,
+    "actions": [],
     "lastAction": null,
     "createdAt": "$TIMESTAMP"
 }


### PR DESCRIPTION
## Summary

- Fix `"actions": 0` → `"actions": []` in task-init.sh session template
- Matches the expected array type in session JSON schema v3

## Changes

- `.devcontainer/images/.claude/scripts/task-init.sh`: Correct actions field initialization