### PR TITLE
fix(grepai): clean stale index.gob.lock on daemon start and restart

### DIFF
--- a/.devcontainer/images/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/images/hooks/lifecycle/postStart.sh
@@ -526,6 +526,8 @@ stop_grepai_daemon() {
             sleep 1
         fi
     fi
+    # Clean stale lock (daemon may have held it when killed)
+    rm -f "/workspace/.grepai/index.gob.lock"
 }
 
 _grepai_init_core() {
@@ -663,6 +665,8 @@ _grepai_init_core() {
     grepai_pid=$(pgrep -f "$GREPAI_BIN watch" 2>/dev/null || true)
 
     if [ -z "$grepai_pid" ]; then
+        # Clean stale lock from previous crashed daemon (no process = lock is stale)
+        rm -f "${grepai_dir}/index.gob.lock"
         log_info "Starting grepai watch daemon..."
         : > "$grepai_log"
         (cd /workspace && nohup "$GREPAI_BIN" watch > "$grepai_log" 2>&1 &)
@@ -750,6 +754,8 @@ grepai_watchdog() {
                 continue
             fi
 
+            # Clean stale lock from crashed daemon before restart
+            rm -f "${grepai_dir}/index.gob.lock"
             (cd /workspace && nohup "$GREPAI_BIN" watch >> "$grepai_log" 2>&1 &)
             sleep 3
 


### PR DESCRIPTION
### **User description**
## Summary

- Clean stale `index.gob.lock` in `stop_grepai_daemon()` after killing the process
- Clean stale lock in Step 9 of `_grepai_init_core()` when no daemon is running (no process = lock is stale)
- Clean stale lock in watchdog restart branch before launching replacement daemon

## Context

Follow-up to #190 and #191. When the grepai daemon crashes mid-indexation (e.g., container restart, Ollama disconnect), `index.gob.lock` persists on disk. This blocks all future daemon start attempts because the new process can't acquire the lock. The watchdog retries indefinitely but hits the same stale lock every time.

**Root cause:** Lock cleanup only existed in Step 7 (invalidation path), which doesn't trigger in the "crashed daemon, no health stamp, no index file" scenario.

## Test plan

- [ ] Kill grepai daemon mid-indexation: `kill -9 $(pgrep -f "grepai watch")`
- [ ] Verify lock file persists: `ls /workspace/.grepai/index.gob.lock`
- [ ] Run postStart: lock cleaned, daemon restarts successfully
- [ ] Verify watchdog restart also cleans lock: kill daemon, wait 90s


___

### **PR Type**
Bug fix


___

### **Description**
- Clean stale `index.gob.lock` file in three critical locations

- Prevent daemon startup failures after unexpected crashes

- Handle lock cleanup in stop, init, and watchdog restart paths


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Daemon Crash"] --> B["Stale Lock Persists"]
  B --> C["Stop Function"]
  B --> D["Init Step 9"]
  B --> E["Watchdog Restart"]
  C --> F["Lock Cleaned"]
  D --> F
  E --> F
  F --> G["Daemon Starts Successfully"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>postStart.sh</strong><dd><code>Add stale lock cleanup in three daemon lifecycle paths</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/images/hooks/lifecycle/postStart.sh

<ul><li>Added lock cleanup in <code>stop_grepai_daemon()</code> after killing the process<br> <li> Added lock cleanup in Step 9 of <code>_grepai_init_core()</code> when no daemon is <br>running<br> <li> Added lock cleanup in <code>grepai_watchdog()</code> restart branch before <br>launching replacement daemon<br> <li> Prevents stale lock from blocking future daemon start attempts after <br>crashes</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/192/files#diff-6cc3dae99fc37d236cf0bd864677954581cb7d9b82a03b7c316f1037f4e960c3">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

