### PR TITLE
fix(hooks): non-blocking lifecycle scripts with run_step pattern

### DIFF
--- a/.devcontainer/hooks/lifecycle/postAttach.sh
+++ b/.devcontainer/hooks/lifecycle/postAttach.sh
@@ -8,7 +8,7 @@
 # Use it for: Welcome messages, status display, interactive prompts.
 # ============================================================================
 
-set -e
+set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../shared/utils.sh"
@@ -22,5 +22,12 @@ echo ""
 # Display useful information
 log_success "IDE connected to DevContainer"
 echo ""
-echo -e "Tip: Use ${GREEN}super-claude${NC} for Claude CLI with MCP config"
+
+# Verify super-claude is available before advertising it
+if [ -f "$HOME/.devcontainer-env.sh" ] && grep -q "super-claude" "$HOME/.devcontainer-env.sh" 2>/dev/null; then
+    echo -e "Tip: Use ${GREEN}super-claude${NC} for Claude CLI with MCP config"
+else
+    log_warning "super-claude not available - environment setup may have failed"
+    log_info "Try running: source ~/.devcontainer-env.sh"
+fi
 echo ""

--- a/.devcontainer/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/hooks/lifecycle/postStart.sh
@@ -6,31 +6,45 @@
 # This script runs after postCreateCommand and before postAttachCommand.
 # Runs each time the container is successfully started.
 # Use it for: MCP setup, services startup, recurring initialization.
+#
+# Uses run_step pattern: each step runs in an isolated subshell so that
+# failures never block the DevContainer lifecycle.
 # ============================================================================
 
-set -e
+set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../shared/utils.sh"
 
 log_info "postStart: Container starting..."
 
+init_steps
+
 # ============================================================================
+# Step functions
+# ============================================================================
+
 # Restore Claude commands/scripts from image defaults OR host installation
-# ============================================================================
 # Priority:
 #   1. Host installation ($HOME/.claude/ with .template-version)
 #   2. Image defaults (/etc/claude-defaults/)
-# ============================================================================
-CLAUDE_DEFAULTS="/etc/claude-defaults"
+step_restore_claude_config() {
+    local CLAUDE_DEFAULTS="/etc/claude-defaults"
 
-# Check if user has a host-installed Claude configuration
-# (installed via install.sh - indicated by .template-version file)
-if [ -f "$HOME/.claude/.template-version" ]; then
-    log_info "Detected host-installed Claude configuration (via install.sh)"
-    log_info "Skipping image defaults restore - using host installation"
-    log_success "Claude configuration from host (priority)"
-elif [ -d "$CLAUDE_DEFAULTS" ]; then
+    # Check if user has a host-installed Claude configuration
+    # (installed via install.sh - indicated by .template-version file)
+    if [ -f "$HOME/.claude/.template-version" ]; then
+        log_info "Detected host-installed Claude configuration (via install.sh)"
+        log_info "Skipping image defaults restore - using host installation"
+        log_success "Claude configuration from host (priority)"
+        return 0
+    fi
+
+    if [ ! -d "$CLAUDE_DEFAULTS" ]; then
+        log_warning "No Claude configuration found (neither host nor image defaults)"
+        return 0
+    fi
+
     log_info "Restoring Claude configuration from image defaults..."
 
     # Ensure base directory exists
@@ -78,100 +92,327 @@ elif [ -d "$CLAUDE_DEFAULTS" ]; then
     fi
 
     log_success "Claude configuration restored from image defaults"
-else
-    log_warning "No Claude configuration found (neither host nor image defaults)"
-fi
+}
 
-# ============================================================================
 # Ensure Claude directories exist (volume mount point)
-# ============================================================================
-mkdir -p "$HOME/.claude/sessions" "$HOME/.claude/plans"
-log_success "Claude directories initialized"
+step_init_claude_dirs() {
+    mkdir -p "$HOME/.claude/sessions" "$HOME/.claude/plans"
+    log_success "Claude directories initialized"
+}
 
-# ============================================================================
 # Ensure shell environment is properly configured (repair mechanism)
-# ============================================================================
 # postCreate.sh creates ~/.devcontainer-env.sh with super-claude() and other
 # shell functions. If the source line is missing from RC files (stale image,
 # volume issue, or .bashrc never configured), inject it here on every start.
