### PR TITLE
fix(ci): chain Release after Docker build and fix workflow_run semantics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,21 +15,31 @@ on:
 
 concurrency:
   group: release-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   release:
-    # Only run on the original repo, and skip if triggered by a failed Docker build
+    # Only run on the original repo
+    # Skip if workflow_run triggered by schedule/dispatch (only release on push-triggered Docker builds)
+    # Skip if workflow_run concluded with failure
     if: >-
       github.repository == 'kodflow/devcontainer-template'
-      && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
+      && (github.event_name != 'workflow_run'
+        || (github.event.workflow_run.conclusion == 'success'
+          && github.event.workflow_run.event == 'push'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
+    env:
+      # workflow_run sets GITHUB_SHA to default branch HEAD, not the triggering commit
+      TARGET_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ env.TARGET_SHA }}
 
       - name: Generate assets archive
         run: |
@@ -39,7 +49,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="v$(date -u +'%Y.%m.%d')-${GITHUB_SHA::7}"
+          TAG="v$(date -u +'%Y.%m.%d')-${TARGET_SHA::7}"
 
           # Delete existing 'latest' release if it exists (keep only one)
           gh release delete latest --yes 2>/dev/null || true
@@ -49,5 +59,5 @@ jobs:
           gh release create "$TAG" \
             claude-assets.tar.gz \
             --title "Release $TAG" \
-            --notes "Auto-generated from commit ${GITHUB_SHA::7} on $(date -u +'%Y-%m-%d %H:%M UTC')" \
+            --notes "Auto-generated from commit ${TARGET_SHA::7} on $(date -u +'%Y-%m-%d %H:%M UTC')" \
             --latest


### PR DESCRIPTION
## Summary

- Chain Release workflow after Docker build via `workflow_run` instead of duplicate path triggers
- Fix `GITHUB_SHA` resolution for `workflow_run` events (use `head_sha` from triggering workflow)
- Filter `workflow_run` to push events only (prevent schedule/dispatch Docker builds from triggering releases)
- Set `cancel-in-progress: false` to prevent orphaning the `latest` release during concurrent runs

## Problem

Every push to `main` touching `.devcontainer/images/**` triggered **both** pipelines simultaneously (Docker build + Release), wasting runners. Additionally, `workflow_run` events set `GITHUB_SHA` to the default branch HEAD rather than the triggering commit, which could package the wrong revision.

## Changes

| Change | Before | After |
|--------|--------|-------|
| `images/**` trigger | Both Docker + Release | Docker only, then Release via `workflow_run` |
| Scheduled Docker builds | N/A | Do NOT trigger Release (`event == 'push'` filter) |
| `GITHUB_SHA` on `workflow_run` | Points to default branch HEAD | Uses `workflow_run.head_sha` (correct commit) |
| `cancel-in-progress` | `true` (can orphan `latest`) | `false` (safe serialization) |
| `features/**` / `hooks/**` only | Release direct | Unchanged (Release direct) |

## Flow

```
Push (images/**) → Docker Build → (success + push event) → Release
Push (features/**|hooks/**) → Release (direct)
Schedule/dispatch → Docker Build → NO Release
```

## Test plan

- [ ] Push touching `images/` only → Docker runs, then Release triggers via `workflow_run`
- [ ] Push touching `features/` only → Release runs directly (no Docker)
- [ ] Push touching both `images/` + `features/` → Both trigger, concurrency serializes
- [ ] Failed Docker build → Release does NOT run
- [ ] Scheduled Docker build → Release does NOT run
- [ ] `workflow_dispatch` on Release → Still works
- [ ] Release tags use correct commit SHA (not stale HEAD)