### PR TITLE
fix(hooks): make all hook scripts fail-open

### DIFF
--- a/.devcontainer/images/.claude/scripts/format.sh
+++ b/.devcontainer/images/.claude/scripts/format.sh
@@ -8,9 +8,9 @@
 #
 # Note: Most formatters also handle import sorting (goimports, ruff, rustfmt).
 
-set -e
+set +e  # Fail-open: hooks should never block unexpectedly
 
-FILE="$1"
+FILE="${1:-}"
 if [ -z "$FILE" ] || [ ! -f "$FILE" ]; then
     exit 0
 fi

--- a/.devcontainer/images/.claude/scripts/lint.sh
+++ b/.devcontainer/images/.claude/scripts/lint.sh
@@ -9,9 +9,9 @@
 # Note: This focuses on CODE QUALITY (style, errors, best practices).
 # typecheck.sh handles strict type checking.
 
-set -e
+set +e  # Fail-open: hooks should never block unexpectedly
 
-FILE="$1"
+FILE="${1:-}"
 if [ -z "$FILE" ] || [ ! -f "$FILE" ]; then
     exit 0
 fi

--- a/.devcontainer/images/.claude/scripts/post-edit.sh
+++ b/.devcontainer/images/.claude/scripts/post-edit.sh
@@ -3,10 +3,10 @@
 # Usage: post-edit.sh <file_path>
 # Note: format.sh handles imports (goimports, ruff, rustfmt, etc.)
 
-set -e
+set +e  # Fail-open: hooks should never block unexpectedly
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-FILE="$1"
+FILE="${1:-}"
 
 if [ -z "$FILE" ] || [ ! -f "$FILE" ]; then
     exit 0

--- a/.devcontainer/images/.claude/scripts/pre-validate.sh
+++ b/.devcontainer/images/.claude/scripts/pre-validate.sh
@@ -3,9 +3,10 @@
 # Usage: pre-validate.sh <file_path>
 # Exit 0 = allow, Exit 2 = block
 
-set -euo pipefail
+set -uo pipefail
+# Note: Removed -e (errexit) to fail-open on unexpected errors
 
-FILE="$1"
+FILE="${1:-}"
 if [ -z "$FILE" ]; then
     exit 0
 fi

--- a/.devcontainer/images/.claude/scripts/security.sh
+++ b/.devcontainer/images/.claude/scripts/security.sh
@@ -6,7 +6,7 @@
 #
 # Exit 0 = OK, Exit 2 = blocked (secrets found)
 
