### PR TITLE
docs(commands): add interview mode and complexity check

### DIFF
--- a/.devcontainer/images/.claude/commands/plan.md
+++ b/.devcontainer/images/.claude/commands/plan.md
@@ -325,6 +325,39 @@ How to rollback if issues
 
 ---
 
+## Phase 5.5: Complexity Check
+
+**Triggered automatically after Synthesize. NOT a blocker — just a question.**
+
+```yaml
+complexity_check:
+  trigger: "files_to_modify + files_to_create > 15"
+
+  action:
+    tool: AskUserQuestion
+    questions:
+      - question: "This plan touches {n} files. Beyond ~15 files in a single session, quality may degrade. How do you want to proceed?"
+        header: "Scope"
+        options:
+          - label: "Execute as-is"
+            description: "Proceed with the full plan in one session"
+          - label: "Split into phases"
+            description: "Claude will propose logical segments to execute separately"
+
+  on_execute_as_is:
+    action: "Continue to Phase 6.0 normally"
+
+  on_split:
+    action: |
+      Rewrite the plan into numbered phases (Phase A, B, C...)
+      Each phase: <= 15 files, independently testable
+      User approves each phase via /do
+```
+
+**If <= 15 files:** Skip this phase silently, proceed to Phase 6.0.
+
+---
+
 ## Phase 6.0: Validation Request
 
 **MANDATORY: Wait for user approval**

--- a/.devcontainer/images/.claude/commands/prompt.md
+++ b/.devcontainer/images/.claude/commands/prompt.md
@@ -43,6 +43,32 @@ DONE:  All public routes throttled at 100 req/min per IP, existing tests pass, n
 
 ---
 
+## Interview Mode (Complex Features)
+
+When requirements are unclear or the feature is large, skip the template and ask Claude to challenge your thinking:
+
+```
+/plan "
+INTERVIEW: <brief description of what you want to build>
+"
+```
+
+Claude will:
+1. Ask targeted questions about implementation, edge cases, and tradeoffs
+2. Challenge assumptions you might not have considered
+3. Generate a spec from your answers before planning
+
+**When to use Interview vs Template:**
+
+| Situation | Use |
+|-----------|-----|
+| Clear scope, known files | Template (WHAT/WHY/WHERE/HOW/DONE) |
+| Fuzzy requirements, many unknowns | Interview mode |
+| Large feature (10+ files) | Interview mode |
+| Bug fix with known location | Template |
+
+---
+
 ## Dimension Guide
 
 | Dimension | Question it answers | Feeds /plan phase |


### PR DESCRIPTION
### **User description**
## Summary

- Add **Interview Mode** section to `/prompt` command for complex features with unclear requirements — users prefix with `INTERVIEW:` to trigger Claude's targeted questioning before planning
- Add **Phase 5.5: Complexity Check** to `/plan` command that warns when a plan touches >15 files and offers to split into independently testable phases

## Changes

| File | Change |
|------|--------|
| `.devcontainer/images/.claude/commands/prompt.md` | New "Interview Mode" section with decision table |
| `.devcontainer/images/.claude/commands/plan.md` | New Phase 5.5 between Synthesize and Validation |

## Test plan

- [ ] Verify `/prompt` displays the Interview Mode section
- [ ] Verify `/plan` with `INTERVIEW:` prefix triggers question flow
- [ ] Verify plans with <=15 files skip Phase 5.5 silently
- [ ] Verify plans with >15 files trigger AskUserQuestion
- [ ] Verify "Execute as-is" continues to Phase 6.0
- [ ] Verify "Split into phases" rewrites plan into segments


___

### **PR Type**
Documentation


___

### **Description**
- Add Interview Mode section to `/prompt` command for complex features with unclear requirements

- Add Phase 5.5 Complexity Check to `/plan` command that warns when plans exceed 15 files

- Provide decision table and workflow for splitting large plans into independently testable phases


___



### File Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prompt.md</strong><dd><code>Add Interview Mode section for complex features</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/images/.claude/commands/prompt.md

<ul><li>Add new "Interview Mode" section explaining when to use targeted <br>questioning approach<br> <li> Include usage example with <code>INTERVIEW:</code> prefix syntax<br> <li> Provide decision table comparing Interview Mode vs Template usage <br>scenarios<br> <li> Document Claude's three-step questioning process for complex features</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/198/files#diff-0dffb223edeb6ecd46203f183e3ac304b8a2442425ecd8dba447c3b801d08db9">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>plan.md</strong><dd><code>Add Phase 5.5 Complexity Check for large plans</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/images/.claude/commands/plan.md

<ul><li>Add Phase 5.5 Complexity Check triggered when plan touches >15 files<br> <li> Implement AskUserQuestion tool with two options: "Execute as-is" or <br>"Split into phases"<br> <li> Define behavior for splitting plans into numbered phases with <=15 <br>files each<br> <li> Specify silent skip when plan has <=15 files</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/198/files#diff-f92c71475e05563295cbb58268f7a69801221bc36d10f764fe1371134fb3c394">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

___