-DC_SOURCE_LINE='[[ -f ~/.devcontainer-env.sh ]] && source ~/.devcontainer-env.sh'
+step_shell_env_repair() {
+    local DC_SOURCE_LINE='[[ -f ~/.devcontainer-env.sh ]] && source ~/.devcontainer-env.sh'
 
-for rc_file in "$HOME/.zshrc" "$HOME/.bashrc"; do
-    if [ -f "$rc_file" ] && ! grep -q "devcontainer-env.sh" "$rc_file" 2>/dev/null; then
-        printf '\n%s\n' "$DC_SOURCE_LINE" >> "$rc_file"
-        log_info "Added devcontainer-env source to $(basename "$rc_file")"
-    fi
-done
-
-# ============================================================================
-# Upgrade devcontainer-env.sh to two-phase loading (v2)
-# ============================================================================
-# v1 loaded heavy init (nvm.sh, eval pyenv/rbenv, 15+ completions) unconditionally,
-# causing VS Code ptyHost to timeout resolving shell environment.
-# v2 splits into: Phase 1 (fast PATH exports) + Phase 2 (heavy init, terminal only).
-DC_ENV="$HOME/.devcontainer-env.sh"
-if [ -f "$DC_ENV" ] && ! grep -q "two-phase" "$DC_ENV" 2>/dev/null; then
-    log_info "Upgrading devcontainer-env.sh to two-phase loading (v2)..."
-
-    # Trigger postCreate.sh to regenerate the env file
-    # Remove the guard marker so postCreate regenerates, but preserve initialization state
-    if [ -f /home/vscode/.devcontainer-initialized ]; then
-        rm -f /home/vscode/.devcontainer-initialized
-        if [ -f /workspace/.devcontainer/hooks/lifecycle/postCreate.sh ]; then
-            bash /workspace/.devcontainer/hooks/lifecycle/postCreate.sh 2>/dev/null || true
+    for rc_file in "$HOME/.zshrc" "$HOME/.bashrc"; do
+        if [ -f "$rc_file" ] && ! grep -q "devcontainer-env.sh" "$rc_file" 2>/dev/null; then
+            printf '\n%s\n' "$DC_SOURCE_LINE" >> "$rc_file"
+            log_info "Added devcontainer-env source to $(basename "$rc_file")"
         fi
-        # Restore marker (postCreate.sh recreates it, but ensure it exists)
-        touch /home/vscode/.devcontainer-initialized
+    done
+
+    # Upgrade devcontainer-env.sh to two-phase loading (v2)
+    # v1 loaded heavy init (nvm.sh, eval pyenv/rbenv, 15+ completions) unconditionally,
+    # causing VS Code ptyHost to timeout resolving shell environment.
+    # v2 splits into: Phase 1 (fast PATH exports) + Phase 2 (heavy init, terminal only).
+    local DC_ENV="$HOME/.devcontainer-env.sh"
+    if [ -f "$DC_ENV" ] && ! grep -q "two-phase" "$DC_ENV" 2>/dev/null; then
+        log_info "Upgrading devcontainer-env.sh to two-phase loading (v2)..."
+
+        # Trigger postCreate.sh to regenerate the env file
+        # Remove the guard marker so postCreate regenerates, but preserve initialization state
+        if [ -f /home/vscode/.devcontainer-initialized ]; then
+            rm -f /home/vscode/.devcontainer-initialized
+            if [ -f /workspace/.devcontainer/hooks/lifecycle/postCreate.sh ]; then
+                bash /workspace/.devcontainer/hooks/lifecycle/postCreate.sh 2>/dev/null || true
+            fi
+            # Restore marker (postCreate.sh recreates it, but ensure it exists)
+            touch /home/vscode/.devcontainer-initialized
+        fi
+        log_success "devcontainer-env.sh upgraded to v2 (two-phase)"
     fi
-    log_success "devcontainer-env.sh upgraded to v2 (two-phase)"
-fi
 
-# ============================================================================
-# Remove duplicate NVM from .zshrc (added by nodejs feature, already in env.sh)
-# ============================================================================
-if [ -f "$HOME/.zshrc" ] && grep -c "NVM_DIR" "$HOME/.zshrc" 2>/dev/null | grep -q "^[2-9]"; then
-    # Remove the nodejs-feature-injected NVM block (lines after devcontainer-env source)
-    # Pattern: block starting with "# NVM" and containing nvm.sh, after the devcontainer-env line
-    sed -i '/^# NVM (Node Version Manager)$/,/^\[ -s "\$NVM_DIR\/nvm\.sh" \]/d' "$HOME/.zshrc" 2>/dev/null || true
-    # Also clean up NVM_SYMLINK_CURRENT if orphaned
-    sed -i '/^export NVM_SYMLINK_CURRENT=true$/d' "$HOME/.zshrc" 2>/dev/null || true
-    log_info "Removed duplicate NVM from .zshrc (handled by devcontainer-env.sh)"
-fi
+    # Remove duplicate NVM from .zshrc (added by nodejs feature, already in env.sh)
+    if [ -f "$HOME/.zshrc" ] && grep -c "NVM_DIR" "$HOME/.zshrc" 2>/dev/null | grep -q "^[2-9]"; then
+        sed -i '/^# NVM (Node Version Manager)$/,/^\[ -s "\$NVM_DIR\/nvm\.sh" \]/d' "$HOME/.zshrc" 2>/dev/null || true
+        sed -i '/^export NVM_SYMLINK_CURRENT=true$/d' "$HOME/.zshrc" 2>/dev/null || true
+        log_info "Removed duplicate NVM from .zshrc (handled by devcontainer-env.sh)"
+    fi
 
-# Ensure zsh is the default login shell
-if [ "$(getent passwd "$(whoami)" | cut -d: -f7)" != "/bin/zsh" ]; then
-    sudo chsh -s /bin/zsh "$(whoami)" 2>/dev/null || true
-    log_success "Default shell set to zsh"
-fi
+    # Ensure zsh is the default login shell
+    if [ "$(getent passwd "$(whoami)" | cut -d: -f7)" != "/bin/zsh" ]; then
+        sudo chsh -s /bin/zsh "$(whoami)" 2>/dev/null || true
+        log_success "Default shell set to zsh"
+    fi
+}
 
 # Reload .env file to get updated tokens
