### PR TITLE
chore(deps): bump Docker actions to v4/v7

### DIFF
--- a/.claude/features.json
+++ b/.claude/features.json
@@ -1,0 +1,1 @@
+{ "version": 2, "features": [] }

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -4,16 +4,16 @@ on:
   push:
     branches: [main]
     paths:
-      - '.devcontainer/images/**'
-      - '.github/workflows/docker-images.yml'
+      - ".devcontainer/images/**"
+      - ".github/workflows/docker-images.yml"
   pull_request:
     branches: [main]
     paths:
-      - '.devcontainer/images/**'
-      - '.github/workflows/docker-images.yml'
+      - ".devcontainer/images/**"
+      - ".github/workflows/docker-images.yml"
   schedule:
     # Daily build at 4:00 AM UTC
-    - cron: '0 4 * * *'
+    - cron: "0 4 * * *"
   workflow_dispatch:
   repository_dispatch:
     types: [ktn-linter-release]
@@ -52,11 +52,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -88,7 +88,7 @@ jobs:
       # PR: Build only (no push)
       - name: Build image (PR)
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .devcontainer/images
           file: .devcontainer/images/Dockerfile
@@ -104,7 +104,7 @@ jobs:
       - name: Build and push by digest
         if: github.event_name != 'pull_request'
         id: build
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .devcontainer/images
           file: .devcontainer/images/Dockerfile
@@ -153,10 +153,10 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -168,7 +168,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |


### PR DESCRIPTION
## Summary

- Consolidate 4 dependabot PRs (#228, #229, #230, #231) into a single update
- Bump `docker/setup-buildx-action` v3.12.0 → v4.0.0
- Bump `docker/login-action` v3.7.0 → v4.0.0
- Bump `docker/metadata-action` v5.10.0 → v6.0.0
- Bump `docker/build-push-action` v6.19.2 → v7.0.0
- Track `.claude/features.json` (schema v2, empty)

Closes #228, closes #229, closes #230, closes #231

## Test plan

- [ ] Workflow syntax valid (YAML linter passed)
- [ ] Docker image build triggers on push to main
- [ ] Multi-arch manifest (amd64 + arm64) created successfully
- [ ] `ghcr.io/kodflow/devcontainer-template:latest` updated