### PR TITLE
feat(coderabbit): add universal config with /review-inspired enrichments

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -98,11 +98,21 @@ reviews:
     - "!**/target/release/**"
     - "!**/.terraform/**"
     - "!**/coverage/**"
-    - "!**/*.lock"
-    - "!**/package-lock.json"
-    - "!**/go.sum"
-
-  path_instructions: []
+  path_instructions:
+    - path: "**/{*.lock,package-lock.json,go.sum,pnpm-lock.yaml,yarn.lock}"
+      instructions: |
+        Treat lockfiles as generated dependency snapshots.
+        Focus on high-signal changes only:
+        - New or removed direct dependencies
+        - Unexpected major version jumps
+        - Dependency source, registry, or resolution changes
+        Ignore formatting, ordering, or transitive reordering churn.
+    - path: "**/*.sh"
+      instructions: "Validate shell safety: strict mode, quoting, exit-on-error behavior, and command injection risks."
+    - path: "**/*.{yml,yaml}"
+      instructions: "Validate CI/CD workflow safety, least-privilege permissions, and secret handling."
+    - path: "**/Dockerfile*"
+      instructions: "Check image hardening, pinning strategy, non-root runtime, and multi-stage build hygiene."
 
   # Abort & Cache
   abort_on_close: true


### PR DESCRIPTION
### **User description**
## Summary

**What:** Add a universal `.coderabbit.yaml` configuration file and update `/init` to auto-generate personalized CodeRabbit configs.

**Why:** CodeRabbit reviews lacked project-aware configuration. The universal config provides sensible defaults for any project type, while `/init` Phase 4.5 personalizes it based on detected tech stack.

**How:** 
- `.coderabbit.yaml`: Schema-compliant universal config with all 46+ tools enabled, enriched with `/review` command's risk model knowledge (evidence-based tone, risk-aware summaries, 8 label categories from risk tags, expanded path filters)
- `init.md`: Added Phase 4.5 (CodeRabbit Configuration) that detects `.coderabbit.yaml` existence and generates a personalized version from project context

**Risk:** None — new files only, no breaking changes.

## Changes
- Add `.coderabbit.yaml` with universal, schema-validated configuration
- Enrich tone with evidence-based review philosophy from `/review`
- Add 8 labeling rules mapped from `/review` risk tags (security, concurrency, database, performance, shell, correctness, dependencies, breaking-change)
- Add risk zone flagging in summary instructions (auth/crypto/secrets, concurrency, state machines, DB migrations, supply chain, caching)
- Expand path filters for common build artifacts
- Add Phase 4.5 to `/init` for automatic CodeRabbit config generation

## Test plan
- [ ] Verify `.coderabbit.yaml` validates against schema
- [ ] Verify CodeRabbit picks up the config on next PR review
- [ ] Test `/init` Phase 4.5 generates personalized config when `.coderabbit.yaml` is missing


___

### **PR Type**
Enhancement


___

### **Description**
- Add universal `.coderabbit.yaml` configuration with schema-compliant defaults

- Enrich config with `/review` command's risk model (8 label categories, risk zones)

- Enable all 46+ CodeRabbit tools with auto-detection of relevance

- Add Phase 4.5 to `/init` for automatic personalized config generation

