### PR TITLE
fix(git,docs): enforce staging of all tracked files in /git skill

### DIFF
--- a/.devcontainer/hooks/CLAUDE.md
+++ b/.devcontainer/hooks/CLAUDE.md
@@ -31,5 +31,7 @@ hooks/
 ## Conventions
 
 - Scripts must be executable (chmod +x)
-- Use bash strict mode (set -euo pipefail)
-- Log to stderr, results to stdout
+- Use `set -u` (not `set -euo pipefail`) — prevents undefined vars without killing script on errors
+- Use `run_step` pattern from `shared/utils.sh` to isolate each operation
+- Each step runs in a subshell; failures are logged but never block container startup
+- Call `print_step_summary` at end for PASS/FAIL report

--- a/.devcontainer/hooks/lifecycle/CLAUDE.md
+++ b/.devcontainer/hooks/lifecycle/CLAUDE.md
@@ -26,6 +26,8 @@ DevContainer lifecycle scripts executed at specific container events.
 ## Conventions
 
 - All scripts must be executable (`chmod +x`)
-- Use bash strict mode: `set -euo pipefail`
+- Use `set -u` (not `set -euo pipefail`) to prevent undefined variable use without killing the script on errors
 - Source `../shared/utils.sh` for common functions
-- Exit 0 on success, non-zero on failure
+- Use `run_step "name" function` pattern to isolate each operation in a subshell
+- Each step tracks PASS/FAIL independently; script always exits 0
+- Call `print_step_summary "label"` at the end to display results


### PR DESCRIPTION
### **User description**
## Summary

- Fix `/git --commit` silently skipping tracked CLAUDE.md files during staging
- Add post-staging verification step (`git diff --name-only` must be empty)
- Add gitignore awareness documentation in Decompose phase
- Update hooks CLAUDE.md to reflect `run_step` convention from PR #175

## Changes

### `/git` skill (`git.md`)
- **Phase 1 (Peek)**: Add critical rule to list ALL tracked modifications, not just task files
- **Phase 2 (Decompose)**: Add `CLAUDE.md`, `.claude/commands/`, hooks to file categories + gitignore awareness section
- **Phase 4 (Execute)**: Replace vague `git add -A` with explicit steps + verification + rules

### CLAUDE.md documentation
- Update hooks conventions: `set -u` + `run_step` pattern (was `set -euo pipefail`)

## Root cause

The `/git` skill specified `git add -A` but as a simple YAML instruction. The LLM implementing it would cherry-pick files selectively, missing collateral changes like CLAUDE.md updates. The fix makes the staging verification explicit and mandatory.

## Test plan

- [ ] Run `/git --commit` and verify ALL tracked files appear in Peek output
- [ ] Verify `git diff --name-only` is empty after staging
- [ ] Verify gitignored files (.env, mcp.json) are NOT staged


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fix `/git` skill to enforce staging of all tracked files, preventing CLAUDE.md and other tracked files from being silently skipped

- Add post-staging verification step using `git diff --name-only` to ensure completeness

- Add gitignore awareness documentation explaining how `git add -A` respects `.gitignore` automatically

- Update hooks CLAUDE.md conventions to use `set -u` with `run_step` pattern instead of strict mode


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["git.md skill"] -->|"Add critical rule"| B["List ALL tracked modifications"]
  A -->|"Add verification step"| C["git diff --name-only check"]
  A -->|"Expand file categories"| D["Include CLAUDE.md, hooks, .claude/"]
  A -->|"Add gitignore awareness"| E["Document auto-exclusion behavior"]
  F["hooks CLAUDE.md"] -->|"Update conventions"| G["set -u + run_step pattern"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Update bash conventions to use run_step pattern</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/hooks/CLAUDE.md

<ul><li>Replace <code>set -euo pipefail</code> with <code>set -u</code> to prevent script termination on <br>errors while preventing undefined variables<br> <li> Add <code>run_step</code> pattern from <code>shared/utils.sh</code> for isolating operations in <br>subshells<br> <li> Add <code>print_step_summary</code> call for PASS/FAIL reporting<br> <li> Clarify that step failures are logged but never block container <br>startup</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/176/files#diff-18fd41a69bfb144427f5979826053396f922721ba19d3e5c2882872348408adb">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Update lifecycle hooks conventions and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/hooks/lifecycle/CLAUDE.md

<ul><li>Replace <code>set -euo pipefail</code> with <code>set -u</code> for safer error handling<br> <li> Add <code>run_step</code> pattern documentation for isolating operations<br> <li> Change exit behavior to always exit 0 with independent PASS/FAIL <br>tracking per step<br> <li> Add <code>print_step_summary</code> call for displaying results</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/176/files#diff-252bdf3769dff7e129b0c2f657299579572144cbb2585c90652cdf6fbb1acea5">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>git.md</strong><dd><code>Add gitignore awareness and staging verification to git skill</code></dd></summary>
<hr>

.devcontainer/images/.claude/commands/git.md

<ul><li>Add critical rule in Peek phase to list ALL tracked modifications <br>including CLAUDE.md, .devcontainer/, and .claude/commands/<br> <li> Expand file pattern categories to include additional languages (Go, <br>Rust, Python) and hook scripts<br> <li> Add new <code>hooks</code> category for <code>.devcontainer/hooks/</code>, <code>.claude/scripts/</code>, and <br><code>.githooks/</code> files<br> <li> Add <code>gitignore_awareness</code> section explaining how <code>git status --porcelain</code> <br>shows all tracked changes and gitignored files are automatically <br>excluded<br> <li> Replace simple <code>git add -A</code> command with multi-step verification <br>including <code>git diff --name-only</code> check to ensure no tracked files are <br>left unstaged<br> <li> Add detailed rules and failure handling for the staging step</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/176/files#diff-3a86f72360cde707f9605e3d9d6fc9dc090ca09a833897c260e6a1590b7ba396">+42/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

