### PR TITLE
fix(grepai): redirect watch daemon output to log file

### DIFF
--- a/.devcontainer/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/hooks/lifecycle/postStart.sh
@@ -228,7 +228,7 @@ init_semantic_search() {
 
     if [ -z "$grepai_pid" ]; then
         log_info "Starting grepai watch daemon for real-time indexing..."
-        (cd /workspace && nohup "$GREPAI_BIN" watch >/dev/null 2>&1 &)
+        (cd /workspace && nohup "$GREPAI_BIN" watch >/tmp/grepai.log 2>&1 &)
         sleep 2
         grepai_pid=$(pgrep -f "$GREPAI_BIN watch" 2>/dev/null || true)
         if [ -n "$grepai_pid" ]; then


### PR DESCRIPTION
### **User description**
## Summary
- Redirect grepai watch daemon output from `/dev/null` to `/tmp/grepai.log`
- Enables debugging and troubleshooting of grepai indexing issues

## Test plan
- [ ] Verify grepai watch daemon starts correctly
- [ ] Check `/tmp/grepai.log` contains daemon output
- [ ] Confirm no regression in indexing functionality


___

### **PR Type**
Bug fix


___

### **Description**
- Redirect grepai watch daemon output to log file

- Changes output destination from /dev/null to /tmp/grepai.log

- Enables debugging and troubleshooting of indexing issues


___

### Diagram Walkthrough


```mermaid
flowchart LR
  daemon["grepai watch daemon"] -- "output redirection" --> old["/dev/null"]
  daemon -- "output redirection" --> new["/tmp/grepai.log"]
  style old fill:#ffcccc
  style new fill:#ccffcc
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>postStart.sh</strong><dd><code>Redirect daemon output to log file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/hooks/lifecycle/postStart.sh

<ul><li>Modified grepai watch daemon startup command<br> <li> Changed stdout redirection from /dev/null to /tmp/grepai.log<br> <li> Preserves stderr redirection to stdout for complete logging</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/132/files#diff-3448f74d4d6a9288781932549c4bd1cffc2385474948e9476862a60bec7a7c4c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

