### PR TITLE
fix(docker): install python3-venv for mkdocs virtual environment

### DIFF
--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -115,9 +115,14 @@ RUN add-apt-repository --yes --update ppa:ansible/ansible && \
 # Pre-installed for /docs skill - avoids reinstall on each rebuild
 # Uses virtual environment to avoid system package conflicts (Markdown 3.5.2)
 # Note: mkdocs-material >= 8.2.0 has native Mermaid support (no plugin needed)
-RUN python3 -m venv /opt/mkdocs && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y --no-install-recommends python3-venv && \
+    python3 -m venv /opt/mkdocs && \
     /opt/mkdocs/bin/pip install --no-cache-dir mkdocs-material && \
-    ln -s /opt/mkdocs/bin/mkdocs /usr/local/bin/mkdocs
+    ln -s /opt/mkdocs/bin/mkdocs /usr/local/bin/mkdocs && \
+    apt-get clean
 
 # =============================================================================
 # 1Password CLI (op) - For secrets management


### PR DESCRIPTION
### **User description**
## Summary

Fixes the Docker build failure on both amd64 and arm64 architectures.

**Root cause:** Ubuntu 24.04 base image doesn't include `python3-venv` by default. The previous fix used `python3 -m venv` without first installing the package.

**Fix:** Install `python3-venv` via apt before creating the virtual environment.

## Test plan

- [ ] CI passes for linux/amd64
- [ ] CI passes for linux/arm64
- [ ] Merge job completes successfully

## Related

Fixes regression from #138


___

### **PR Type**
Bug fix


___

### **Description**
- Install python3-venv package before creating mkdocs virtual environment

- Add apt cache mounts to optimize Docker layer caching

- Clean apt cache after installation to reduce image size


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Ubuntu 24.04 base"] -->|missing python3-venv| B["venv creation fails"]
  C["Install python3-venv"] -->|apt install| D["Create venv successfully"]
  E["Add cache mounts"] -->|optimize layers| F["Faster rebuilds"]
  G["Clean apt cache"] -->|reduce size| H["Smaller image"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Add python3-venv installation and optimize apt caching</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/images/Dockerfile

<ul><li>Install <code>python3-venv</code> package via apt before creating virtual <br>environment<br> <li> Add cache mounts for <code>/var/cache/apt</code> and <code>/var/lib/apt</code> to optimize <br>Docker layer caching<br> <li> Add <code>apt-get clean</code> command to remove apt cache and reduce final image <br>size<br> <li> Restructure RUN command with proper line continuations for readability</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/139/files#diff-c7855c74207a209eb30480b4c70b684a58d118e03f8cdbd24f8c6233c8718ed2">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