-set -e
+set +e  # Fail-open: don't exit on errors (hook should never block unexpectedly)
 
 # === Single file scan function ===
 scan_file() {

--- a/.devcontainer/images/.claude/scripts/test.sh
+++ b/.devcontainer/images/.claude/scripts/test.sh
@@ -10,9 +10,9 @@
 #   make test              # Run all tests
 #   make test FILE=path    # Run tests for specific file
 
-set -e
+set +e  # Fail-open: hooks should never block unexpectedly
 
-FILE="$1"
+FILE="${1:-}"
 if [ -z "$FILE" ] || [ ! -f "$FILE" ]; then
     exit 0
 fi

--- a/.devcontainer/images/.claude/scripts/typecheck.sh
+++ b/.devcontainer/images/.claude/scripts/typecheck.sh
@@ -9,9 +9,9 @@
 # Note: This focuses on TYPE SAFETY, not general linting.
 # lint.sh handles general code quality issues.
 
-set -e
+set +e  # Fail-open: hooks should never block unexpectedly
 
-FILE="$1"
+FILE="${1:-}"
 if [ -z "$FILE" ] || [ ! -f "$FILE" ]; then
     exit 0
 fi


### PR DESCRIPTION
### **User description**
## Summary
- Remove `set -e` from hook scripts to prevent unexpected failures
- Add graceful stdin handling with empty/invalid JSON fallback
- Use `${1:-}` for optional arguments to handle `set -u`
- Hooks now exit 0 on errors instead of blocking Claude

## Affected scripts
- `commit-validate.sh`
- `security.sh`
- `pre-validate.sh`
- `post-edit.sh`
- `test.sh`
- `format.sh`
- `lint.sh`
- `typecheck.sh`

## Test plan
- [x] Scripts exit 0 with empty stdin
- [x] Scripts exit 0 without arguments
- [x] Blocking (exit 2) still works for explicit violations


___

### **PR Type**
Bug fix


___

### **Description**
- Remove `set -e` from all hook scripts to prevent unexpected failures

- Add graceful stdin/JSON handling with fallback to empty object

- Use `${1:-}` syntax for optional arguments to handle `set -u`

- Hooks now exit 0 on errors instead of blocking Claude operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hook Scripts<br/>with set -e"] -->|Remove errexit| B["Fail-open behavior"]
  C["Empty/Invalid JSON"] -->|Graceful handling| B
  D["Missing arguments"] -->|Use ${1:-}| B
  B -->|Exit 0 on errors| E["Never block Claude<br/>unexpectedly"]
  B -->|Exit 2 on violations| F["Explicit blocking<br/>still works"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commit-validate.sh</strong><dd><code>Add graceful JSON input handling with fail-open</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/images/.claude/scripts/commit-validate.sh

<ul><li>Remove <code>set -e</code> from <code>set -euo pipefail</code>, keep <code>set -uo pipefail</code><br> <li> Add graceful stdin reading with <code>cat 2>/dev/null</code> and empty object <br>fallback<br> <li> Exit 0 early if input is empty or invalid JSON<br> <li> Add jq availability check before processing<br> <li> Wrap jq commands with error handling and fallback values</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/124/files#diff-d7275b2dbf81bc5a05f2f725063c7a6304f5970f8dd653ffc300014e448e9cb8">+20/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>format.sh</strong><dd><code>Disable errexit and add safe argument handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/images/.claude/scripts/format.sh

<ul><li>Change <code>set -e</code> to <code>set +e</code> to disable errexit<br> <li> Replace <code>$1</code> with <code>${1:-}</code> for safe optional argument handling<br> <li> Add inline comment explaining fail-open philosophy</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/124/files#diff-4b0cd976481cdf56ee28b60cb66b6fcbd22c8aa4b9f4a36535f92306971abc63">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lint.sh</strong><dd><code>Disable errexit and add safe argument handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/images/.claude/scripts/lint.sh

<ul><li>Change <code>set -e</code> to <code>set +e</code> to disable errexit<br> <li> Replace <code>$1</code> with <code>${1:-}</code> for safe optional argument handling<br> <li> Add inline comment explaining fail-open philosophy</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/124/files#diff-de6c4323a659ab9886296ec8913dde956493cba43908f4b38ac0b8a9d645c231">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>post-edit.sh</strong><dd><code>Disable errexit and add safe argument handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/images/.claude/scripts/post-edit.sh

<ul><li>Change <code>set -e</code> to <code>set +e</code> to disable errexit<br> <li> Replace <code>$1</code> with <code>${1:-}</code> for safe optional argument handling<br> <li> Add inline comment explaining fail-open philosophy</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/124/files#diff-0b8e08ec5fd72e3805adce7924d11de9b6fd20d7af27ebfe8a5f08a4dc0a8e02">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pre-validate.sh</strong><dd><code>Remove errexit and add safe argument handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/images/.claude/scripts/pre-validate.sh

<ul><li>Remove <code>set -e</code> from <code>set -euo pipefail</code>, keep <code>set -uo pipefail</code><br> <li> Replace <code>$1</code> with <code>${1:-}</code> for safe optional argument handling<br> <li> Add comment explaining removal of errexit flag</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/124/files#diff-a8703f822e9bdfff0753b9d8e92733bf2b1a6ade4bdc09e0d13bdd3bb8a63127">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>security.sh</strong><dd><code>Disable errexit for fail-open behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/images/.claude/scripts/security.sh

<ul><li>Change <code>set -e</code> to <code>set +e</code> to disable errexit<br> <li> Add inline comment explaining fail-open philosophy</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/124/files#diff-96421a7561a0e19be10a7096deba4115823485fc963fa3c020c49a80457beac9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test.sh</strong><dd><code>Disable errexit and add safe argument handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/images/.claude/scripts/test.sh

<ul><li>Change <code>set -e</code> to <code>set +e</code> to disable errexit<br> <li> Replace <code>$1</code> with <code>${1:-}</code> for safe optional argument handling<br> <li> Add inline comment explaining fail-open philosophy</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/124/files#diff-12eea86c1785f79070d508e8fc0abfd378935fbdb8bb8d3534ada28796f59b39">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>typecheck.sh</strong><dd><code>Disable errexit and add safe argument handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/images/.claude/scripts/typecheck.sh

<ul><li>Change <code>set -e</code> to <code>set +e</code> to disable errexit<br> <li> Replace <code>$1</code> with <code>${1:-}</code> for safe optional argument handling<br> <li> Add inline comment explaining fail-open philosophy</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/124/files#diff-a18fa96cd5226cff0dc6a9a4574f43421e386c0c56a8a7dee16f09230a9d01fa">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

