### PR TITLE
fix(ci): always send Codacy final signal for diff coverage status

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,11 +63,12 @@ jobs:
               --project-token "${{ secrets.CODACY_PROJECT_TOKEN }}" \
               -r "$REPORT" \
               --partial || true
-            bash <(curl -Ls https://coverage.codacy.com/get.sh) final \
-              --project-token "${{ secrets.CODACY_PROJECT_TOKEN }}" || true
           else
-            echo "No coverage report found, skipping Codacy upload"
+            echo "No coverage report found, sending final signal only"
           fi
+          # Always send final signal so Codacy posts the status check
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) final \
+            --project-token "${{ secrets.CODACY_PROJECT_TOKEN }}" || true
 
       - name: Upload coverage artifact
         if: always()


### PR DESCRIPTION
## Summary

- Fix Codacy Diff Coverage status check never being posted on PRs without code coverage (YAML/JSON/MD-only changes)
- The `final` signal to Codacy was inside an `if [ -n "$REPORT" ]` block — it only ran when a coverage report existed
- Move the `final` call outside the conditional so it always executes

## Root cause

The "Codacy Diff Coverage" required status check was blocking all PRs that didn't generate coverage reports (e.g. Dependabot PRs, config-only changes). Without the `final` signal, Codacy never posted the status check, and GitHub waited forever.

## Test plan

- [ ] Merge this PR (the workflow itself will validate — if Codacy Diff Coverage status appears, the fix works)
- [ ] After merge, rebase PR #240 (Dependabot) and verify it can now merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What
Ensures the Codacy final signal is always sent to Codacy, regardless of whether a coverage report is generated, by moving the final signal call outside the conditional block in the coverage upload step.

## Why
When PRs contained only non-code changes (YAML/JSON/Markdown), no coverage report was generated. The final Codacy signal was conditionally executed only when a report existed, causing Codacy to never receive the signal and therefore never post the "Codacy Diff Coverage" status check, leaving GitHub in a waiting state.

## How
In `.github/workflows/tests.yml`, the bash call to send the final signal (`bash <(curl -Ls https://coverage.codacy.com/get.sh) final ...`) was relocated from inside the `if [ -n "$REPORT" ]` block to execute unconditionally after the if/else block. The message for the no-report case was updated from "No coverage report found, skipping Codacy upload" to "No coverage report found, sending final signal only."

## Risk
Low risk. This is a CI workflow change that adds signal emission without altering build logic or introducing dependencies. No breaking changes or migration steps required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->