### PR TITLE
feat(init): remove entire docs/ directory for new projects

### DIFF
--- a/.devcontainer/images/.claude/commands/init.md
+++ b/.devcontainer/images/.claude/commands/init.md
@@ -19,6 +19,7 @@ allowed-tools:
   - "Bash(pgrep:*)"
   - "Bash(nohup:*)"
   - "Bash(mkdir:*)"
+  - "Bash(rm:*)"
   - "Bash(wc:*)"
   - "Read(**/*)"
   - "Glob(**/*)"
@@ -80,9 +81,8 @@ detect_repository:
       reset_files:
         - "/workspace/CLAUDE.md"
         - "/workspace/AGENTS.md"
-        - "/workspace/docs/vision.md"
-        - "/workspace/docs/architecture.md"
-        - "/workspace/docs/workflows.md"
+      reset_directories:
+        - "/workspace/docs/"    # rm -rf — template docs don't apply to new projects
       note: "README.md is NOT erased — only its description will be updated in Phase 3"
 ```
 
@@ -119,9 +119,7 @@ detect_template:
   → Resetting docs for fresh initialization...
     ✗ CLAUDE.md        (reset)
     ✗ AGENTS.md        (reset)
-    ✗ docs/vision.md   (reset)
-    ✗ docs/architecture.md (reset)
-    ✗ docs/workflows.md    (reset)
+    ✗ docs/            (removed)
 
   → Starting discovery conversation...
 


### PR DESCRIPTION
### **User description**
## Summary

- When `/init` detects a project different from devcontainer-template, clean the full `docs/` directory (`rm -rf`) instead of resetting individual files
- Prevents new projects from inheriting template-specific documentation (vision.md, architecture.md, workflows.md, index.md)

## Changes

1. Add `Bash(rm:*)` to `/init` allowed-tools
2. Replace individual `docs/*` file resets with `reset_directories: ["/workspace/docs/"]`
3. Update Phase 0 output block to show `docs/ (removed)`

## Test plan

- [ ] Run `/init` on a project with a different git remote
- [ ] Verify `docs/` directory is fully removed (not just individual files)
- [ ] Verify Phase 3 recreates `docs/` with new project documentation
- [ ] Run `/init` on devcontainer-template repo — no change in behavior


___

### **PR Type**
Enhancement


___

### **Description**
- Replace individual docs file resets with directory-level removal

- Add `Bash(rm:*)` to allowed-tools for directory deletion capability

- Update Phase 0 output to reflect full `docs/` directory removal

- Prevents new projects from inheriting template-specific documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Init detects non-template project"] -->|"Previously"| B["Reset individual docs files"]
  A -->|"Now"| C["Remove entire docs/ directory"]
  C --> D["Phase 3 recreates with new docs"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>init.md</strong><dd><code>Replace individual docs resets with directory removal</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/images/.claude/commands/init.md

<ul><li>Added <code>Bash(rm:*)</code> to allowed-tools list for directory removal <br>operations<br> <li> Replaced three individual <code>docs/*</code> file resets with single <br><code>reset_directories: ["/workspace/docs/"]</code> entry<br> <li> Updated Phase 0 output block to show <code>docs/</code> (removed) instead of <br>individual file resets<br> <li> Added clarifying comment that template docs don't apply to new <br>projects</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/163/files#diff-497855124f57151537298096965ef700871424fca8b1d4918baee61811ac7f05">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

