### PR TITLE
fix(devcontainer): ensure npm cache has correct ownership for MCP servers

### DIFF
--- a/.devcontainer/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/hooks/lifecycle/postStart.sh
@@ -191,6 +191,23 @@ for OP_DIR in "${OP_CONFIG_DIRS[@]}"; do
 done
 log_success "1Password config directories configured"
 
+# ============================================================================
+# npm Cache Permissions Fix
+# ============================================================================
+# Docker named volumes create directories with root ownership.
+# npm requires write access to its cache for npx/MCP servers to work.
+# See: https://github.com/kodflow/devcontainer-template/issues/88
+NPM_CACHE_DIR="$HOME/.cache/npm"
+
+if [ -d "$NPM_CACHE_DIR" ]; then
+    # Fix ownership if not current user
+    if [ "$(stat -c '%U' "$NPM_CACHE_DIR" 2>/dev/null)" != "$(whoami)" ]; then
+        log_info "Fixing ownership of npm cache..."
+        sudo chown -R "$(whoami):$(whoami)" "$NPM_CACHE_DIR"
+    fi
+fi
+log_success "npm cache configured"
+
 # Try 1Password if OP_SERVICE_ACCOUNT_TOKEN is defined
 if [ -n "$OP_SERVICE_ACCOUNT_TOKEN" ] && command -v op &> /dev/null; then
     log_info "Retrieving secrets from 1Password..."


### PR DESCRIPTION
## Bug

The npm cache folder (`/home/vscode/.cache/npm`) contains root-owned files after container creation, causing EACCES permission errors that block all MCP servers from starting.

**Error:**
```
npm error code EACCES
npm error syscall open
npm error path /home/vscode/.cache/npm/_cacache/tmp/...
npm error Your cache folder contains root-owned files
```

## Root cause

Docker named volumes (`package-cache:/home/vscode/.cache`) are created by the Docker daemon with root ownership. When npm tries to write to its cache during `npx` commands (used by MCP servers), it fails with permission errors.

## Fix

Add permission fix in `postStart.sh` (following the same pattern as #87 for 1Password):
- Check if npm cache directory exists
- Fix ownership if not owned by current user
- Runs on every container start to handle existing containers

### File changed

- `.devcontainer/hooks/lifecycle/postStart.sh`: Add npm cache ownership fix section

## Test plan

- [ ] Rebuild container from scratch
- [ ] Verify npm cache is owned by `vscode:vscode`
- [ ] Verify `npx` commands work correctly
- [ ] Verify MCP servers start without EACCES errors

Closes #88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Amélioration de la configuration de l'environnement de développement : ajout d'un correctif automatisé des permissions du cache npm exécuté au démarrage du conteneur, qui vérifie et ajuste le propriétaire si nécessaire pour garantir un accès fiable aux répertoires lors de l'initialisation.

<sub>✏️ Astuce : vous pouvez personnaliser ce résumé dans vos paramètres de revue.</sub>

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->