### PR TITLE
fix(install): prevent unbound variable errors with set -u

### DIFF
--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -513,7 +513,7 @@ load_env_file() {
 
 # List all vaults from service account
 get_1password_vaults() {
-    if command -v op &>/dev/null && [ -n "$OP_SERVICE_ACCOUNT_TOKEN" ]; then
+    if command -v op &>/dev/null && [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
         op vault list --format=json 2>/dev/null | jq -r '.[].name' 2>/dev/null || echo ""
     fi
 }
@@ -525,7 +525,7 @@ get_1password_field() {
     local value=""
     local vaults
 
-    if ! command -v op &>/dev/null || [ -z "$OP_SERVICE_ACCOUNT_TOKEN" ]; then
+    if ! command -v op &>/dev/null || [ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
         echo ""
         return
     fi
@@ -571,7 +571,7 @@ fetch_1password_tokens() {
         return 0
     fi
 
-    if [ -z "$OP_SERVICE_ACCOUNT_TOKEN" ]; then
+    if [ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
         echo "  ⚠ OP_SERVICE_ACCOUNT_TOKEN not set"
         echo "    Set it in .env or export it"
         return 0


### PR DESCRIPTION
### **User description**
## Problem

The install script uses `set -euo pipefail` which is good for catching errors, but the `-u` flag causes the script to exit when accessing undefined variables.

When `OP_SERVICE_ACCOUNT_TOKEN` is not defined (common when 1Password is not used), the script fails before reaching `install_super_claude`, leaving the user without the `super-claude` function.

## Solution

Use bash parameter expansion `${VAR:-}` to provide an empty default when the variable is unset:

```bash
# Before (fails with set -u if OP_SERVICE_ACCOUNT_TOKEN unset)
if [ -z "$OP_SERVICE_ACCOUNT_TOKEN" ]; then

# After (safe with set -u)
if [ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
```

## Fixed Lines

- Line 516: `get_1password_vaults()`
- Line 528: `get_1password_field()`
- Line 574: `fetch_1password_tokens()`

## Test Plan

- [ ] Install without 1Password CLI → script completes
- [ ] Install without OP_SERVICE_ACCOUNT_TOKEN → script completes
- [ ] Install with 1Password configured → tokens fetched normally
- [ ] `super-claude` function available after install


___

### **PR Type**
Bug fix


___

### **Description**
- Fix unbound variable errors in install script with `set -u`

- Replace bare variable references with safe parameter expansion

- Prevent script exit when `OP_SERVICE_ACCOUNT_TOKEN` is undefined

- Enable successful installation without 1Password integration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Install Script<br/>set -euo pipefail"] -->|"Unbound Variable<br/>OP_SERVICE_ACCOUNT_TOKEN"| B["Script Exit<br/>Error"]
  A -->|"Safe Parameter<br/>Expansion ${VAR:-}"| C["Script Completes<br/>Successfully"]
  B -->|"Fix Applied"| C
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install.sh</strong><dd><code>Replace unbound variable references with safe defaults</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/install.sh

<ul><li>Updated <code>get_1password_vaults()</code> to use <code>${OP_SERVICE_ACCOUNT_TOKEN:-}</code> <br>syntax<br> <li> Updated <code>get_1password_field()</code> to use safe parameter expansion for <br>token check<br> <li> Updated <code>fetch_1password_tokens()</code> to use safe parameter expansion for <br>token validation<br> <li> Prevents script failure when environment variable is unset under <code>set </code><br><code>-u</code></ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/154/files#diff-209bdbb23aa0a35af49e0c18909203da30c00947c08b815d4c28852cf67084c8">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

