### PR TITLE
fix(rtk): auto-install RTK from GitHub Releases when missing at startup

### DIFF
--- a/.devcontainer/images/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/images/hooks/lifecycle/postStart.sh
@@ -1390,7 +1390,7 @@ init_rtk() {
         local rtk_tag
         rtk_tag=$(curl -fsSL --connect-timeout 5 --max-time 15 "${curl_auth_args[@]}" \
             "https://api.github.com/repos/rtk-ai/rtk/releases/latest" 2>/dev/null | jq -r '.tag_name // empty')
-        if [ -z "$rtk_tag" ] || ! [[ "$rtk_tag" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+        if [ -z "$rtk_tag" ] || ! [[ "$rtk_tag" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             log_warning "RTK: failed to fetch valid release tag"
             return 0
         fi


### PR DESCRIPTION
## Summary

- **postStart.sh** `init_rtk()` now auto-downloads the latest RTK binary from GitHub Releases when `rtk` is not found in PATH, instead of silently skipping
- Supports both `x86_64` and `aarch64` architectures (musl builds)
- Hardened with: jq availability guard, curl timeouts (`--connect-timeout 5`, `--max-time 15/60`), semver tag validation (`^v?[0-9]+\.[0-9]+\.[0-9]+$`), and optional GitHub API token auth to avoid rate limits
- All failures are non-blocking (warnings only) — container startup is never interrupted

## Changes

### `.devcontainer/images/hooks/lifecycle/postStart.sh` (+29, -2)
- Replaced `log_info "RTK not installed, skipping"` with full auto-install logic
- Architecture detection via `uname -m` → musl target triple
- GitHub API latest release tag fetch with jq parsing
- Tarball download and extraction to `/usr/local/bin/rtk`

## Root cause

RTK was added to the Dockerfile but the Docker image hadn't been rebuilt yet (daily cron at 4AM UTC). Containers started from the old image had no `rtk` binary, and `init_rtk()` silently skipped — now it self-heals.

## Test plan

- [ ] Verify RTK installs on fresh container without RTK in image
- [ ] Verify RTK skips gracefully when jq is missing
- [ ] Verify RTK skips gracefully on unsupported architecture
- [ ] Verify RTK skips gracefully on network failure (timeouts)
- [ ] Verify existing containers with RTK pre-installed are unaffected