### PR TITLE
fix(devcontainer): resolve VS Code ptyHost shell environment timeout

### DIFF
--- a/.devcontainer/features/languages/nodejs/install.sh
+++ b/.devcontainer/features/languages/nodejs/install.sh
@@ -286,22 +286,10 @@ if [ -d "$NVM_DIR" ]; then
     log_success "NVM directory ownership set to vscode"
 fi
 
-# Add NVM to zshrc for interactive shells
-ZSHRC="/home/vscode/.zshrc"
-if [ -f "$ZSHRC" ]; then
-    if ! grep -q "NVM_DIR" "$ZSHRC"; then
-        log_info "Adding NVM to .zshrc..."
-        cat >> "$ZSHRC" <<'EOF'
-
-# NVM (Node Version Manager)
-# NVM installed in system location (not volume) - Microsoft best practice
-# See: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/node.md
-export NVM_DIR="/usr/local/share/nvm"
-export NVM_SYMLINK_CURRENT=true
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-EOF
-    fi
-fi
+# NVM is loaded via ~/.devcontainer-env.sh (sourced by both .zshrc and .bashrc)
+# No need to inject NVM into .zshrc directly — avoids double-loading which
+# causes VS Code ptyHost shell environment resolution timeout
+log_info "NVM will be loaded via ~/.devcontainer-env.sh (two-phase loading)"
 
 echo ""
 echo -e "${GREEN}=========================================${NC}"

--- a/.devcontainer/features/openvpn/CLAUDE.md
+++ b/.devcontainer/features/openvpn/CLAUDE.md
@@ -10,7 +10,7 @@ Entirely opt-in: without configuration, nothing happens.
 | Component | Description |
 |-----------|-------------|
 | openvpn | OpenVPN client daemon |
-| openresolv | DNS resolution for VPN routes |
+| resolvconf | DNS resolution for VPN routes |
 | vpn-connect | Start VPN connection |
 | vpn-disconnect | Stop VPN connection |
 | vpn-status | Check VPN state |
