### PR TITLE
fix(coderabbit): add provider field to auth.json for CLI v0.3.6

### DIFF
--- a/.devcontainer/images/.claude/commands/secret.md
+++ b/.devcontainer/images/.claude/commands/secret.md
@@ -459,7 +459,7 @@ list_workflow:
   (legacy items without path)
     ├─ mcp-github
     ├─ mcp-codacy
-    └─ Coderabbit TOKEN
+    └─ mcp-coderabbit
 
   Total: 8 items (5 with paths, 3 legacy)
 


### PR DESCRIPTION
### **User description**
## Summary\n\n- **Root cause**: CodeRabbit CLI v0.3.6 requires a `provider` field in `~/.coderabbit/auth.json` to consider the user authenticated. The previous format (`accessToken` + `expiresAt`) was insufficient.\n- Add provider auto-detection from git remote URL (github/gitlab)\n- Replace deprecated `expiresAt` field with `provider` field in `postStart.sh`\n- Rename 1Password item reference from `Coderabbit TOKEN` to `mcp-coderabbit` in docs (item already renamed in vault)\n\n## Test plan\n\n- [x] Verified `coderabbit auth status` reports \"Logged in\" with new format\n- [x] Verified `shellcheck` passes on modified lines\n- [x] Verified provider detection works for GitHub remote\n- [ ] CodeRabbit CI review


___

### **PR Type**
Bug fix


___

### **Description**
- Add provider field detection to auth.json for CodeRabbit CLI v0.3.6

- Auto-detect provider (github/gitlab) from git remote URL

- Replace deprecated expiresAt field with provider field

- Update 1Password item reference documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CodeRabbit CLI v0.3.6<br/>requires provider field"] -->|detect from| B["Git remote URL"]
  B -->|github/gitlab| C["Provider value"]
  C -->|replace expiresAt| D["Updated auth.json<br/>format"]
  E["1Password docs"] -->|rename item| F["mcp-coderabbit"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>postStart.sh</strong><dd><code>Add provider detection to CodeRabbit auth.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/images/hooks/lifecycle/postStart.sh

<ul><li>Add provider auto-detection logic from git remote URL (github/gitlab)<br> <li> Replace deprecated <code>expiresAt</code> field with <code>provider</code> field in JSON output<br> <li> Update jq command to include provider argument in auth.json generation<br> <li> Maintain backward compatibility with default github provider</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/219/files#diff-6cc3dae99fc37d236cf0bd864677954581cb7d9b82a03b7c316f1037f4e960c3">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>secret.md</strong><dd><code>Update 1Password item reference in docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/images/.claude/commands/secret.md

<ul><li>Rename 1Password item reference from <code>Coderabbit TOKEN</code> to <br><code>mcp-coderabbit</code><br> <li> Align documentation with actual vault item naming</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/219/files#diff-dbaac85bf79e1bdf2b862026c54e940f6082ed557bab56851cb6dfc242a7a114">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

