### PR TITLE
fix(docs): resolve ~/.claude/docs/ path references in skills and agents

### DIFF
--- a/.devcontainer/images/.claude/agents/developer-executor-correctness.md
+++ b/.devcontainer/images/.claude/agents/developer-executor-correctness.md
@@ -226,7 +226,7 @@ idempotence:
 ```yaml
 documentation:
   1_local_first:
-    path: ".claude/docs/"
+    path: "~/.claude/docs/"
     usage: "Design patterns, language idioms"
 
   2_remote:

--- a/.devcontainer/images/.claude/agents/developer-executor-design.md
+++ b/.devcontainer/images/.claude/agents/developer-executor-design.md
@@ -2,7 +2,7 @@
 name: developer-executor-design
 description: |
   Design pattern and architecture analyzer. Detects antipatterns, DDD violations,
-  layering issues, and SOLID principle violations. Consults .claude/docs/ for patterns
+  layering issues, and SOLID principle violations. Consults ~/.claude/docs/ for patterns
   and cross-references with official documentation.
   Returns condensed JSON with pattern references and fix recommendations.
 tools:
@@ -39,8 +39,8 @@ Architectural and design pattern analysis. Detect **antipatterns**, **DDD violat
 ```yaml
 documentation:
   1_local_first:
-    path: ".claude/docs/"
-    index: ".claude/docs/README.md"
+    path: "~/.claude/docs/"
+    index: "~/.claude/docs/README.md"
     categories:
       - "gof/" (Gang of Four)
       - "enterprise/" (Martin Fowler PoEAA)
@@ -60,7 +60,7 @@ documentation:
   3_cross_reference:
     workflow:
       1: "Identify pattern in code"
-      2: "Check .claude/docs/ for canonical implementation"
+      2: "Check ~/.claude/docs/ for canonical implementation"
       3: "Query Context7 for framework-specific guidance"
       4: "Compare with official documentation"
       5: "Report with references to both sources"
@@ -243,7 +243,7 @@ solid:
       "title": "Domain imports infrastructure",
       "evidence": "import \"github.com/project/infrastructure/db\"",
 
-      "pattern_reference": ".claude/docs/ddd/layered-architecture.md",
+      "pattern_reference": "~/.claude/docs/ddd/layered-architecture.md",
       "official_reference": "https://herbertograca.com/2017/11/16/explicit-architecture-01-ddd-hexagonal-onion-clean-cqrs-how-i-put-it-all-together/",
 
       "recommendation": "Inject repository interface, implement in infrastructure",

--- a/.devcontainer/images/.claude/agents/developer-executor-quality.md
+++ b/.devcontainer/images/.claude/agents/developer-executor-quality.md
@@ -184,4 +184,4 @@ dto_check:
     DTOs correctly use dto:"dir,ctx,sec" format with appropriate security classification
 ```
 
-**Reference:** `.claude/docs/conventions/dto-tags.md`
+**Reference:** `~/.claude/docs/conventions/dto-tags.md`

--- a/.devcontainer/images/.claude/agents/developer-executor-security.md
+++ b/.devcontainer/images/.claude/agents/developer-executor-security.md
@@ -247,7 +247,7 @@ codacy_integration:
 ```yaml
 documentation:
   1_local_first:
-    path: ".claude/docs/security/"
+    path: "~/.claude/docs/security/"
     usage: "Security patterns, OWASP guidelines"
 
   2_remote:

--- a/.devcontainer/images/.claude/agents/developer-specialist-go.md
+++ b/.devcontainer/images/.claude/agents/developer-specialist-go.md
@@ -379,7 +379,7 @@ SECURITY:  pub (public) | priv (IDs) | pii (RGPD) | secret (password)
 | KTN-STRUCT-CTOR | Exempte les DTOs (pas de constructeur) |
 | KTN-DTO-TAG | Valide format `dto:"dir,ctx,sec"` |
 
-**Reference:** `.claude/docs/conventions/dto-tags.md`
+**Reference:** `~/.claude/docs/conventions/dto-tags.md`
 
 ## Forbidden (ABSOLUTE)
 

--- a/.devcontainer/images/.claude/agents/developer-specialist-review.md
+++ b/.devcontainer/images/.claude/agents/developer-specialist-review.md
@@ -172,7 +172,7 @@ parallel_dispatch:
 
       Repo profile: {repo_profile}
       Diff context: {diff_snippet}
-      Consult: .claude/docs/ for patterns
+      Consult: ~/.claude/docs/ for patterns
 
       Check: antipatterns, DDD, layering, SOLID
 

