### PR TITLE
fix(devcontainer): ensure 1Password CLI config directory has correct permissions

### DIFF
--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -116,9 +116,10 @@ USER vscode
 WORKDIR /home/vscode
 
 # Create cache and config directories
+# Note: .config/op must exist with correct ownership for 1Password CLI (requires 700 perms)
 RUN mkdir -p .cache .config .local/bin .local/share .zsh_history_dir \
     .cache/{terraform,helm,aws,bazel} \
-    .config/{aws,gcloud,azure} .kube \
+    .config/{aws,gcloud,azure,op} .kube \
     .claude .config/@anthropic .cache/@anthropic .local/share/@anthropic
 
 # Oh My Zsh + Powerlevel10k (force fresh install to ensure completeness)


### PR DESCRIPTION
## Bug

The 1Password CLI (`op`) fails to retrieve secrets during `postStart.sh` because the config directory `/home/vscode/.config/op` has incorrect ownership and permissions.

**Errors encountered:**
1. `[ERROR] Can't continue. We can't safely access "/home/vscode/.config/op" because it's not owned by the current user.`
2. `[ERROR] Can't continue. We can't safely access "/home/vscode/.config/op" because its permissions are too broad. Change its permissions to 700 and try again.`

## Root cause

Docker named volumes (`op-config` and `op-cache` in docker-compose.yml) are created by the Docker daemon with `root:root` ownership and `755` permissions before the container user (`vscode`) takes over.

The 1Password CLI requires:
- Ownership by current user (`vscode:vscode`)
- Permissions `700` (owner read/write/execute only)

## Fix

Two-layer approach (belt and suspenders):

1. **Preventive (Dockerfile):** Add `.config/op` to the `mkdir -p` command in user setup
   - Ensures correct ownership when image is built
   - Named volume inherits content from image on first mount

2. **Defensive (postStart.sh):** Add permission fix before `op` invocation
   - Handles existing containers with wrong permissions
   - Uses `sudo` only if ownership needs fixing
   - Sets `chmod 700` unconditionally

### Files changed

- `.devcontainer/images/Dockerfile`: Add `.config/op` to user directories
- `.devcontainer/hooks/lifecycle/postStart.sh`: Add permission fix section

## Test plan

- [ ] Rebuild container from scratch
- [ ] Verify `.config/op` is owned by `vscode:vscode`
- [ ] Verify `.config/op` has `700` permissions
- [ ] Verify `op` commands work correctly
- [ ] Verify MCP tokens are populated in `.mcp.json`

Closes #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * L'environnement de développement a été amélioré pour assurer une initialisation correcte des répertoires de configuration 1Password CLI avec les permissions de sécurité appropriées au démarrage du conteneur.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->