@@ -71,5 +71,5 @@ Place `.ovpn` file at `~/.config/openvpn/client.ovpn` (volume mount or manual co
 | `RTNETLINK: Operation not permitted` | Missing `NET_ADMIN` capability in docker-compose.yml |
 | `Cannot open TUN/TAP dev` | Missing `/dev/net/tun` device in docker-compose.yml |
 | `auth-user-pass` error | Check `OPENVPN_AUTH_USER_REF` / `OPENVPN_AUTH_PASS_REF` |
-| DNS not resolving | Check `openresolv` is installed: `resolvconf --version` |
+| DNS not resolving | Check `resolvconf` is installed: `resolvconf --version` |
 | Logs | `cat /tmp/openvpn.log` |

--- a/.devcontainer/features/openvpn/install.sh
+++ b/.devcontainer/features/openvpn/install.sh
@@ -17,10 +17,10 @@ TARGET_HOME="$(getent passwd "$TARGET_USER" 2>/dev/null | cut -d: -f6 || echo "/
 # ─────────────────────────────────────────────────────────────────────────────
 # Install OpenVPN + DNS resolution
 # ─────────────────────────────────────────────────────────────────────────────
-echo -e "${YELLOW}Installing openvpn and openresolv...${NC}"
+echo -e "${YELLOW}Installing openvpn and resolvconf...${NC}"
 
 apt-get update -y
-apt-get install -y --no-install-recommends openvpn openresolv
+apt-get install -y --no-install-recommends openvpn resolvconf
 rm -rf /var/lib/apt/lists/*
 
 echo -e "${GREEN}✓ openvpn $(openvpn --version 2>&1 | head -1 | awk '{print $2}') installed${NC}"
@@ -170,7 +170,7 @@ echo -e "${GREEN}=========================================${NC}"
 echo ""
 echo "Installed components:"
 echo "  - openvpn $(openvpn --version 2>&1 | head -1 | awk '{print $2}')"
-echo "  - openresolv (DNS for VPN routes)"
+echo "  - resolvconf (DNS for VPN routes)"
 echo "  - vpn-connect (start VPN)"
 echo "  - vpn-disconnect (stop VPN)"
 echo "  - vpn-status (check VPN state)"


### PR DESCRIPTION
### **User description**
## Summary

- Split `~/.devcontainer-env.sh` into two-phase loading to fix VS Code ptyHost timeout
- Phase 1 (always): fast PATH/env exports with zero subprocesses
- Phase 2 (real terminal only): heavy init guarded by `[ ! -t 1 ]`
- Remove duplicate NVM injection from nodejs feature (was loading NVM twice)
- Add postStart.sh repair to upgrade existing containers automatically
- Fix openvpn feature: `openresolv` → `resolvconf` package name

## Root Cause

VS Code's ptyHost spawns `zsh -ilc 'env'` with a 10s timeout to resolve shell environment variables. The `~/.devcontainer-env.sh` script was loading:
- NVM twice (nodejs feature + devcontainer-env.sh)
- 6+ `eval` subprocess calls (pyenv, rbenv, sdkman, cargo)
- 15+ completion generators (`source <(kubectl completion zsh)`, etc.)

This easily exceeded the timeout on ARM64.

## Fix Architecture

**Phase 1** (always runs — needed by VS Code env resolution):
- All `export` statements and PATH additions
- Direct directory checks only (`[ -d ... ]`), no subprocesses
- Adds shims/bins to PATH directly instead of running `eval "$(pyenv init -)"`

**Phase 2** (real terminal only — guarded by `[ ! -t 1 ]`):
- NVM full initialization (`nvm.sh`)
- Version manager eval calls (pyenv, rbenv, sdkman)
- All 15+ completion generators
- `super-claude()` function and aliases

## Files Changed

| File | Change |
|------|--------|
| `hooks/lifecycle/postCreate.sh` | Restructure env template with Phase 1/2 split |
| `hooks/lifecycle/postStart.sh` | Add v2 upgrade repair + NVM dedup for existing containers |
| `features/languages/nodejs/install.sh` | Remove duplicate NVM injection into .zshrc |
| `features/openvpn/install.sh` | Fix openresolv→resolvconf package name |
| `features/openvpn/CLAUDE.md` | Update docs to match |

## Test plan

- [ ] Rebuild container — verify no ptyHost timeout errors in VS Code logs
- [ ] Open terminal — verify `nvm`, `node`, completions all work (Phase 2)
- [ ] Check `~/.devcontainer-env.sh` contains "two-phase" marker
- [ ] Verify `.zshrc` has no duplicate NVM_DIR entries
- [ ] Existing container upgrade: postStart.sh detects v1 and regenerates


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Split shell environment initialization into two-phase loading to fix VS Code ptyHost timeout
  - Phase 1: Fast PATH/env exports with no subprocesses (always runs)
  - Phase 2: Heavy initialization guarded by terminal detection (interactive only)

- Remove duplicate NVM injection from nodejs feature to prevent double-loading

- Add automatic upgrade mechanism for existing containers to v2 two-phase loading

- Fix openvpn feature package name from openresolv to resolvconf


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Shell startup<br/>zsh/bash"] -->|sources| B["~/.devcontainer-env.sh<br/>v2 two-phase"]
  B -->|Phase 1<br/>always| C["Fast PATH exports<br/>no subprocesses"]
  B -->|Phase 2<br/>terminal only| D["Heavy init<br/>nvm/pyenv/completions"]
  C -->|provides| E["VS Code ptyHost<br/>env resolution"]
  D -->|provides| F["Interactive terminal<br/>features"]
  G["postStart.sh"] -->|upgrades| B
  H["nodejs feature"] -->|removed<br/>duplicate NVM| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>postCreate.sh</strong><dd><code>Implement two-phase shell environment loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/hooks/lifecycle/postCreate.sh

<ul><li>Restructured ~/.devcontainer-env.sh with two-phase loading <br>architecture<br> <li> Phase 1: Direct PATH additions for NVM, pyenv, rbenv, SDKMAN, Cargo, <br>Go without eval subprocesses<br> <li> Phase 2: Heavy initialization (nvm.sh, eval calls, completions) <br>guarded by terminal detection <code>[ ! -t 1 ]</code><br> <li> Added detailed comments explaining the timeout issue and optimization <br>strategy</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/172/files#diff-62a8741135c5cb293b9b20e37138b78288815b2ec86e892ed65cebf3638df53f">+52/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>install.sh</strong><dd><code>Remove duplicate NVM injection from zshrc</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/features/languages/nodejs/install.sh

<ul><li>Removed direct NVM injection into .zshrc that was causing <br>double-loading<br> <li> Replaced with comment explaining NVM is now loaded via <br>~/.devcontainer-env.sh<br> <li> Prevents VS Code ptyHost shell environment resolution timeout</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/172/files#diff-704e547dc88f8d34951a44c305885b0e49f8baeee05a1f5c0d148b863a649e77">+4/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>install.sh</strong><dd><code>Fix openvpn DNS package name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/features/openvpn/install.sh

<ul><li>Changed package name from <code>openresolv</code> to <code>resolvconf</code> in apt-get install <br>command<br> <li> Updated log messages and documentation to reference correct package <br>name<br> <li> Fixes DNS resolution for VPN routes with correct Debian package</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/172/files#diff-e7513c85e771544d9f68149a449cf9eebcf206f0e0fb3462cc3a46494aff44ba">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>postStart.sh</strong><dd><code>Add upgrade repair and NVM deduplication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/hooks/lifecycle/postStart.sh

<ul><li>Added v2 upgrade repair to detect and regenerate old <br>devcontainer-env.sh files<br> <li> Implemented duplicate NVM removal from .zshrc using sed patterns<br> <li> Detects v1 marker absence and triggers postCreate.sh regeneration for <br>existing containers<br> <li> Cleans up orphaned NVM_SYMLINK_CURRENT exports</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/172/files#diff-3448f74d4d6a9288781932549c4bd1cffc2385474948e9476862a60bec7a7c4c">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Update openvpn documentation package reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/features/openvpn/CLAUDE.md

<ul><li>Updated component documentation from openresolv to resolvconf<br> <li> Fixed troubleshooting section to reference correct package name</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/172/files#diff-5d633077da5256f47c75c0c1a06b31dcca212cbec94b7a5a39bb98265c99f07a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