--- a/.devcontainer/images/.claude/agents/docs-analyzer-patterns.md
+++ b/.devcontainer/images/.claude/agents/docs-analyzer-patterns.md
@@ -2,7 +2,7 @@
 name: docs-analyzer-patterns
 description: |
   Docs analyzer: Design patterns knowledge base inventory.
-  Analyzes .claude/docs/ for pattern categories, counts, and templates.
+  Analyzes ~/.claude/docs/ for pattern categories, counts, and templates.
   Returns condensed JSON to /tmp/docs-analysis/patterns.json.
 tools:
   - Read

--- a/.devcontainer/images/.claude/commands/improve.md
+++ b/.devcontainer/images/.claude/commands/improve.md
@@ -21,9 +21,9 @@ Amélioration continue automatique. Détecte le contexte et agit.
 │  kodflow/devcontainer-template│  Autre projet                       │
 │  ══════════════════════════════│══════════════════════════════════  │
 │                               │                                      │
-│  → Améliorer .claude/docs/    │  → Analyser le code                 │
+│  → Améliorer ~/.claude/docs/    │  → Analyser le code                 │
 │    ├─ MAJ best practices      │    ├─ Détecter anti-patterns        │
-│    ├─ Corriger incohérences   │    ├─ Comparer avec .claude/docs/   │
+│    ├─ Corriger incohérences   │    ├─ Comparer avec ~/.claude/docs/   │
 │    ├─ Affiner exemples        │    ├─ Trouver bonnes pratiques      │
 │    └─ WebSearch validations   │    └─ Créer issues sur template     │
 │                               │                                      │
@@ -44,7 +44,7 @@ detection:
   rules:
     - if: "contains 'kodflow/devcontainer-template'"
       mode: "DOCS_IMPROVEMENT"
-      scope: ".claude/docs/**/*.md"
+      scope: "~/.claude/docs/**/*.md"
       action: "Améliorer la documentation patterns"
 
     - else:
@@ -61,7 +61,7 @@ detection:
 ```yaml
 inventory:
   mode_docs:
-    action: Glob(".claude/docs/**/*.md")
+    action: Glob("~/.claude/docs/**/*.md")
     group_by: category (principles, creational, behavioral, etc.)
 
   mode_antipattern:
@@ -111,7 +111,7 @@ parallel_execution:
   mode_antipattern:
     prompt_per_file: |
       FICHIER: {path}
-      RÉFÉRENCE: .claude/docs/
+      RÉFÉRENCE: ~/.claude/docs/
 
       TÂCHES:
       1. Lire le code
@@ -238,7 +238,7 @@ report:
 
 ---
 
-## Catégories patterns (.claude/docs/)
+## Catégories patterns (~/.claude/docs/)
 
 | Catégorie | Scope |
 |-----------|-------|

--- a/.devcontainer/images/.claude/commands/plan.md
+++ b/.devcontainer/images/.claude/commands/plan.md
@@ -204,7 +204,7 @@ parallel_exploration:
     - task: "patterns-consultant"
       type: "Explore"
       prompt: |
-        Consult .claude/docs/ for: {description}
+        Consult ~/.claude/docs/ for: {description}
         Find: applicable design patterns
         Return: {patterns[], references[]}
 ```
@@ -215,7 +215,7 @@ parallel_exploration:
 
 ## Phase 3.5 : Pattern Consultation (OBLIGATOIRE)
 
-**Consulter `.claude/docs/` pour les patterns :**
+**Consulter `~/.claude/docs/` pour les patterns :**
 
 ```yaml
 pattern_consultation:
@@ -229,7 +229,7 @@ pattern_consultation:
       - "Sécurité?" → security/README.md
 
   2_read_patterns:
-    action: "Read(.claude/docs/<category>/README.md)"
+    action: "Read(~/.claude/docs/<category>/README.md)"
     output: "2-3 patterns applicables"
 
   3_integrate:
@@ -249,9 +249,9 @@ pattern_consultation:
     ✓ Middleware (Enterprise) - Pour auth chain
 
   Références consultées:
-    → .claude/docs/ddd/README.md
-    → .claude/docs/creational/README.md
-    → .claude/docs/enterprise/README.md
+    → ~/.claude/docs/ddd/README.md
+    → ~/.claude/docs/creational/README.md
+    → ~/.claude/docs/enterprise/README.md
 
 ═══════════════════════════════════════════════════════════════
 ```
@@ -286,8 +286,8 @@ synthesize_workflow:
 
 | Pattern | Category | Justification | Reference |
 |---------|----------|---------------|-----------|
