### PR TITLE
fix(hooks): prevent mcp_tmp unbound variable in postStart RETURN trap

### DIFF
--- a/.devcontainer/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/hooks/lifecycle/postStart.sh
@@ -315,7 +315,7 @@ step_mcp_configuration() {
                     return 0
                 }
 
-                trap 'rm -f "$mcp_tmp" 2>/dev/null || true' RETURN
+                trap 'rm -f "${mcp_tmp:-}" 2>/dev/null || true' RETURN
 
                 if ! sed -e "s|{{CODACY_TOKEN}}|${escaped_codacy}|g" \
                         -e "s|{{GITHUB_TOKEN}}|${escaped_github}|g" \


### PR DESCRIPTION
### **User description**
## Summary\n\n- Fix `mcp_tmp: unbound variable` error in postStart MCP configuration step\n- The `trap ... RETURN` set inside `generate_mcp_from_template()` leaks to the parent function `step_mcp_configuration()`\n- When the parent returns, the trap fires again but `mcp_tmp` is out of scope, causing `set -u` to abort\n- Using `${mcp_tmp:-}` safely defaults to empty string in the leaked trap context\n\n## Root Cause\n\nLine 318 of `postStart.sh`:\n```bash\ntrap 'rm -f \"$mcp_tmp\" 2>/dev/null || true' RETURN\n```\n\nThe RETURN trap fires correctly when `generate_mcp_from_template()` returns (mcp_tmp in scope), but **also fires again** when the parent `step_mcp_configuration()` returns, at which point `mcp_tmp` is no longer defined.\n\n## Test plan\n\n- [ ] Rebuild devcontainer and verify postStart completes with 9/9 PASS\n- [ ] Verify MCP configuration step no longer shows FAIL\n- [ ] Verify mcp.json is correctly generated


___

### **PR Type**
Bug fix


___

### **Description**
- Fix unbound variable error in postStart RETURN trap

- Use parameter expansion to safely handle mcp_tmp scope leak

- Prevent set -u abort when parent function returns


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["generate_mcp_from_template()"] -->|"sets RETURN trap"| B["trap fires on function return"]
  B -->|"mcp_tmp in scope"| C["cleanup succeeds"]
  B -->|"mcp_tmp out of scope"| D["unbound variable error"]
  E["Fix: use \${mcp_tmp:-}"] -->|"defaults to empty"| F["trap executes safely"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>postStart.sh</strong><dd><code>Use parameter expansion in cleanup trap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/hooks/lifecycle/postStart.sh

<ul><li>Changed trap command to use parameter expansion <code>${mcp_tmp:-}</code> instead <br>of <code>$mcp_tmp</code><br> <li> Prevents unbound variable error when RETURN trap fires in parent <br>function scope<br> <li> Safely defaults to empty string when mcp_tmp is not defined</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/177/files#diff-3448f74d4d6a9288781932549c4bd1cffc2385474948e9476862a60bec7a7c4c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