- Expand path filters to exclude common build artifacts and dependencies


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Project Context"] -->|Phase 4.5| B["Check .coderabbit.yaml"]
  B -->|Missing| C["Detect Tech Stack"]
  C -->|Map Tools| D["Build Path Instructions"]
  D -->|Add Labels| E["Generate Config"]
  E -->|Validate Schema| F[".coderabbit.yaml"]
  B -->|Exists| G["Skip Generation"]
  F -->|Auto-detect| H["Enable Relevant Tools"]
  H -->|Risk-aware| I["Enhanced Reviews"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.coderabbit.yaml</strong><dd><code>Universal CodeRabbit configuration with risk-aware enrichments</code></dd></summary>
<hr>

.coderabbit.yaml

<ul><li>New universal configuration file with schema compliance and 46+ tools <br>enabled<br> <li> Evidence-based tone instructions prioritizing correctness, security, <br>design, quality<br> <li> 8 labeling rules mapped from <code>/review</code> risk tags (dependencies, <br>breaking-change, security, concurrency, database, performance, shell, <br>correctness)<br> <li> Risk zone flagging in summary instructions (auth/crypto, concurrency, <br>state machines, DB migrations, supply chain, caching)<br> <li> Expanded path filters excluding node_modules, build artifacts, lock <br>files, and common generated files<br> <li> Auto-review enabled with conventional commit title format and <br>finishing touches for docstrings and unit tests</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/220/files#diff-c0f93b6ec1bb8a9771fe87219aa22843985ba0cd27a23689b7be274bfb7baf57">+312/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>init.md</strong><dd><code>Add Phase 4.5 for automatic CodeRabbit config generation</code>&nbsp; </dd></summary>
<hr>

.devcontainer/images/.claude/commands/init.md

<ul><li>Add Phase 4.5 (CodeRabbit Configuration) to initialization workflow<br> <li> Detect project tech stack and map to CodeRabbit tool names and file <br>patterns<br> <li> Generate language-specific path_instructions based on detected stack<br> <li> Build project-aware labeling rules and code guidelines file patterns<br> <li> Validate generated <code>.coderabbit.yaml</code> against official schema before <br>writing<br> <li> Provide clear output messages for both generated and skipped scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/kodflow/devcontainer-template/pull/220/files#diff-497855124f57151537298096965ef700871424fca8b1d4918baee61811ac7f05">+155/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What
Adds a universal, schema-compliant `.coderabbit.yaml` configuration file with 46+ CodeRabbit tools enabled and risk-aware labeling/instructions, plus Phase 4.5 in initialization documentation to auto-generate personalized `.coderabbit.yaml` when missing.

## Why
Establishes consistent, automated code review behavior across the project with evidence-based tone instructions prioritizing correctness, security, design, and quality. Integrates /review command risk-model knowledge through eight labeling rules (dependencies, breaking-change, security, concurrency, database, performance, shell, correctness) and explicit risk-zone flags for auth/crypto/secrets, concurrency patterns, state machines, database migrations, supply chain updates, and caching invalidation.

## How
- **Configuration file** (`.coderabbit.yaml`, 322 lines): Global settings (language, tone, inheritance), reviews profile with conventional-commit auto-titles, eight labeling rules with auto-apply enabled, extensive path filtering for build artifacts, language-specific path_instructions (lockfiles, shell scripts, CI/CD YAML, Dockerfiles), and 55+ linting/security tools (shellcheck, hadolint, yamllint, eslint, semgrep, trivy, etc.).
- **Automation** (Phase 4.5 in `init.md`, 165 lines): Five-step workflow — detect tech stack, generate language-specific path_instructions, build labeling rules (always-in: 8 core labels + architecture-derived additions), populate code guidelines, generate and validate file against remote schema using full jsonschema validation.
- **Lockfile handling**: Moved from broad path_filters exclusions to focused path_instructions treating lockfiles as generated snapshots; high-signal changes only (new/removed dependencies, major version jumps).

## Risk
- **External dependency**: Validation requires remote schema at `https://www.coderabbit.ai/integrations/schema.v2.json`; schema unavailability will fail Phase 4.5.
- **Security zones**: Config explicitly flags auth/crypto/secrets, concurrency, state machines, database migrations, supply chain, and caching as risk areas; auto-labeling enabled means these tags will auto-apply to matching PRs.
- **Behavioral changes**: Auto-review, auto-title formatting (conventional commits), and auto-labeling enabled by default; docstring/unit-test finishing touches enabled.
- **No breaking changes**: No public API modifications or migration steps required; file is declarative configuration only. Existing projects without `.coderabbit.yaml` will auto-generate on /init; existing configs are preserved (Phase 4.5 SKIPs if file present).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->