-| Repository | DDD | Data access abstraction | .claude/docs/ddd/README.md |
-| Factory | Creational | Token creation | .claude/docs/creational/README.md |
+| Repository | DDD | Data access abstraction | ~/.claude/docs/ddd/README.md |
+| Factory | Creational | Token creation | ~/.claude/docs/creational/README.md |
 
 ## Prerequisites
 - [ ] <Dépendance ou setup requis>
@@ -413,7 +413,7 @@ dto_reminder:
         Email string `dto:"in,api,pii" json:"email"`
     }
     ```
-    Ref: `.claude/docs/conventions/dto-tags.md`
+    Ref: `~/.claude/docs/conventions/dto-tags.md`
 ```
 
 ---

--- a/.devcontainer/images/.claude/commands/review.md
+++ b/.devcontainer/images/.claude/commands/review.md
@@ -275,7 +275,7 @@ repo_profile:
       - ".eslintrc*"
       - "pyproject.toml"
       - "CODEOWNERS"
-      - ".claude/docs/**"
+      - "~/.claude/docs/**"
 
   extract:
     languages: [string]
@@ -1246,14 +1246,14 @@ CI: {status}
 
 ## Pattern Consultation (CONDITIONNELLE)
 
-**Source :** `.claude/docs/` (Design Patterns Knowledge Base)
+**Source :** `~/.claude/docs/` (Design Patterns Knowledge Base)
 
 **Déclencher UNIQUEMENT si :**
 
 ```yaml
 pattern_triggers:
-  source: ".claude/docs/"
-  index: ".claude/docs/README.md"
+  source: "~/.claude/docs/"
+  index: "~/.claude/docs/README.md"
 
   conditions:
     - "complexity_increase > 20%"
@@ -1268,8 +1268,8 @@ pattern_triggers:
     - "mode == TRIAGE"
 
   workflow:
-    1_identify: "Lire .claude/docs/README.md pour identifier catégorie"
-    2_consult: "Read(.claude/docs/<category>/README.md)"
+    1_identify: "Lire ~/.claude/docs/README.md pour identifier catégorie"
+    2_consult: "Read(~/.claude/docs/<category>/README.md)"
     3_analyze: "Vérifier patterns utilisés vs recommandés"
     4_report: "Inclure dans section 'Pattern Analysis'"
 
@@ -1366,7 +1366,7 @@ dto_validation:
     | user_dto.go | CreateUserRequest | ✓ | - |
     | order.go | OrderResponse | ✗ | Missing dto:"..." tags |
 
-  reference: ".claude/docs/conventions/dto-tags.md"
+  reference: "~/.claude/docs/conventions/dto-tags.md"
 ```
 
 ---

--- a/.devcontainer/images/.claude/commands/search.md
+++ b/.devcontainer/images/.claude/commands/search.md
@@ -2,7 +2,7 @@
 name: search
 description: |
   Documentation Research with RLM (Recursive Language Model) patterns.
-  LOCAL-FIRST: Searches internal docs (.claude/docs/) before external sources.
+  LOCAL-FIRST: Searches internal docs (~/.claude/docs/) before external sources.
   Cross-validates sources, generates .context.md, handles conflicts.
   Use when: researching technologies, APIs, or best practices before implementation.
 allowed-tools:
@@ -38,7 +38,7 @@ Recherche avec stratégie **LOCAL-FIRST** et patterns RLM.
 ### Priorité : Documentation locale validée
 
 ```
-.claude/docs/ (LOCAL)  →  Sources officielles (EXTERNE)
+~/.claude/docs/ (LOCAL)  →  Sources officielles (EXTERNE)
      ✓ Validée              ⚠ Peut être obsolète
      ✓ Cohérente            ⚠ Peut contredire local
      ✓ Immédiate            ⚠ Nécessite validation
@@ -46,7 +46,7 @@ Recherche avec stratégie **LOCAL-FIRST** et patterns RLM.
 
 **Patterns RLM appliqués :**
 
-- **Local-First** - Consultation `.claude/docs/` en priorité
+- **Local-First** - Consultation `~/.claude/docs/` en priorité
 - **Peek** - Aperçu rapide avant analyse complète
 - **Grep** - Filtrage par keywords avant fetch sémantique
 - **Partition+Map** - Recherches parallèles multi-domaines
@@ -163,14 +163,14 @@ Workflow:
 
 ```yaml
 local_first:
