### PR TITLE
fix(docker): use gnu target for RTK on ARM64

### DIFF
--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -122,7 +122,7 @@ RUN ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     tar xz -C /usr/local/bin grepai && \
     RTK_LATEST=$(curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: token ${GITHUB_TOKEN}"} "https://api.github.com/repos/rtk-ai/rtk/releases/latest" | jq -r '.tag_name') && \
     echo "Installing rtk ${RTK_LATEST}..." && \
-    RTK_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64-unknown-linux-musl" || echo "x86_64-unknown-linux-musl") && \
+    RTK_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64-unknown-linux-gnu" || echo "x86_64-unknown-linux-musl") && \
     curl -fsSL "https://github.com/rtk-ai/rtk/releases/download/${RTK_LATEST}/rtk-${RTK_ARCH}.tar.gz" | \
     tar xz -C /usr/local/bin rtk
 


### PR DESCRIPTION
## Summary

- Fix ARM64 image build failure caused by missing `rtk-aarch64-unknown-linux-musl.tar.gz` (404)
- RTK only publishes `aarch64-unknown-linux-gnu` for Linux ARM64, not `musl`
- Change target triple from `aarch64-unknown-linux-musl` to `aarch64-unknown-linux-gnu`

This has been breaking the daily scheduled builds and all ARM64 image builds.

## Test plan

- [ ] ARM64 Docker image build completes successfully
- [ ] RTK binary is functional inside ARM64 container
- [ ] AMD64 build remains unaffected (still uses `x86_64-unknown-linux-musl`)