### PR TITLE
feat(hooks): add auto-save on agent/task completion

### DIFF
--- a/.devcontainer/images/.claude/scripts/auto-save.sh
+++ b/.devcontainer/images/.claude/scripts/auto-save.sh
@@ -12,9 +12,9 @@ cd "$PROJECT_DIR" 2>/dev/null || exit 0
 # Skip if not a git repo
 git rev-parse --is-inside-work-tree &>/dev/null || exit 0
 
-# Skip if on main/master (never commit directly)
+# Skip if on main/master or detached HEAD (never commit directly)
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-case "$BRANCH" in main|master|"") exit 0 ;; esac
+case "$BRANCH" in main|master|HEAD|"") exit 0 ;; esac
 
 # Skip if no changes
 git diff --quiet HEAD 2>/dev/null && git diff --cached --quiet 2>/dev/null && \
@@ -36,8 +36,13 @@ if [ -n "$INPUT" ] && command -v jq &>/dev/null; then
 fi
 [ -z "$CONTEXT" ] && CONTEXT="progress checkpoint"
 
-# Stage all + commit (--no-verify to skip hooks, fast)
+# Stage all + commit
+# --no-verify is opt-in via AUTO_SAVE_SKIP_HOOKS=1 (default: run hooks)
 git add -A 2>/dev/null
-git commit --no-verify -m "chore(save): $CONTEXT" 2>/dev/null || true
+if [ "${AUTO_SAVE_SKIP_HOOKS:-0}" = "1" ]; then
+  git commit --no-verify -m "chore(save): $CONTEXT" 2>/dev/null || true
+else
+  git commit -m "chore(save): $CONTEXT" 2>/dev/null || true
+fi
 
 exit 0

--- a/.devcontainer/images/.claude/settings.json
+++ b/.devcontainer/images/.claude/settings.json
@@ -304,8 +304,7 @@
           {
             "type": "command",
             "command": "/home/vscode/.claude/scripts/subagent-stop.sh",
-            "timeout": 5,
-            "async": true
+            "timeout": 5
           },
           {
             "type": "command",
@@ -352,8 +351,7 @@
           {
             "type": "command",
             "command": "/home/vscode/.claude/scripts/task-completed.sh",
-            "timeout": 5,
-            "async": true
+            "timeout": 5
           },
           {
             "type": "command",


### PR DESCRIPTION
## Summary

- Add `auto-save.sh` hook script that auto-commits uncommitted changes when subagents stop or tasks complete
- Prevents work loss in multi-agent workflows where `git reset` by another agent could discard progress
- Hook registered on both `SubagentStop` and `TaskCompleted` events in `settings.json`

## Changes

**New file:** `.devcontainer/images/.claude/scripts/auto-save.sh`
- Skips `main`/`master` branches (respects "never commit to main" convention)
- Detects uncommitted changes (staged, unstaged, untracked)
- Extracts context from hook JSON input (task subject, agent type, teammate name)
- Commits with `chore(save): <context>` using `--no-verify` for speed
- Fail-open design: all errors silently ignored, never blocks agent execution

**Modified:** `.devcontainer/images/.claude/settings.json`
- Added `auto-save.sh` to `SubagentStop` hooks (after `subagent-stop.sh`)
- Added `auto-save.sh` to `TaskCompleted` hooks (after `task-completed.sh`)
- Timeout: 10s per hook invocation

## Test plan

- [ ] Verify `auto-save.sh` is executable and passes `shellcheck`
- [ ] Verify `settings.json` is valid JSON after modifications
- [ ] Test on feature branch: create a file change, simulate hook → verify auto-commit created
- [ ] Test on `main`: verify script exits without committing
- [ ] Test with no changes: verify script exits cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**What**
Adds an auto-save hook script that auto-commits workspace changes when subagents stop or tasks complete, and registers it in the hooks configuration.

**Why**
To capture uncommitted progress at key agent/task lifecycle events to reduce risk of lost work during execution.

**How**
- Adds .devcontainer/images/.claude/scripts/auto-save.sh which:
  - Exits early if not in a Git repo, on main/master or detached HEAD, or if there are no changes.
  - Detects staged, unstaged, and untracked changes and stages all changes before commit.
  - Extracts commit context from hook JSON input (prefers task_subject trimmed to 60 chars, then agent_type, then teammate_name) via optional jq; falls back to "progress checkpoint".
  - Commits with message "chore(save): <context>". Use of --no-verify is controlled by environment variable AUTO_SAVE_SKIP_HOOKS (opt-in); default runs hooks.
  - Uses a fail-open design: errors are suppressed and the script always exits successfully so it cannot block agent execution.
- Updates .devcontainer/images/.claude/settings.json to register auto-save.sh on SubagentStop (after subagent-stop.sh) and TaskCompleted (after task-completed.sh) with a 10s timeout, and removes "async": true from the predecessor hooks to enforce ordering.

**Risk**
- Low-to-moderate: no auth/crypto/secrets, DB migrations, or public API changes. Key risk points:
  - Commits are made automatically on feature branches; organization policies or workflows expecting manual commits might be affected.
  - Hook ordering change (removal of async on predecessor hooks) alters runtime ordering semantics and could affect existing hook behavior.
  - AUTO_SAVE_SKIP_HOOKS controls skipping pre-commit hooks; if set to enable --no-verify it may bypass local git hooks that enforce checks.
- No new mandatory runtime dependencies (jq is optional). No code-level concurrency, caching, or supply-chain changes introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->