-  source: ".claude/docs/"
-  index: ".claude/docs/README.md"
+  source: "~/.claude/docs/"
+  index: "~/.claude/docs/README.md"
 
   workflow:
     1_search_local:
       action: |
-        Grep(".claude/docs/", pattern=<keywords>)
-        Glob(".claude/docs/**/*.md", pattern=<topic>)
+        Grep("~/.claude/docs/", pattern=<keywords>)
+        Glob("~/.claude/docs/**/*.md", pattern=<topic>)
       output: [matching_files]
 
     2_read_matches:
@@ -219,7 +219,7 @@ local_first:
   Query    : <query>
   Keywords : <k1>, <k2>, <k3>
 
-  Local Search (.claude/docs/):
+  Local Search (~/.claude/docs/):
     ├─ Matches: 3 files
     │   ├─ behavioral/observer.md (95% match)
     │   ├─ behavioral/README.md (70% match)
@@ -243,7 +243,7 @@ local_first:
   Query    : "OAuth2 JWT authentication"
   Keywords : OAuth2, JWT, authentication
 
-  Local Search (.claude/docs/):
+  Local Search (~/.claude/docs/):
     ├─ Matches: 1 file
     │   └─ security/README.md (50% match)
     │
@@ -409,7 +409,7 @@ conflict_resolution:
 
       **Sujet:** {topic}
 
-      **Documentation locale (.claude/docs/):**
+      **Documentation locale (~/.claude/docs/):**
       {local_content}
 
       **Documentation externe ({source}):**
@@ -443,7 +443,7 @@ conflict_resolution:
         **Date:** {ISO8601}
 
         ### Local Documentation
