### PR TITLE
fix(openvpn): replace resolvconf with container-friendly DNS update

### DIFF
--- a/.devcontainer/features/openvpn/CLAUDE.md
+++ b/.devcontainer/features/openvpn/CLAUDE.md
@@ -10,7 +10,7 @@ Entirely opt-in: without configuration, nothing happens.
 | Component | Description |
 |-----------|-------------|
 | openvpn | OpenVPN client daemon |
-| resolvconf | DNS resolution for VPN routes |
+| update-dns | Container-friendly DNS update (writes /etc/resolv.conf directly) |
 | vpn-connect | Start VPN connection |
 | vpn-disconnect | Stop VPN connection |
 | vpn-status | Check VPN state |
@@ -71,5 +71,5 @@ Place `.ovpn` file at `~/.config/openvpn/client.ovpn` (volume mount or manual co
 | `RTNETLINK: Operation not permitted` | Missing `NET_ADMIN` capability in docker-compose.yml |
 | `Cannot open TUN/TAP dev` | Missing `/dev/net/tun` device in docker-compose.yml |
 | `auth-user-pass` error | Check `OPENVPN_AUTH_USER_REF` / `OPENVPN_AUTH_PASS_REF` |
-| DNS not resolving | Check `resolvconf` is installed: `resolvconf --version` |
+| DNS not resolving | Check `/etc/openvpn/update-dns` exists and is executable |
 | Logs | `cat /tmp/openvpn.log` |

--- a/.devcontainer/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/hooks/lifecycle/postStart.sh
@@ -681,8 +681,8 @@ init_openvpn() {
         --daemon ovpn-client
         --log /tmp/openvpn.log
         --script-security 2
-        --up /etc/openvpn/update-resolv-conf
-        --down /etc/openvpn/update-resolv-conf
+        --up /etc/openvpn/update-dns
+        --down /etc/openvpn/update-dns
         --keepalive 10 60
         --connect-retry 5
         --connect-retry-max 0

--- a/.devcontainer/images/.claude/commands/ovpn.md
+++ b/.devcontainer/images/.claude/commands/ovpn.md
@@ -279,8 +279,8 @@ connect_workflow:
         --daemon ovpn-client \
         --log /tmp/openvpn.log \
         --script-security 2 \
-        --up /etc/openvpn/update-resolv-conf \
-        --down /etc/openvpn/update-resolv-conf \
+        --up /etc/openvpn/update-dns \
+        --down /etc/openvpn/update-dns \
         --keepalive 10 60 \
         --connect-retry 5 \
         --connect-retry-max 0 \


### PR DESCRIPTION
### **User description**
## Summary

- Replace `resolvconf` package (broken in Docker containers) with custom `/etc/openvpn/update-dns` script
- Script writes `/etc/resolv.conf` directly, bypassing systemd-resolved/D-Bus dependency
- VPN DNS nameservers take priority, Docker DNS kept as fallback
- Backup/restore of original `resolv.conf` on connect/disconnect

## Problem

On Ubuntu 24.04, `resolvconf` is a transitional package that installs `systemd-resolved` as backend. In Docker containers, `systemd-resolved` fails because D-Bus is not available:

```
/sbin/resolvconf → symlink → /bin/resolvectl (systemd-resolved)
resolvectl → sd_bus_open_system → "No such file or directory" (no D-Bus)
→ exit 1 → "Exiting due to fatal error"
```

## Changes

| File | Change |
|------|--------|
| `install.sh` | Remove `resolvconf` from apt, create `/etc/openvpn/update-dns` |
| `postStart.sh` | Use `update-dns` instead of `update-resolv-conf` |
| `CLAUDE.md` | Update components and troubleshooting |
| `ovpn.md` | Update skill references |

## Test plan

- [ ] shellcheck passes on modified scripts
- [ ] Container rebuild installs openvpn without resolvconf
- [ ] `/etc/openvpn/update-dns` is created and executable
- [ ] `vpn-connect` uses `update-dns` for `--up`/`--down`
- [ ] VPN connects without DNS crash


___

### **PR Type**
Bug fix


___

### **Description**
- Replace `resolvconf` package with custom `/etc/openvpn/update-dns` script

- Script writes `/etc/resolv.conf` directly, avoiding systemd-resolved D-Bus dependency

- VPN DNS takes priority with Docker DNS kept as fallback

- Backup and restore original `resolv.conf` on VPN connect/disconnect


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["resolvconf package<br/>systemd-resolved<br/>D-Bus dependency"] -->|"Remove from apt"| B["Custom update-dns script"]
  B -->|"Direct write"| C["/etc/resolv.conf"]
  D["VPN DHCP options"] -->|"Parse"| B
  E["Docker DNS backup"] -->|"Restore on down"| B
  B -->|"Used by"| F["OpenVPN up/down hooks"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install.sh</strong><dd><code>Create container-friendly DNS update script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/features/openvpn/install.sh

<ul><li>Removed <code>resolvconf</code> from apt-get install command<br> <li> Created new <code>/etc/openvpn/update-dns</code> script with 50+ lines of bash code<br> <li> Script handles DNS backup on VPN connect and restoration on disconnect<br> <li> Updated installation messages and component list to reference new <br>script</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/173/files#diff-e7513c85e771544d9f68149a449cf9eebcf206f0e0fb3462cc3a46494aff44ba">+60/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>postStart.sh</strong><dd><code>Update OpenVPN hooks to use new DNS script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/hooks/lifecycle/postStart.sh

<ul><li>Updated OpenVPN command arguments to use <code>/etc/openvpn/update-dns</code> <br>instead of <code>/etc/openvpn/update-resolv-conf</code><br> <li> Changed both <code>--up</code> and <code>--down</code> hook references</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/173/files#diff-3448f74d4d6a9288781932549c4bd1cffc2385474948e9476862a60bec7a7c4c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Update documentation for DNS resolution changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/features/openvpn/CLAUDE.md

<ul><li>Updated component table to replace <code>resolvconf</code> with <code>update-dns</code> <br>description<br> <li> Updated troubleshooting section to check for <code>/etc/openvpn/update-dns</code> <br>instead of <code>resolvconf --version</code></ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/173/files#diff-5d633077da5256f47c75c0c1a06b31dcca212cbec94b7a5a39bb98265c99f07a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ovpn.md</strong><dd><code>Update command reference documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/images/.claude/commands/ovpn.md

<ul><li>Updated OpenVPN command documentation to reference <br><code>/etc/openvpn/update-dns</code> instead of <code>/etc/openvpn/update-resolv-conf</code><br> <li> Changed both <code>--up</code> and <code>--down</code> hook references in workflow documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/173/files#diff-be5bfb4be33520ee5b3692c82ff0627c14827f15df49855422cd55dad062b33d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