-ENV_FILE="/workspace/.devcontainer/.env"
-if [ -f "$ENV_FILE" ]; then
-    log_info "Reloading environment from .env..."
-    set -a
-    source "$ENV_FILE"
-    set +a
-fi
+step_reload_env() {
+    local ENV_FILE="/workspace/.devcontainer/.env"
+    if [ -f "$ENV_FILE" ]; then
+        log_info "Reloading environment from .env..."
+        set -a
+        source "$ENV_FILE"
+        set +a
+    fi
+}
+
+# Fix 1Password CLI config directory permissions
+# Docker named volumes create directories with root ownership.
+# 1Password CLI requires: ownership by current user + permissions 700.
+step_1password_permissions() {
+    local OP_CONFIG_DIRS=("$HOME/.config/op" "$HOME/.op")
+
+    for OP_DIR in "${OP_CONFIG_DIRS[@]}"; do
+        if [ -d "$OP_DIR" ]; then
+            # Fix ownership if not current user
+            if [ "$(stat -c '%U' "$OP_DIR" 2>/dev/null)" != "$(whoami)" ]; then
+                log_info "Fixing ownership of $OP_DIR..."
+                sudo chown -R "$(whoami):$(whoami)" "$OP_DIR"
+            fi
+            # Ensure correct permissions (700 = owner only)
+            chmod 700 "$OP_DIR"
+        fi
+    done
+    log_success "1Password config directories configured"
+}
+
+# Fix npm cache permissions
+# Docker named volumes create directories with root ownership.
+# npm requires write access to its cache for npx/MCP servers to work.
+step_npm_cache_permissions() {
+    local NPM_CACHE_DIR="$HOME/.cache/npm"
+
+    if [ -d "$NPM_CACHE_DIR" ]; then
+        # Fix ownership if not current user
+        if [ "$(stat -c '%U' "$NPM_CACHE_DIR" 2>/dev/null)" != "$(whoami)" ]; then
+            log_info "Fixing ownership of npm cache..."
+            sudo chown -R "$(whoami):$(whoami)" "$NPM_CACHE_DIR"
+        fi
+    fi
+    log_success "npm cache configured"
+}
+
+# MCP configuration setup (inject secrets into template)
+step_mcp_configuration() {
+    # 1Password vault ID (can be overridden via OP_VAULT_ID env var)
+    local VAULT_ID="${OP_VAULT_ID:-ypahjj334ixtiyjkytu5hij2im}"
+    local MCP_TPL="/etc/mcp/mcp.json.tpl"
+    local MCP_OUTPUT="/workspace/mcp.json"
+
+    # Helper function to get 1Password field (tries multiple field names)
+    get_1password_field() {
+        local item="$1"
+        local vault="$2"
+        local fields=("credential" "password" "identifiant" "mot de passe")
+
+        for field in "${fields[@]}"; do
+            local value
+            value=$(op item get "$item" --vault "$vault" --fields "$field" --reveal 2>/dev/null || echo "")
+            if [ -n "$value" ]; then
+                echo "$value"
+                return 0
+            fi
+        done
+        echo ""
+    }
+
+    # Initialize tokens from environment variables (fallback)
+    local CODACY_TOKEN="${CODACY_API_TOKEN:-}"
+    local GITHUB_TOKEN="${GITHUB_API_TOKEN:-}"
+
+    # Try 1Password if OP_SERVICE_ACCOUNT_TOKEN is defined
+    if [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ] && command -v op &> /dev/null; then
+        log_info "Retrieving secrets from 1Password..."
+
+        local OP_CODACY
+        OP_CODACY=$(get_1password_field "mcp-codacy" "$VAULT_ID")
+        local OP_GITHUB
+        OP_GITHUB=$(get_1password_field "mcp-github" "$VAULT_ID")
+
+        [ -n "$OP_CODACY" ] && CODACY_TOKEN="$OP_CODACY"
+        [ -n "$OP_GITHUB" ] && GITHUB_TOKEN="$OP_GITHUB"
+    fi
+
+    # Show status of tokens (INFO for optional, WARNING for essential)
+    [ -z "$CODACY_TOKEN" ] && log_info "Codacy token not configured (optional)"
+    [ -z "$GITHUB_TOKEN" ] && log_warning "GitHub token not available"
+
+    # Helper: escape special chars for sed replacement
+    escape_for_sed() {
+        LC_ALL=C printf '%s' "$1" | tr -d '\n\r' | sed -e 's/[&/|\\]/\\&/g'
+    }
+
+    # Security: refuse to write secrets through symlinks or unsafe directories
+    local MCP_DIR
+    MCP_DIR=$(dirname -- "$MCP_OUTPUT")
+    if [ ! -d "$MCP_DIR" ] || [ -L "$MCP_DIR" ]; then
+        log_error "Refusing to write mcp.json: unsafe parent directory ($MCP_DIR)"
+        return 0
+    elif [ -e "$MCP_OUTPUT" ] && { [ -L "$MCP_OUTPUT" ] || [ ! -f "$MCP_OUTPUT" ]; }; then
+        log_error "Refusing to write mcp.json: not a regular file ($MCP_OUTPUT)"
+        return 0
+    fi
+
+    # Migrate legacy .mcp.json to mcp.json (renamed in v2)
+    if [ -f "/workspace/.mcp.json" ] && [ ! -e "$MCP_OUTPUT" ]; then
+        log_info "Migrating legacy .mcp.json to mcp.json..."
+
+        if ! command -v jq >/dev/null 2>&1; then
+            log_warning "jq not found; migrating without JSON validation"
+            if cp "/workspace/.mcp.json" "$MCP_OUTPUT"; then
+                chown "$(id -u):$(id -g)" "$MCP_OUTPUT" 2>/dev/null || true
+                chmod 600 "$MCP_OUTPUT"
+                rm -f "/workspace/.mcp.json" || log_warning "Could not remove legacy .mcp.json (permissions?)"
+                log_success "Migration complete: .mcp.json → mcp.json"
+            else
+                log_error "Migration failed: unable to copy legacy file"
+            fi
+        else
+            local MCP_MIG_TMP
+            MCP_MIG_TMP=$(mktemp "${MCP_OUTPUT}.migrate.XXXXXX") || {
+                log_error "Migration failed: unable to create temp file"
+                MCP_MIG_TMP=""
+            }
+            if [ -n "$MCP_MIG_TMP" ] && cp "/workspace/.mcp.json" "$MCP_MIG_TMP"; then
+                if jq empty "$MCP_MIG_TMP" 2>/dev/null; then
+                    mv "$MCP_MIG_TMP" "$MCP_OUTPUT"
+                    chown "$(id -u):$(id -g)" "$MCP_OUTPUT" 2>/dev/null || true
+                    chmod 600 "$MCP_OUTPUT"
+                    rm -f "/workspace/.mcp.json" || log_warning "Could not remove legacy .mcp.json (permissions?)"
+                    log_success "Migration complete: .mcp.json → mcp.json"
+                else
+                    log_error "Legacy .mcp.json is invalid JSON; keeping legacy file"
+                    rm -f "$MCP_MIG_TMP"
+                fi
+            elif [ -n "$MCP_MIG_TMP" ]; then
+                log_error "Migration failed"
+                rm -f "$MCP_MIG_TMP"
+            fi
+        fi
+    fi
+
+    # Generate mcp.json from template (baked in Docker image)
+    # ALWAYS regenerate from template to ensure latest MCP config is applied
+    if [ -f "$MCP_TPL" ]; then
+        if [ -z "$CODACY_TOKEN" ] && [ -z "$GITHUB_TOKEN" ]; then
+            log_warning "No tokens available, creating minimal mcp.json"
+            printf '%s\n' '{"mcpServers":{}}' > "$MCP_OUTPUT"
+            chown "$(id -u):$(id -g)" "$MCP_OUTPUT" 2>/dev/null || true
+            chmod 600 "$MCP_OUTPUT"
+            log_info "Created minimal mcp.json (optional MCPs will be added below)"
+        else
+            generate_mcp_from_template() {
+                local escaped_codacy escaped_github mcp_tmp
+                escaped_codacy=$(escape_for_sed "${CODACY_TOKEN}")
+                escaped_github=$(escape_for_sed "${GITHUB_TOKEN}")
+
+                mcp_tmp=$(mktemp "${MCP_OUTPUT}.tmp.XXXXXX") || {
+                    log_error "Failed to create temp file for mcp.json generation"
+                    return 0
+                }
+
+                trap 'rm -f "$mcp_tmp" 2>/dev/null || true' RETURN
+
+                if ! sed -e "s|{{CODACY_TOKEN}}|${escaped_codacy}|g" \
+                        -e "s|{{GITHUB_TOKEN}}|${escaped_github}|g" \
+                        "$MCP_TPL" > "$mcp_tmp"; then
+                    log_error "Failed to render mcp.json template"
+                    return 0
+                fi
+
+                if jq empty "$mcp_tmp" 2>/dev/null; then
+                    mv "$mcp_tmp" "$MCP_OUTPUT"
+                    chown "$(id -u):$(id -g)" "$MCP_OUTPUT" 2>/dev/null || true
+                    chmod 600 "$MCP_OUTPUT"
+                    log_success "mcp.json generated successfully"
+                else
+                    log_error "Generated mcp.json is invalid JSON, keeping original"
+                fi
+            }
+            log_info "Regenerating mcp.json from template (forced)..."
+            generate_mcp_from_template
+        fi
+
+        # Add optional MCPs based on installed features
+        add_optional_mcp() {
+            local name="$1"
+            local binary="$2"
+            local output="$3"
+
+            [ -f "$output" ] || return 0
+
+            if ! command -v jq >/dev/null 2>&1; then
+                log_warning "Skipping $name MCP injection (jq not found)"
+                return 0
+            fi
+
+            if [ -x "$binary" ]; then
+                log_info "Adding $name MCP (binary found at $binary)"
+                local tmp_file
+                tmp_file=$(mktemp "${output}.tmp.XXXXXX") || {
+                    log_warning "Failed to add $name MCP (unable to create temp file)"
+                    return 0
+                }
+                if jq --arg name "$name" --arg bin "$binary" \
+                   '.mcpServers = (.mcpServers // {}) | .mcpServers[$name] = {"command": $bin, "args": [], "env": {}}' \
+                   "$output" > "$tmp_file" && jq empty "$tmp_file" 2>/dev/null; then
+                    mv "$tmp_file" "$output"
+                    chown "$(id -u):$(id -g)" "$output" 2>/dev/null || true
+                    chmod 600 "$output" 2>/dev/null || true
+                else
+                    log_warning "Failed to add $name MCP, keeping original"
+                    rm -f "$tmp_file"
+                fi
+            else
+                log_info "Skipping $name MCP (binary not found)"
+            fi
+        }
+
+        add_optional_mcp "rust-analyzer" "$HOME/.cache/cargo/bin/rust-analyzer-mcp" "$MCP_OUTPUT"
+    else
+        log_warning "MCP template not found at $MCP_TPL"
+    fi
+}
+
+# Clean git credential helpers (remove macOS-specific helpers)
+step_git_credential_cleanup() {
+    log_info "Cleaning git credential helpers..."
+    git config --global --unset-all credential.https://github.com.helper 2>/dev/null || true
+    git config --global --unset-all credential.https://gist.github.com.helper 2>/dev/null || true
+    log_success "Git credential helpers cleaned"
+}
+
+# Auto-run /init for project initialization check
+# Runs at every container start to verify project is properly initialized
+# Skipped in CI environment
+step_auto_init_check() {
+    local INIT_LOG="$HOME/.devcontainer-init.log"
+
+    if command -v claude &> /dev/null && [ -z "${CI:-}" ]; then
+        log_info "Running project initialization check..."
+        nohup bash -c "sleep 2 && claude \"/init\" || echo \"[\$(date -Iseconds)] Init check failed with exit code \$?\" >> \"$INIT_LOG\"" >> "$INIT_LOG" 2>&1 &
+        log_success "Init check scheduled (logs: ~/.devcontainer-init.log)"
+    elif [ -n "${CI:-}" ]; then
+        log_info "CI environment detected, skipping init"
+    fi
+}
 
 # ============================================================================
 # Ollama + grepai Initialization (for semantic code search MCP)
 # ============================================================================
