### PR TITLE
docs(go-agent): add code patterns for Go 1.18-1.24

### DIFF
--- a/.devcontainer/features/languages/CLAUDE.md
+++ b/.devcontainer/features/languages/CLAUDE.md
@@ -22,7 +22,7 @@ Language-specific installation scripts. Conventions handled by specialist agents
 | Fortran | Fortran 2023 | `developer-specialist-fortran` |
 | PHP | >= 8.5.0 | `developer-specialist-php` |
 | Rust | >= 1.92.0 | `developer-specialist-rust` |
-| Go | >= 1.25.0 | `developer-specialist-go` |
+| Go | >= 1.26.0 | `developer-specialist-go` |
 | Ada | Ada 2022 | `developer-specialist-ada` |
 | MATLAB/Octave | Octave 9+ | `developer-specialist-matlab` |
 | Assembly | NASM 2.16+ | `developer-specialist-assembly` |

--- a/.devcontainer/images/.claude/commands/lint.md
+++ b/.devcontainer/images/.claude/commands/lint.md
@@ -120,7 +120,7 @@ KTN-VAR-SYNCPOOL     → Use sync.Pool
 KTN-VAR-ARRAY        → Use array if <=64 bytes
 ```
 
-**PHASE 5 - MODERN** (Go 1.18-1.25 idioms)
+**PHASE 5 - MODERN** (Go 1.18-1.26 idioms)
 
 ```text
 KTN-VAR-USEANY       → interface{} → any


### PR DESCRIPTION
### **User description**
## Summary

- Add 5 missing code pattern sections to `developer-specialist-go.md` for Go 1.18, 1.20, 1.22, 1.23, and 1.24 features (generics, errors.Join, range-over-int, iterators, generic type aliases)
- Add 3 forbidden pattern rows (C-style loops, loop var capture, intermediate slice filtering)
- Bump Go version references from 1.25 to 1.26 in `languages/CLAUDE.md` and `lint.md`

## Test plan

- [ ] Verify all 13 version-tagged `### ` headers exist in Code Patterns section
- [ ] Grep `Go 1.18`, `Go 1.22`, `Go 1.23` matches both YAML and code pattern sections
- [ ] Forbidden table has 15 rows (was 12)


___

### **PR Type**
Documentation


___

### **Description**
- Add comprehensive code patterns for Go 1.18-1.24 features (generics, errors.Join, range-over-int, iterators, generic type aliases)

- Expand Go version features documentation from single 1.25 section to detailed 1.18-1.26 breakdown

- Add 4 new forbidden pattern rows to guide away from outdated practices

- Bump minimum Go version requirement from 1.25 to 1.26 across documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Go Version Features<br/>1.18-1.25"] -->|Expand & Reorganize| B["Detailed Feature List<br/>1.18-1.26"]
  C["Code Patterns Section"] -->|Add 5 New Patterns| D["Generics, errors.Join,<br/>Range-over-int, Iterators,<br/>Generic Type Aliases"]
  E["Forbidden Patterns<br/>12 rows"] -->|Add 4 Rows| F["Forbidden Patterns<br/>16 rows"]
  G["Go Version Refs<br/>1.25"] -->|Update| H["Go Version Refs<br/>1.26"]
  B --> D
  D --> F
  F --> H
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Update Go minimum version to 1.26.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/features/languages/CLAUDE.md

<ul><li>Update minimum Go version requirement from 1.25.0 to 1.26.0 in <br>language specification table</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/197/files#diff-9d88e12113574ccbb91b4748fc416e3f796cf900cdeb29df90df6a5b1df56877">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>developer-specialist-go.md</strong><dd><code>Add Go 1.18-1.26 patterns and expand version features</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/images/.claude/agents/developer-specialist-go.md

<ul><li>Reorganize <code>go_1_25_features</code> into comprehensive <code>go_version_features</code> <br>structure covering Go 1.18-1.26<br> <li> Add 5 new code pattern sections: Generics (Go 1.18), errors.Join (Go <br>1.20), Range over integers (Go 1.22), Iterators (Go 1.23), and Generic <br>type aliases (Go 1.24)<br> <li> Add 2 new code pattern sections for Go 1.26 features: new() with <br>expressions and errors.AsType[T]()<br> <li> Add 4 new forbidden pattern rows addressing errors.AsType, C-style <br>loops, loop variable capture, and intermediate slice filtering<br> <li> Update minimum Go version requirement from 1.25.0 to 1.26.0</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/197/files#diff-78f60dac8005ba221190ddf7a057a2882e795d0df13ba354775ec91e3648ec10">+206/-6</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lint.md</strong><dd><code>Update lint phase Go version range</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/images/.claude/commands/lint.md

<ul><li>Update PHASE 5 comment to reflect Go 1.18-1.26 idioms instead of <br>1.18-1.25</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/197/files#diff-54be8ca141aedc69c77175a0fe1764da08e105c192d31ce093185cb99b79b2de">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