-        **File:** `.claude/docs/{path}`
+        **File:** `~/.claude/docs/{path}`
         **Content:**
         ```
         {local_excerpt}
@@ -491,7 +491,7 @@ conflict_resolution:
 
   Topic: Observer Pattern implementation
 
-  Local (.claude/docs/behavioral/observer.md):
+  Local (~/.claude/docs/behavioral/observer.md):
     → Uses EventEmitter interface
     → Recommends typed events
 
@@ -519,7 +519,7 @@ conflict_resolution:
 
   Topic: JWT expiration handling
 
-  Local (.claude/docs/security/jwt.md):
+  Local (~/.claude/docs/security/jwt.md):
     → Recommends 15min access token
 
   External (tools.ietf.org/html/rfc7519):
@@ -665,7 +665,7 @@ local_first_rule:
   reason: "Documentation locale est validée et cohérente"
 
   workflow:
-    1: "TOUJOURS chercher dans .claude/docs/ d'abord"
+    1: "TOUJOURS chercher dans ~/.claude/docs/ d'abord"
     2: "SI local suffisant → utiliser local uniquement"
     3: "SI conflit → demander à l'utilisateur"
     4: "SI mise à jour nécessaire → créer issue GitHub"

--- a/.devcontainer/images/.claude/commands/warmup.md
+++ b/.devcontainer/images/.claude/commands/warmup.md
@@ -258,7 +258,7 @@ parallel_analysis:
 
     - task: "docs-analyzer"
       type: "Explore"
-      scope: ".claude/docs/"
+      scope: "~/.claude/docs/"
       prompt: |
         Analyser la base de connaissances:
         - Catégories de patterns disponibles
@@ -826,6 +826,6 @@ grepai_config_update:
 | Progressive Disclosure | DevOps | Détail croissant par profondeur |
 
 **Références :**
-- `.claude/docs/cloud/cache-aside.md`
-- `.claude/docs/performance/lazy-load.md`
-- `.claude/docs/devops/feature-toggles.md`
+- `~/.claude/docs/cloud/cache-aside.md`
+- `~/.claude/docs/performance/lazy-load.md`
+- `~/.claude/docs/devops/feature-toggles.md`


### PR DESCRIPTION
### **User description**
## Summary

- Skills and agents referenced `.claude/docs/` as a relative path, which resolved to `/workspace/.claude/docs/` (nonexistent at runtime)
- The actual runtime location is `~/.claude/docs/` (`/home/vscode/.claude/docs/`), restored by `postStart.sh` from `/etc/claude-defaults/docs/`
- Updated 66 occurrences across 13 files (6 commands, 7 agents) to use the absolute `~/.claude/docs/` path

## Changed Files

**Commands (6):** `search.md`, `docs.md`, `plan.md`, `review.md`, `improve.md`, `warmup.md`
**Agents (7):** `developer-executor-design.md`, `developer-executor-correctness.md`, `developer-executor-security.md`, `developer-executor-quality.md`, `developer-specialist-go.md`, `developer-specialist-review.md`, `docs-analyzer-patterns.md`

## Root Cause

The design patterns knowledge base (250+ patterns) is baked into the Docker image at build time and restored to `~/.claude/docs/` at each container start via `postStart.sh`. Skills and agents used `.claude/docs/` which Claude Code resolved relative to the workspace (`/workspace/.claude/docs/`), causing file-not-found errors during `/search` and `/review` execution.

## Test Plan

- [ ] Verify `~/.claude/docs/` exists at runtime (should contain 250+ .md files)
- [ ] Verify `/workspace/.claude/docs/` does NOT exist
- [ ] Run `/search` with a design pattern query — should find local docs
- [ ] Grep for orphan `.claude/docs/` references (should be 0, only `~/.claude/docs/` and `images/.claude/docs/`)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed path resolution for design patterns knowledge base
  - Changed 66 references from relative `.claude/docs/` to absolute `~/.claude/docs/`
  - Resolves file-not-found errors during `/search` and `/review` execution

- Updated 13 files across commands and agents
  - 6 command files: search, docs, plan, review, improve, warmup
  - 7 agent files: developer-executor (design, correctness, security, quality), developer-specialist (go, review), docs-analyzer-patterns


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Relative Path<br/>.claude/docs/"] -->|"Resolves to<br/>/workspace/.claude/docs/<br/>(nonexistent)"| B["❌ File Not Found<br/>at Runtime"]
  C["Absolute Path<br/>~/.claude/docs/"] -->|"Resolves to<br/>/home/vscode/.claude/docs/<br/>(restored by postStart.sh)"| D["✓ Correct Location<br/>at Runtime"]
  B -->|"This PR fixes"| D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td><strong>developer-executor-correctness.md</strong><dd><code>Updated documentation path to absolute reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/182/files#diff-3fba1e953246786c3304b675598f13615c946638572551eb0142b7e1ceba6945">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>developer-executor-design.md</strong><dd><code>Fixed 4 path references in agent description and workflows</code></dd></td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/182/files#diff-5b242e5f316eccdea253ea046331a05c872cda96f1d4d8c860c82cd0e1c3c635">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>developer-executor-quality.md</strong><dd><code>Updated DTO validation reference path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/182/files#diff-fb81fcf1067b49d1d8288e531d0490e930de9816e813d9225ae72b27612d65ee">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>developer-executor-security.md</strong><dd><code>Fixed security documentation path reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/182/files#diff-b312876e749c648bd90f075415c9311a4f27a27e656f4e1fb1a7661982c099f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>developer-specialist-go.md</strong><dd><code>Updated DTO conventions reference path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/182/files#diff-78f60dac8005ba221190ddf7a057a2882e795d0df13ba354775ec91e3648ec10">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>developer-specialist-review.md</strong><dd><code>Fixed pattern consultation path reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/182/files#diff-fab03bac807252115b0202f54aca93f238b805133ed8b140b791e370248664d5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docs-analyzer-patterns.md</strong><dd><code>Updated knowledge base analysis path reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/182/files#diff-60a14eef884bce420a0e623ddd18c13bc27b8b25bf76dd3a5d19f88816b29043">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docs.md</strong><dd><code>Fixed 11 path references across documentation workflow</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/182/files#diff-736c40ab37146533f43df4071d92eaa09e748a90b4742b153399ac94fc60b900">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>improve.md</strong><dd><code>Updated 4 path references in improvement workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/182/files#diff-a14601adae5c2a14b7c555016cd6c5f791b9397c89fbe72a638585b0f82439dd">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>plan.md</strong><dd><code>Fixed 8 path references in pattern consultation workflow</code>&nbsp; </dd></td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/182/files#diff-f92c71475e05563295cbb58268f7a69801221bc36d10f764fe1371134fb3c394">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>review.md</strong><dd><code>Updated 7 path references in review and pattern analysis</code>&nbsp; </dd></td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/182/files#diff-36ae55cc79c8892cac53e3c203b094e862372b4c48a9812f692e7613324dd9c7">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>search.md</strong><dd><code>Fixed 11 path references in local-first search strategy</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/182/files#diff-b0a447f776e1034406dcfe74b4fbbbfe534f4717eb691eb3fe5371157bcb5e40">+14/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>warmup.md</strong><dd><code>Updated 4 path references in analysis and documentation</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/182/files#diff-eaa8f699a8c6be5ae0cc61bc6953890899f797370164b0b24b81340131e909c7">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