-# Ollama runs on HOST machine for GPU acceleration (Metal/CUDA)
-# Installed automatically via initialize.sh during devcontainer build
-# Accessible from container via host.docker.internal:11434
-#
-# Model: qwen3-embedding:0.6b (fast, high-quality, 32K context, code-aware)
 GREPAI_BIN="/usr/local/bin/grepai"
 GREPAI_CONFIG_TPL="/etc/grepai/config.yaml"
 EMBEDDING_MODEL="qwen3-embedding:0.6b"
 OLLAMA_HOST_ENDPOINT="host.docker.internal:11434"
 
-# Detect Ollama on host machine
 detect_ollama_endpoint() {
     local endpoint=""
     local source=""
 
-    # Check for explicit override via env var
     if [ -n "${OLLAMA_HOST:-}" ]; then
         endpoint="$OLLAMA_HOST"
         source="OLLAMA_HOST env var"
@@ -183,7 +424,6 @@ detect_ollama_endpoint() {
         fi
     fi
 
-    # Check host Ollama (installed via initialize.sh)
     endpoint="$OLLAMA_HOST_ENDPOINT"
     if curl -sf --connect-timeout 3 "http://${endpoint}/api/tags" >/dev/null 2>&1; then
         source="host (GPU-accelerated)"
@@ -191,19 +431,16 @@ detect_ollama_endpoint() {
         return 0
     fi
 
-    # No Ollama available
     echo ""
     return 1
 }
 
-# Check if model is available on endpoint
 check_model_available() {
     local endpoint="$1"
     local model="$2"
     curl -sf "http://${endpoint}/api/tags" 2>/dev/null | grep -q "$model"
 }
 
-# Provide installation instructions for host Ollama
 show_ollama_instructions() {
     log_warning "==============================================================================="
     log_warning "  Ollama not running - Semantic search (grepai) will be disabled"
@@ -232,9 +469,6 @@ init_semantic_search() {
     local ollama_endpoint=""
     local ollama_source=""
 
-    # =========================================================================
-    # STEP 1: Detect Ollama on host (installed via initialize.sh)
-    # =========================================================================
     log_info "Checking Ollama on host ($OLLAMA_HOST_ENDPOINT)..."
     detected_result=$(detect_ollama_endpoint)
 
@@ -243,23 +477,16 @@ init_semantic_search() {
         ollama_source=$(echo "$detected_result" | cut -d'|' -f2)
         log_success "Ollama connected: $ollama_endpoint ($ollama_source)"
     else
-        # No Ollama available - show instructions but still initialize config
         show_ollama_instructions
-
-        # Initialize grepai config anyway (will work when Ollama becomes available)
         if [ -x "$GREPAI_BIN" ] && [ -f "$GREPAI_CONFIG_TPL" ]; then
             mkdir -p "$grepai_dir"
             cp "$GREPAI_CONFIG_TPL" "$grepai_config" 2>/dev/null || true
-            # Set endpoint to host for when Ollama starts
             sed -i -E "s|(endpoint: http://)[^[:space:]]+|\1${OLLAMA_HOST_ENDPOINT}|" "$grepai_config" 2>/dev/null || true
             log_info "grepai config initialized (waiting for Ollama)"
         fi
         return 0
     fi
 
-    # =========================================================================
-    # STEP 2: Initialize grepai config with detected endpoint
-    # =========================================================================
     if [ -x "$GREPAI_BIN" ]; then
         log_info "Initializing grepai configuration..."
         mkdir -p "$grepai_dir"
@@ -275,7 +502,6 @@ init_semantic_search() {
             (cd /workspace && "$GREPAI_BIN" init --provider ollama --backend gob --yes 2>/dev/null) || true
         fi
 
-        # Update endpoint in config to detected Ollama
         if [ -f "$grepai_config" ]; then
             sed -i -E "s|(endpoint: http://)[^[:space:]]+|\1${ollama_endpoint}|" "$grepai_config"
             log_info "grepai endpoint set to: http://$ollama_endpoint"
@@ -285,26 +511,18 @@ init_semantic_search() {
         return 0
     fi
 
-    # =========================================================================
-    # STEP 3: Check embedding model (pulled during initialize.sh)
-    # =========================================================================
     if check_model_available "$ollama_endpoint" "$EMBEDDING_MODEL"; then
         log_success "Model $EMBEDDING_MODEL available"
     else
         log_warning "Model $EMBEDDING_MODEL not found on host"
         log_info "Pull the model on your host machine:"
         log_info "  ollama pull $EMBEDDING_MODEL"
-        # Continue anyway - grepai will work once model is pulled
     fi
 
-    # Show available models for debugging
     local loaded_models
     loaded_models=$(curl -sf "http://${ollama_endpoint}/api/tags" 2>/dev/null | grep -o '"name":"[^"]*"' | sed 's/"name":"//g;s/"//g' | tr '\n' ' ' || echo "none")
     log_info "Available Ollama models: ${loaded_models:-none}"
 
-    # =========================================================================
-    # STEP 4: Start grepai watch daemon
-    # =========================================================================
     local grepai_pid
     grepai_pid=$(pgrep -f "$GREPAI_BIN watch" 2>/dev/null || true)
 
@@ -322,7 +540,6 @@ init_semantic_search() {
         log_info "grepai watch daemon already running (PID: $grepai_pid)"
     fi
 
-    # Check initial indexing status
     sleep 3
     local index_status
     index_status=$(cd /workspace && "$GREPAI_BIN" status 2>/dev/null || echo "")
@@ -348,257 +565,9 @@ init_semantic_search() {
     fi
 }
 
-# Run in background to not block container startup
-init_semantic_search &
-
-# ============================================================================
-# MCP Configuration Setup (inject secrets into template)
-# ============================================================================
-# 1Password vault ID (can be overridden via OP_VAULT_ID env var)
-VAULT_ID="${OP_VAULT_ID:-ypahjj334ixtiyjkytu5hij2im}"
-MCP_TPL="/etc/mcp/mcp.json.tpl"
-MCP_OUTPUT="/workspace/mcp.json"
-
-# Helper function to get 1Password field (tries multiple field names)
-# Usage: get_1password_field <item_name> <vault_id>
-get_1password_field() {
-    local item="$1"
-    local vault="$2"
-    local fields=("credential" "password" "identifiant" "mot de passe")
-
-    for field in "${fields[@]}"; do
-        local value
-        value=$(op item get "$item" --vault "$vault" --fields "$field" --reveal 2>/dev/null || echo "")
-        if [ -n "$value" ]; then
-            echo "$value"
-            return 0
-        fi
-    done
-    echo ""
-}
-
-# Initialize tokens from environment variables (fallback)
-CODACY_TOKEN="${CODACY_API_TOKEN:-}"
-GITHUB_TOKEN="${GITHUB_API_TOKEN:-}"
-
-# ============================================================================
-# 1Password CLI Config Directory Permissions Fix
-# ============================================================================
-# Docker named volumes create directories with root ownership.
-# 1Password CLI requires: ownership by current user + permissions 700.
-# See: https://github.com/kodflow/devcontainer-template/issues/86
-OP_CONFIG_DIRS=("$HOME/.config/op" "$HOME/.op")
-
-for OP_DIR in "${OP_CONFIG_DIRS[@]}"; do
-    if [ -d "$OP_DIR" ]; then
-        # Fix ownership if not current user
-        if [ "$(stat -c '%U' "$OP_DIR" 2>/dev/null)" != "$(whoami)" ]; then
-            log_info "Fixing ownership of $OP_DIR..."
-            sudo chown -R "$(whoami):$(whoami)" "$OP_DIR"
-        fi
-        # Ensure correct permissions (700 = owner only)
-        chmod 700 "$OP_DIR"
-    fi
-done
-log_success "1Password config directories configured"
-
-# ============================================================================
-# npm Cache Permissions Fix
-# ============================================================================
-# Docker named volumes create directories with root ownership.
-# npm requires write access to its cache for npx/MCP servers to work.
-# See: https://github.com/kodflow/devcontainer-template/issues/88
-NPM_CACHE_DIR="$HOME/.cache/npm"
-
-if [ -d "$NPM_CACHE_DIR" ]; then
-    # Fix ownership if not current user
-    if [ "$(stat -c '%U' "$NPM_CACHE_DIR" 2>/dev/null)" != "$(whoami)" ]; then
-        log_info "Fixing ownership of npm cache..."
-        sudo chown -R "$(whoami):$(whoami)" "$NPM_CACHE_DIR"
-    fi
-fi
-log_success "npm cache configured"
-
-# Try 1Password if OP_SERVICE_ACCOUNT_TOKEN is defined
-if [ -n "$OP_SERVICE_ACCOUNT_TOKEN" ] && command -v op &> /dev/null; then
-    log_info "Retrieving secrets from 1Password..."
-
-    OP_CODACY=$(get_1password_field "mcp-codacy" "$VAULT_ID")
-    OP_GITHUB=$(get_1password_field "mcp-github" "$VAULT_ID")
-
-    [ -n "$OP_CODACY" ] && CODACY_TOKEN="$OP_CODACY"
-    [ -n "$OP_GITHUB" ] && GITHUB_TOKEN="$OP_GITHUB"
-fi
-
-# Show status of tokens (INFO for optional, WARNING for essential)
-[ -z "$CODACY_TOKEN" ] && log_info "Codacy token not configured (optional)"
-[ -z "$GITHUB_TOKEN" ] && log_warning "GitHub token not available"
-
-# Helper: escape special chars for sed replacement
-# Handles: & \ | / and strips newlines/CR (covers all token formats)
-# LC_ALL=C ensures deterministic behavior across locales
-escape_for_sed() {
-    LC_ALL=C printf '%s' "$1" | tr -d '\n\r' | sed -e 's/[&/|\\]/\\&/g'
-}
-
-# Security: refuse to write secrets through symlinks or unsafe directories
-MCP_DIR=$(dirname -- "$MCP_OUTPUT")
-if [ ! -d "$MCP_DIR" ] || [ -L "$MCP_DIR" ]; then
-    log_error "Refusing to write mcp.json: unsafe parent directory ($MCP_DIR)"
-    # Skip all MCP generation but continue with rest of postStart
-elif [ -e "$MCP_OUTPUT" ] && { [ -L "$MCP_OUTPUT" ] || [ ! -f "$MCP_OUTPUT" ]; }; then
-    log_error "Refusing to write mcp.json: not a regular file ($MCP_OUTPUT)"
-    # Skip all MCP generation but continue with rest of postStart
-else
-
-# Migrate legacy .mcp.json to mcp.json (renamed in v2)
-if [ -f "/workspace/.mcp.json" ] && [ ! -e "$MCP_OUTPUT" ]; then
-    log_info "Migrating legacy .mcp.json to mcp.json..."
-
-    if ! command -v jq >/dev/null 2>&1; then
-        log_warning "jq not found; migrating without JSON validation"
-        if cp "/workspace/.mcp.json" "$MCP_OUTPUT"; then
-            chown "$(id -u):$(id -g)" "$MCP_OUTPUT" 2>/dev/null || true
-            chmod 600 "$MCP_OUTPUT"
-            rm -f "/workspace/.mcp.json" || log_warning "Could not remove legacy .mcp.json (permissions?)"
-            log_success "Migration complete: .mcp.json → mcp.json"
-        else
-            log_error "Migration failed: unable to copy legacy file"
-        fi
-    else
-        MCP_MIG_TMP=$(mktemp "${MCP_OUTPUT}.migrate.XXXXXX") || {
-            log_error "Migration failed: unable to create temp file"
-            MCP_MIG_TMP=""
-        }
-        if [ -n "$MCP_MIG_TMP" ] && cp "/workspace/.mcp.json" "$MCP_MIG_TMP"; then
-            # Validate JSON before completing migration
-            if jq empty "$MCP_MIG_TMP" 2>/dev/null; then
-                mv "$MCP_MIG_TMP" "$MCP_OUTPUT"
-                chown "$(id -u):$(id -g)" "$MCP_OUTPUT" 2>/dev/null || true
-                chmod 600 "$MCP_OUTPUT"
-                rm -f "/workspace/.mcp.json" || log_warning "Could not remove legacy .mcp.json (permissions?)"
-                log_success "Migration complete: .mcp.json → mcp.json"
-            else
-                log_error "Legacy .mcp.json is invalid JSON; keeping legacy file"
-                rm -f "$MCP_MIG_TMP"
-            fi
-        elif [ -n "$MCP_MIG_TMP" ]; then
-            log_error "Migration failed"
-            rm -f "$MCP_MIG_TMP"
-        fi
-    fi
-fi
-
-# Generate mcp.json from template (baked in Docker image)
-# ALWAYS regenerate from template to ensure latest MCP config is applied
-if [ -f "$MCP_TPL" ]; then
-    if [ -z "$CODACY_TOKEN" ] && [ -z "$GITHUB_TOKEN" ]; then
-        # No tokens available - create minimal config for optional MCPs (grepai, playwright, etc.)
-        log_warning "No tokens available, creating minimal mcp.json"
-        printf '%s\n' '{"mcpServers":{}}' > "$MCP_OUTPUT"
-        chown "$(id -u):$(id -g)" "$MCP_OUTPUT" 2>/dev/null || true
-        chmod 600 "$MCP_OUTPUT"
-        log_info "Created minimal mcp.json (optional MCPs will be added below)"
-    else
-        # Generate mcp.json from template (uses subshell to avoid global trap clobbering)
-        generate_mcp_from_template() {
-            local escaped_codacy escaped_github mcp_tmp
-            escaped_codacy=$(escape_for_sed "${CODACY_TOKEN}")
-            escaped_github=$(escape_for_sed "${GITHUB_TOKEN}")
-
-            mcp_tmp=$(mktemp "${MCP_OUTPUT}.tmp.XXXXXX") || {
-                log_error "Failed to create temp file for mcp.json generation"
-                return 0
-            }
-
-            # Cleanup on function exit (does not affect other traps)
-            trap 'rm -f "$mcp_tmp" 2>/dev/null || true' RETURN
-
-            if ! sed -e "s|{{CODACY_TOKEN}}|${escaped_codacy}|g" \
-                    -e "s|{{GITHUB_TOKEN}}|${escaped_github}|g" \
-                    "$MCP_TPL" > "$mcp_tmp"; then
-                log_error "Failed to render mcp.json template"
-                return 0
-            fi
-
-            if jq empty "$mcp_tmp" 2>/dev/null; then
-                mv "$mcp_tmp" "$MCP_OUTPUT"
-                chown "$(id -u):$(id -g)" "$MCP_OUTPUT" 2>/dev/null || true
-                chmod 600 "$MCP_OUTPUT"
-                log_success "mcp.json generated successfully"
-            else
-                log_error "Generated mcp.json is invalid JSON, keeping original"
-            fi
-        }
-        log_info "Regenerating mcp.json from template (forced)..."
-        generate_mcp_from_template
-    fi
-
-    # =========================================================================
-    # Add optional MCPs based on installed features
-    # =========================================================================
-    # Helper function to add a conditional MCP server (uses atomic temp file)
-    add_optional_mcp() {
-        local name="$1"
-        local binary="$2"
-        local output="$3"
-
-        # Nothing to do if there is no base config to modify
-        [ -f "$output" ] || return 0
-
-        # jq is required for JSON manipulation
-        if ! command -v jq >/dev/null 2>&1; then
-            log_warning "Skipping $name MCP injection (jq not found)"
-            return 0
-        fi
-
-        if [ -x "$binary" ]; then
-            log_info "Adding $name MCP (binary found at $binary)"
-            local tmp_file
-            tmp_file=$(mktemp "${output}.tmp.XXXXXX") || {
-                log_warning "Failed to add $name MCP (unable to create temp file)"
-                return 0
-            }
-            if jq --arg name "$name" --arg bin "$binary" \
-               '.mcpServers = (.mcpServers // {}) | .mcpServers[$name] = {"command": $bin, "args": [], "env": {}}' \
-               "$output" > "$tmp_file" && jq empty "$tmp_file" 2>/dev/null; then
-                mv "$tmp_file" "$output"
-                # Ensure correct ownership and secure permissions
-                chown "$(id -u):$(id -g)" "$output" 2>/dev/null || true
-                chmod 600 "$output" 2>/dev/null || true
-            else
-                log_warning "Failed to add $name MCP, keeping original"
-                rm -f "$tmp_file"
-            fi
-        else
-            log_info "Skipping $name MCP (binary not found)"
-        fi
-    }
-
-    # Rust: rust-analyzer-mcp (only if Rust feature is installed)
-    add_optional_mcp "rust-analyzer" "$HOME/.cache/cargo/bin/rust-analyzer-mcp" "$MCP_OUTPUT"
-
-    # Future conditional MCPs can be added here:
-    # add_optional_mcp "gopls" "$HOME/.cache/go/bin/gopls-mcp" "$MCP_OUTPUT"
-    # add_optional_mcp "pyright" "$HOME/.cache/pyenv/shims/pyright-mcp" "$MCP_OUTPUT"
-else
-    log_warning "MCP template not found at $MCP_TPL"
-fi
-
-fi  # End of symlink security check
-
 # ============================================================================
 # OpenVPN Auto-Connect (optional - skipped if no config found)
 # ============================================================================
-# Config source: OPENVPN_CONFIG_REF=op://VAULT/PROFILE
-#   - DOCUMENT "PROFILE" in vault → .ovpn file (op document get)
-#   - LOGIN "PROFILE" in vault → username/password (resolved via UUID to avoid ambiguity)
-#   - Fallback: file on disk at $OPENVPN_CONFIG
-#   - Nothing found → skip silently
-#
-# Convention: each VPN profile = 2 items with same title in the vault:
-#   "HOME" (DOCUMENT) + "HOME" (LOGIN)
-#   "OFFICE" (DOCUMENT) + "OFFICE" (LOGIN)
 init_openvpn() {
     local ovpn_config="${OPENVPN_CONFIG:-/home/vscode/.config/openvpn/client.ovpn}"
     local ovpn_auth="${OPENVPN_AUTH:-/tmp/vpn-auth.txt}"
@@ -621,7 +590,6 @@ init_openvpn() {
 
     # Source 1: Resolve from 1Password vault
     if [ -n "${OPENVPN_CONFIG_REF:-}" ] && [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ] && command -v op &> /dev/null; then
-        # Parse vault/profile from reference (strip op:// prefix if present)
         local ref="${OPENVPN_CONFIG_REF#op://}"
         local vault profile
         vault=$(echo "$ref" | cut -d'/' -f1)
@@ -630,15 +598,12 @@ init_openvpn() {
         log_info "Resolving VPN profile '$profile' from 1Password ($vault)..."
         mkdir -p "$ovpn_dir"
 
-        # Resolve UUIDs by category to avoid same-title ambiguity
-        # (same profile name exists as both DOCUMENT and LOGIN)
         local doc_uuid login_uuid
         doc_uuid=$(op item list --vault "$vault" --categories DOCUMENT --format json 2>/dev/null \
             | jq -r --arg t "$profile" '.[] | select(.title==$t) | .id' 2>/dev/null || echo "")
         login_uuid=$(op item list --vault "$vault" --categories LOGIN --format json 2>/dev/null \
             | jq -r --arg t "$profile" '.[] | select(.title==$t) | .id' 2>/dev/null || echo "")
 
-        # Get .ovpn file by UUID
         if [ -n "$doc_uuid" ] && op document get "$doc_uuid" --vault "$vault" > "$ovpn_config" 2>/dev/null; then
             chmod 600 "$ovpn_config"
             log_success "Resolved .ovpn config ($vault/$profile)"
@@ -669,13 +634,11 @@ init_openvpn() {
         return 0
     fi
 
-    # Validate
     if [ ! -s "$ovpn_config" ]; then
         log_warning "OpenVPN config is empty: $ovpn_config"
         return 0
     fi
 
-    # Build openvpn command with auto-reconnect options
     local -a vpn_args=(
         --config "$ovpn_config"
         --daemon ovpn-client
@@ -691,15 +654,12 @@ init_openvpn() {
         --resolv-retry infinite
     )
 
-    # Add auth-user-pass if credentials file exists
     if [ -f "$ovpn_auth" ] && [ -s "$ovpn_auth" ]; then
         vpn_args+=(--auth-user-pass "$ovpn_auth")
     fi
 
-    # Connect
     log_info "Starting OpenVPN..."
     if sudo openvpn "${vpn_args[@]}"; then
-        # Wait for tun0
         local attempt=0
         while [ $attempt -lt 15 ]; do
             if ip link show tun0 &>/dev/null; then
@@ -718,44 +678,28 @@ init_openvpn() {
     return 0
 }
 
+# ============================================================================
+# Execution
+# ============================================================================
+
+run_step "Restore Claude config"    step_restore_claude_config
+run_step "Init Claude dirs"         step_init_claude_dirs
+run_step "Shell env repair"         step_shell_env_repair
+run_step "Reload environment"       step_reload_env
+run_step "1Password permissions"    step_1password_permissions
+run_step "npm cache permissions"    step_npm_cache_permissions
+run_step "MCP configuration"        step_mcp_configuration
+run_step "Git credential cleanup"   step_git_credential_cleanup
+
+# Background tasks (have internal error handling, not tracked in summary)
+init_semantic_search &
 init_openvpn &
 
-# ============================================================================
-# Git Credential Cleanup (remove macOS-specific helpers)
-# ============================================================================
-log_info "Cleaning git credential helpers..."
-git config --global --unset-all credential.https://github.com.helper 2>/dev/null || true
-git config --global --unset-all credential.https://gist.github.com.helper 2>/dev/null || true
-log_success "Git credential helpers cleaned"
-
-# ============================================================================
 # Export dynamic environment variables (appended to ~/.devcontainer-env.sh)
-# ============================================================================
 # Note: ~/.devcontainer-env.sh is created by postCreate.sh with static content
-# We only append dynamic variables here (secrets from 1Password)
-DC_ENV="$HOME/.devcontainer-env.sh"
 
-# ============================================================================
-# Auto-run /init for project initialization check
-# ============================================================================
-# Runs at every container start to verify project is properly initialized
-# (compares CLAUDE.md and README.md footprints with template)
-# Skipped in CI environment
+run_step "Project init check"       step_auto_init_check
 
-INIT_LOG="$HOME/.devcontainer-init.log"
+print_step_summary "postStart"
 
-if command -v claude &> /dev/null && [ -z "${CI:-}" ]; then
-    log_info "Running project initialization check..."
-    # Run /init in background to not block container startup
-    # Logs persisted to $HOME for debugging (survives container restarts)
-    nohup bash -c "sleep 2 && claude \"/init\" || echo \"[\$(date -Iseconds)] Init check failed with exit code \$?\" >> \"$INIT_LOG\"" >> "$INIT_LOG" 2>&1 &
-    log_success "Init check scheduled (logs: ~/.devcontainer-init.log)"
-elif [ -n "${CI:-}" ]; then
-    log_info "CI environment detected, skipping init"
-fi
-
-# ============================================================================
-# Final message
-# ============================================================================
-echo ""
 log_success "postStart: Container ready!"


### PR DESCRIPTION
### **User description**
## Summary

- **Root cause fix**: `set -euo pipefail` in `postCreate.sh` kills the script when `git config --global user.email` returns exit 1 (unconfigured). This prevents `~/.devcontainer-env.sh` (containing `super-claude`) from ever being created. The `|| true` at devcontainer.json level silently swallows the crash.

- **Solution**: Replace `set -euo pipefail` / `set -e` with `set -u` only. Decompose monolithic scripts into small step functions, each executed via a new `run_step` utility that runs the function in an isolated subshell (`set +e +o pipefail`), captures exit code without killing the parent, and tracks PASS/FAIL per step with a summary table.

## Changes

| File | Change |
|------|--------|
| `utils.sh` | Add `init_steps`, `run_step`, `print_step_summary`, `step_ok` + exports |
| `postCreate.sh` | 5 isolated steps (git safe dir, SSL, GPG, env script, mark init) |
| `postStart.sh` | 8 isolated steps (Claude config, dirs, env, 1Password, npm, MCP, git creds, init check) |
| `postAttach.sh` | Verify `super-claude` availability before showing tip |

## Test plan

- [ ] Run `rm -f ~/.devcontainer-initialized ~/.devcontainer-env.sh && bash postCreate.sh` — all 5 steps PASS, summary table displayed
- [ ] Run `bash postCreate.sh` again — "already initialized" early exit
- [ ] Run `source ~/.devcontainer-env.sh && type super-claude` — function available
- [ ] Run `bash postAttach.sh` — shows tip when env file present
- [ ] Remove env file, run `postAttach.sh` — shows warning instead of tip
- [ ] Simulate GPG failure (no keys) — step shows FAIL but script completes


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replace `set -euo pipefail` with `set -u` to prevent script termination on command failures

- Introduce `run_step` pattern: isolated subshells capture failures without killing parent process

- Decompose monolithic scripts into small step functions with PASS/FAIL tracking and summary table

- Fix root cause: unconfigured git email no longer prevents `~/.devcontainer-env.sh` creation

- Add verification in `postAttach.sh` to check `super-claude` availability before advertising it


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["set -euo pipefail<br/>Monolithic scripts"] -->|Replace with| B["set -u<br/>Step functions"]
  B -->|Execute via| C["run_step utility<br/>Isolated subshells"]
  C -->|Track results| D["Step summary table<br/>PASS/FAIL per step"]
  E["Git config failure<br/>Kills script"] -->|Fixed by| C
  F["~/.devcontainer-env.sh<br/>Never created"] -->|Now created| D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.sh</strong><dd><code>Add step tracking and non-blocking execution utilities</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/hooks/shared/utils.sh

<ul><li>Add <code>init_steps()</code> to reset step tracking arrays at script start<br> <li> Add <code>run_step()</code> to execute functions in isolated subshells with <code>set +e </code><br><code>+o pipefail</code><br> <li> Add <code>print_step_summary()</code> to display PASS/FAIL table with color coding<br> <li> Add <code>step_ok()</code> to check if a named step succeeded<br> <li> Export all four new functions for use in subscripts</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/175/files#diff-ae222d4bae14a6fc6aba412ccb856536fcbd775d7ed56384b830c7edd5dd3a2c">+90/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>postStart.sh</strong><dd><code>Refactor into isolated steps with error isolation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/hooks/lifecycle/postStart.sh

<ul><li>Replace <code>set -e</code> with <code>set -u</code> to prevent early termination on command <br>failures<br> <li> Decompose into 8 step functions: <code>step_restore_claude_config</code>, <br><code>step_init_claude_dirs</code>, <code>step_reload_env</code>, <code>step_1password_permissions</code>, <br><code>step_npm_cache_permissions</code>, <code>step_mcp_configuration</code>, <br><code>step_git_credential_cleanup</code>, <code>step_auto_init_check</code><br> <li> Use <code>run_step</code> to execute each function in isolated subshell with error <br>isolation<br> <li> Move semantic search to background execution (not tracked in summary)<br> <li> Add <code>print_step_summary</code> to display results table at end<br> <li> Always exit with code 0 to ensure container lifecycle completes</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/175/files#diff-3448f74d4d6a9288781932549c4bd1cffc2385474948e9476862a60bec7a7c4c">+300/-282</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>postAttach.sh</strong><dd><code>Add super-claude availability verification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/hooks/lifecycle/postAttach.sh

<ul><li>Replace <code>set -e</code> with <code>set -u</code> for consistency<br> <li> Add verification check: only advertise <code>super-claude</code> if <br><code>~/.devcontainer-env.sh</code> exists and contains the function<br> <li> Display warning with recovery instructions if environment setup failed<br> <li> Gracefully handle missing environment file without killing script</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/175/files#diff-b796c68998ca3f85a0d5ef4a02665a19670674a9a682bf064110176bbbd3858c">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>postCreate.sh</strong><dd><code>Decompose into isolated steps with non-blocking execution</code></dd></summary>
<hr>

.devcontainer/hooks/lifecycle/postCreate.sh

<ul><li>Replace <code>set -euo pipefail</code> with <code>set -u</code> to prevent early termination<br> <li> Decompose into 5 step functions: <code>step_git_safe_directory</code>, <br><code>step_git_ssl_config</code>, <code>step_gpg_signing</code>, <code>step_create_env_script</code>, <br><code>step_mark_initialized</code><br> <li> Use <code>run_step</code> to execute each function in isolated subshell, capturing <br>failures without killing parent<br> <li> Move early-exit check for already-initialized container after git <br>steps (which always run)<br> <li> Add <code>print_step_summary</code> to display results table at end<br> <li> Always exit with code 0 to ensure container starts successfully</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/175/files#diff-62a8741135c5cb293b9b20e37138b78288815b2ec86e892ed65cebf3638df53f">+74/-52</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

