### PR TITLE
fix(devcontainer): upgrade golangci-lint v2 and fix grepai MCP integration

### DIFF
--- a/.devcontainer/features/languages/go/install.sh
+++ b/.devcontainer/features/languages/go/install.sh
@@ -147,12 +147,12 @@ get_github_version() {
     echo "${version:-$fallback}"
 }
 
-# Quality & Linting - golangci-lint (prebuilt)
-# Fallback 1.63.4 fixes CVE-2024-45337 (golang.org/x/crypto) and CVE-2024-45338 (golang.org/x/net)
-GOLANGCI_VERSION=$(get_github_version "golangci/golangci-lint" "1.63.4")
+# Quality & Linting - golangci-lint v2 (prebuilt)
+# v2.x is a major rewrite with breaking config changes (use .golangci.yml version: "2")
+GOLANGCI_VERSION=$(get_github_version "golangci/golangci-lint" "2.8.0")
 install_go_tool "golangci-lint" \
     "https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_VERSION}/golangci-lint-${GOLANGCI_VERSION}-linux-${GO_ARCH}.tar.gz" \
-    "github.com/golangci/golangci-lint/cmd/golangci-lint" \
+    "github.com/golangci/golangci-lint/v2/cmd/golangci-lint" \
     "tar.gz"
 
 # Security - gosec (prebuilt)


### PR DESCRIPTION
### **User description**
## Summary

- Upgrade golangci-lint from v1.63.4 fallback to v2.8.0 in Go feature install script
- Fix grepai Ollama endpoint configuration (localhost:11434 → ollama:11434 sidecar)
- Add grepai watch daemon automatic startup in postStart.sh
- Integrate grepai initialization into /init command with parallel checker agent
- Strengthen GREPAI-FIRST rule as mandatory in CLAUDE.md documentation

## Changes

### golangci-lint v2 (`install.sh`)
| Before | After |
|--------|-------|
| Fallback `1.63.4` | Fallback `2.8.0` |
| Module path v1 | Module path `/v2/cmd/golangci-lint` |

### grepai MCP (`postStart.sh`)
| Issue | Fix |
|-------|-----|
| Wrong Ollama endpoint | `localhost:11434` → `ollama:11434` |
| No sidecar check | Added 30s wait with API health check |
| No watch daemon | Added automatic `grepai watch` startup |

### /init command (`init.md`)
- Added `mcp__grepai__*` to allowed-tools
- Added `grepai-checker` parallel agent
- Added "Semantic Search" section in output report

### Documentation (`CLAUDE.md`)
- GREPAI-FIRST rule marked as "MANDATORY - ABSOLUTE"
- Added decision matrix for grepai vs Grep usage
- Added workflow documentation for semantic search

## Test plan

- [ ] Rebuild devcontainer and verify golangci-lint v2 is installed
- [ ] Verify grepai MCP connects to Ollama sidecar
- [ ] Run `/init` and check grepai initialization
- [ ] Test `mcp__grepai__grepai_search` returns results


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Upgrade golangci-lint from v1.63.4 to v2.8.0 with v2 module path

- Fix grepai Ollama endpoint configuration (localhost → sidecar)

- Add grepai watch daemon automatic startup in postStart.sh

- Integrate grepai initialization into /init command with parallel checker

- Strengthen GREPAI-FIRST rule as mandatory in documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["golangci-lint v1.63.4"] -- "upgrade to v2.8.0" --> B["golangci-lint v2"]
  C["grepai config"] -- "fix endpoint localhost:11434" --> D["Ollama sidecar ollama:11434"]
  E["postStart.sh"] -- "add watch daemon startup" --> F["grepai watch running"]
  G["init.md"] -- "add grepai-checker agent" --> H["grepai initialization"]
  I["CLAUDE.md"] -- "strengthen GREPAI-FIRST rule" --> J["Mandatory grepai usage"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install.sh</strong><dd><code>Upgrade golangci-lint to v2.8.0 with v2 module path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/features/languages/go/install.sh

<ul><li>Upgrade golangci-lint fallback version from 1.63.4 to 2.8.0<br> <li> Update module path from <code>cmd/golangci-lint</code> to <code>v2/cmd/golangci-lint</code><br> <li> Update comment to reflect v2 major rewrite with breaking config <br>changes</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/105/files#diff-042011b2d3eb0060d241f6dee5155f9a78a362f7118a25f076e272099d25070e">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>init.md</strong><dd><code>Integrate grepai initialization into /init command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/images/.claude/commands/init.md

<ul><li>Add grepai, curl, pgrep, nohup to allowed-tools<br> <li> Add mcp__grepai__* to allowed-tools<br> <li> Add grepai to tools list in decompose_workflow<br> <li> Add new semantic_search section with Ollama and grepai checks<br> <li> Add grepai-checker parallel agent with initialization steps<br> <li> Update parallel_checks mode from 4 to 5 Task calls<br> <li> Add Semantic Search section to synthesize_workflow output<br> <li> Add Search Usage section with grepai MCP examples</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/105/files#diff-497855124f57151537298096965ef700871424fca8b1d4918baee61811ac7f05">+49/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>postStart.sh</strong><dd><code>Fix Ollama endpoint and add grepai watch daemon startup</code>&nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/hooks/lifecycle/postStart.sh

<ul><li>Replace localhost:11434 with Ollama sidecar endpoint (ollama:11434)<br> <li> Add 30-second health check loop for Ollama sidecar readiness<br> <li> Replace local Ollama binary startup with curl-based API calls<br> <li> Add grepai config endpoint fix (localhost → sidecar)<br> <li> Add grepai watch daemon automatic startup with process verification</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/105/files#diff-3448f74d4d6a9288781932549c4bd1cffc2385474948e9476862a60bec7a7c4c">+48/-15</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Add comprehensive grepai workflow and decision matrix</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/images/.claude/CLAUDE.md

<ul><li>Reorder priority_order to place search (grepai) first<br> <li> Add new section 1.1 GREPAI-FIRST RULE with detailed workflow<br> <li> Add grepai workflow steps (index check, semantic search, trace <br>analysis)<br> <li> Add decision matrix table for grepai vs Grep tool usage<br> <li> Add fallback conditions for when to use Grep</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/105/files#diff-0226aa5cd67f2779c9accea586eb0b7083bb6d77c341c5c3aed13e3d95d0402e">+43/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Strengthen GREPAI-FIRST rule to mandatory absolute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

<ul><li>Change GREPAI-FIRST RULE title to "MANDATORY - ABSOLUTE"<br> <li> Rewrite rule from "fallback to Grep" to "NEVER use Grep"<br> <li> Add pre_search_check workflow (verify index, run /init if needed)<br> <li> Restructure search_workflow with semantic_query, impact_analysis, <br>dependency_analysis, full_graph<br> <li> Add grep_fallback_conditions with specific failure scenarios<br> <li> Add decision matrix table for search task selection<br> <li> Add initialization commands (grepai init, endpoint fix, watch daemon)<br> <li> Update "Why grepai-first" section with local processing note</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/105/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+55/-43</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Chores**
  * Mise à jour de golangci-lint vers la version majeure 2 avec configuration compatible.
  * Refonte du système de démarrage Ollama pour utiliser une architecture sidecar avec vérification de disponibilité et mise à jour automatique de la configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->