### PR TITLE
feat(git): add Phase 3.5 review comments triage to /git --merge

### DIFF
--- a/.devcontainer/images/.claude/commands/git.md
+++ b/.devcontainer/images/.claude/commands/git.md
@@ -15,6 +15,7 @@ allowed-tools:
   - "Read(**/*)"
   - "Write(.env)"
   - "Edit(.env)"
+  - "Edit(.codacy.yaml)"
   - "Glob(**/*)"
   - "mcp__grepai__*"
   - "Grep(**/*)"
@@ -1276,6 +1277,31 @@ review_triage:
           Option 1: "Continue fixing (raise iteration limit)"
           Option 2: "Merge anyway (override review findings)"
           Option 3: "Abort merge"
+
+    #---------------------------------------------------------------------------
+    # UNBLOCK: Reply to dismiss non-actionable findings
+    #---------------------------------------------------------------------------
+    # After all fixes are applied, if CodeRabbit still has CHANGES_REQUESTED
+    # due to dismissed suggestions (not bugs), post a structured reply on
+    # EACH unresolved thread explaining the decision. CodeRabbit will then
+    # re-evaluate and either resolve the thread or approve.
+    #---------------------------------------------------------------------------
+    unblock_stale_reviews:
+      trigger: "All actionable findings fixed but CHANGES_REQUESTED persists"
+      action: |
+        FOR each unresolved review thread:
+          IF finding was intentionally not fixed (design decision):
+            Post reply on the thread via mcp__github__add_issue_comment:
+              - Acknowledge the suggestion
+              - Explain why it was not applied (with justification)
+              - Reference the design decision or consistency argument
+          THEN:
+            Post "@coderabbitai resolve" to dismiss resolved threads
+            Post "@coderabbitai review" to trigger fresh evaluation
+      rule: |
+        NEVER ignore findings silently. Each dismissed finding MUST have
+        a justified reply on the thread. This unblocks CodeRabbit's
+        CHANGES_REQUESTED state for merge.
 ```
 
 **Output Phase 3.5 (Triage Summary):**


### PR DESCRIPTION
## Summary

- Add Phase 3.5 (Review Comments Triage) to `/git --merge` workflow between CI monitoring (Phase 3.0) and error extraction (Phase 4.0)
- Automatically fetches, classifies, fixes, and interacts with review bots (CodeRabbit, Qodo, Codacy) and human reviewers
- Includes iterative fix loop (max 3 iterations) with bot-specific interaction commands
- GitHub-only implementation with platform guard (skipped on GitLab)

## Changes

**`.devcontainer/images/.claude/commands/git.md`** (+264, -2)

- **Phase 3.5.1** - Parallel fetch from 3 MCP sources (GitHub-only, with platform guard)
- **Phase 3.5.2** - Classification with exact-match source detection rules (`coderabbitai[bot]`, `qodo-merge-pro[bot]`, `qodo-code-review[bot]`) and relevance filters
- **Phase 3.5.3** - Priority-based sorting (human > CodeRabbit > Qodo P0 > Codacy Critical > Qodo P1 > Codacy Medium > CodeRabbit suggestions)
- **Phase 3.5.4** - Fix loop with CodeRabbit interaction (`@coderabbitai resolve/review/pause/resume`), Codacy false-positive handling via `AskUserQuestion`, and escalation after 3 iterations
- **Output blocks** - Triage summary, satisfaction report, and no-findings variant
- **Arguments** - Added `--skip-review` option to `--merge` options table and help text
- **Guardrails** - Added "Review Triage Safeguards" table (7 rules)
- **Permissions** - Added `mcp__codacy__*` and `.codacy.yaml` edit to `allowed-tools` frontmatter
- **Bug fix** - Corrected phase reference in --commit context update (Phase 3+3.5 to Phase 4+5)
- **Platform guard** - Phase 3.5 declared GitHub-only with automatic skip on GitLab

## Test plan

- [ ] Run `/git --merge` on a PR with CodeRabbit/Codacy findings
- [ ] Verify Phase 3.5 activates after CI passes
- [ ] Verify comments fetched from all sources in parallel
- [ ] Verify exact-match bot detection (no `contains` impersonation risk)
- [ ] Verify `--skip-review` flag bypasses Phase 3.5
- [ ] Verify Phase 3.5 skipped on GitLab platform
- [ ] Verify guardrails prevent auto-dismissing human comments