### PR TITLE
refactor(hooks): move quality gate from Stop to pre-commit

### DIFF
--- a/.devcontainer/images/.claude/commands/git/commit.md
+++ b/.devcontainer/images/.claude/commands/git/commit.md
@@ -121,8 +121,7 @@ incremental_quality:
   strategy:
     1_detect_changes: "git diff main...HEAD + unstaged + staged → changed files"
     2_detect_languages: "Map file extensions to languages (Go, Rust, TS, Python, Shell, etc.)"
-    3_makefile_first: "If Makefile has lint/test targets → delegate to make"
-    4_fallback: "Language-specific tools scoped to changed files/packages"
+    3_scoped_first: "Language-specific tools scoped to changed files/packages"
 
   supported_languages:
     go: { lint: "golangci-lint run <changed_pkgs>", test: "go test -race <changed_pkgs>" }
@@ -165,7 +164,7 @@ incremental_quality:
 ═══════════════════════════════════════════════════════════════
 ```
 
-**IMPORTANT**: Run `.claude/scripts/pre-commit-checks.sh` which auto-detects languages.
+**IMPORTANT**: Run `.claude/scripts/pre-commit-quality.sh main` which auto-detects languages.
 
 ---
 

--- a/.devcontainer/images/.claude/scripts/pre-commit-quality.sh
+++ b/.devcontainer/images/.claude/scripts/pre-commit-quality.sh
@@ -38,6 +38,7 @@ CHANGED_FILES=$(
 [ -z "$CHANGED_FILES" ] && exit 0
 
 # === Detect which languages have changes ===
+# shellcheck disable=SC2034  # Variables reserved for future language checkers
 HAS_GO=false HAS_RUST=false HAS_NODE=false HAS_PYTHON=false HAS_SHELL=false
 HAS_JAVA=false HAS_CPP=false HAS_RUBY=false HAS_PHP=false HAS_ELIXIR=false
 HAS_DART=false HAS_SCALA=false HAS_KOTLIN=false HAS_SWIFT=false
@@ -62,6 +63,7 @@ while IFS= read -r f; do
 done <<< "$CHANGED_FILES"
 
 # === Extract changed packages/directories for scoped checks ===
+# shellcheck disable=SC2034  # Used by future language checkers that scope by directory
 CHANGED_DIRS=$(echo "$CHANGED_FILES" | xargs -I{} dirname {} | sort -u | head -20)
 
 # === Build parallel check commands ===
@@ -81,36 +83,37 @@ run_lint() {
     if $HAS_GO && command -v golangci-lint &>/dev/null; then
         local go_pkgs
         go_pkgs=$(echo "$CHANGED_FILES" | grep '\.go$' | xargs -I{} dirname {} | sort -u | sed 's|^|./|' | paste -sd' ')
-        golangci-lint run $go_pkgs 2>&1 >> "$out" || exit_code=1
+        # shellcheck disable=SC2086 -- intentional word splitting on go_pkgs
+        golangci-lint run $go_pkgs >> "$out" 2>&1 || exit_code=1
     fi
     if $HAS_RUST && command -v cargo &>/dev/null; then
-        cargo clippy -- -D warnings 2>&1 >> "$out" || exit_code=1
+        cargo clippy -- -D warnings >> "$out" 2>&1 || exit_code=1
     fi
     if $HAS_NODE; then
         if [ -f "$PROJECT_ROOT/package.json" ] && command -v npx &>/dev/null; then
-            npx eslint --fix $(echo "$CHANGED_FILES" | grep -E '\.(ts|tsx|js|jsx)$' | tr '\n' ' ') 2>&1 >> "$out" || exit_code=1
+            npx eslint $(echo "$CHANGED_FILES" | grep -E '\.(ts|tsx|js|jsx)$' | tr '\n' ' ') >> "$out" 2>&1 || exit_code=1
         fi
     fi
     if $HAS_PYTHON && command -v ruff &>/dev/null; then
-        ruff check $(echo "$CHANGED_FILES" | grep '\.py$' | tr '\n' ' ') 2>&1 >> "$out" || exit_code=1
+        ruff check $(echo "$CHANGED_FILES" | grep '\.py$' | tr '\n' ' ') >> "$out" 2>&1 || exit_code=1
     fi
     if $HAS_SHELL && command -v shellcheck &>/dev/null; then
-        shellcheck -x $(echo "$CHANGED_FILES" | grep -E '\.(sh|bash)$' | tr '\n' ' ') 2>&1 >> "$out" || exit_code=1
+        shellcheck -x $(echo "$CHANGED_FILES" | grep -E '\.(sh|bash)$' | tr '\n' ' ') >> "$out" 2>&1 || exit_code=1
     fi
     if $HAS_JAVA && has_makefile_target "lint" "$PROJECT_ROOT"; then
-        make lint 2>&1 >> "$out" || exit_code=1
+        make lint >> "$out" 2>&1 || exit_code=1
     fi
     if $HAS_RUBY && command -v rubocop &>/dev/null; then
-        rubocop $(echo "$CHANGED_FILES" | grep '\.rb$' | tr '\n' ' ') 2>&1 >> "$out" || exit_code=1
+        rubocop $(echo "$CHANGED_FILES" | grep '\.rb$' | tr '\n' ' ') >> "$out" 2>&1 || exit_code=1
     fi
     if $HAS_PHP && command -v phpstan &>/dev/null; then
-        phpstan analyse $(echo "$CHANGED_FILES" | grep '\.php$' | tr '\n' ' ') 2>&1 >> "$out" || exit_code=1
+        phpstan analyse $(echo "$CHANGED_FILES" | grep '\.php$' | tr '\n' ' ') >> "$out" 2>&1 || exit_code=1
     fi
     if $HAS_ELIXIR && command -v mix &>/dev/null; then
-        mix credo --strict 2>&1 >> "$out" || exit_code=1
+        mix credo --strict >> "$out" 2>&1 || exit_code=1
     fi
     if $HAS_DART && command -v dart &>/dev/null; then
-        dart analyze $(echo "$CHANGED_FILES" | grep '\.dart$' | tr '\n' ' ') 2>&1 >> "$out" || exit_code=1
+        dart analyze $(echo "$CHANGED_FILES" | grep '\.dart$' | tr '\n' ' ') >> "$out" 2>&1 || exit_code=1
     fi
 
     return $exit_code
@@ -126,27 +129,30 @@ run_test() {
     if $HAS_GO && command -v go &>/dev/null; then
         local go_pkgs
         go_pkgs=$(echo "$CHANGED_FILES" | grep '\.go$' | xargs -I{} dirname {} | sort -u | sed 's|^|./|' | paste -sd' ')
-        go test -race -count=1 $go_pkgs 2>&1 >> "$out" || exit_code=1
+        # shellcheck disable=SC2086 -- intentional word splitting on go_pkgs
+        go test -race -count=1 $go_pkgs >> "$out" 2>&1 || exit_code=1
     fi
     if $HAS_RUST && command -v cargo &>/dev/null; then
-        cargo test 2>&1 >> "$out" || exit_code=1
+        cargo test >> "$out" 2>&1 || exit_code=1
     fi
     if $HAS_NODE && [ -f "$PROJECT_ROOT/package.json" ]; then
         if command -v npx &>/dev/null; then
-            npx vitest run --reporter=verbose 2>&1 >> "$out" || \
-            npx jest --passWithNoTests 2>&1 >> "$out" || exit_code=1
+            npx vitest run --reporter=verbose >> "$out" 2>&1 || \
+            npx jest --passWithNoTests >> "$out" 2>&1 || exit_code=1
         fi
     fi
     if $HAS_PYTHON && command -v pytest &>/dev/null; then
-        pytest --tb=short -q 2>&1 >> "$out" || exit_code=1
+        pytest --tb=short -q >> "$out" 2>&1 || exit_code=1
     fi
     if $HAS_SHELL; then
-        if command -v bats &>/dev/null && ls tests/**/*.bats &>/dev/null 2>&1; then
-            bats tests/**/*.bats 2>&1 >> "$out" || exit_code=1
+        if [ -x "tests/hooks/run-all.sh" ]; then
+            bash tests/hooks/run-all.sh >> "$out" 2>&1 || exit_code=1
+        elif command -v bats &>/dev/null && ls tests/**/*.bats &>/dev/null 2>&1; then
+            bats tests/**/*.bats >> "$out" 2>&1 || exit_code=1
         fi
     fi
     if $HAS_ELIXIR && command -v mix &>/dev/null; then
-        mix test 2>&1 >> "$out" || exit_code=1
+        mix test >> "$out" 2>&1 || exit_code=1
     fi
 
     return $exit_code

--- a/.devcontainer/images/.claude/settings.json
+++ b/.devcontainer/images/.claude/settings.json
@@ -140,10 +140,7 @@
     "additionalDirectories": []
   },
   "enableAllProjectMcpServers": true,
-  "disabledMcpjsonServers": [
-    "codacy",
-    "playwright"
-  ],
+  "disabledMcpjsonServers": ["codacy", "playwright"],
   "hooks": {
     "SessionStart": [
       {
@@ -210,11 +207,6 @@
             "command": "/home/vscode/.claude/scripts/log.sh",
             "timeout": 5,
             "async": true
-          },
-          {
-            "type": "command",
-            "command": "/home/vscode/.claude/scripts/rtk-rewrite.sh",
-            "timeout": 5
           }
         ]
       },


### PR DESCRIPTION
## Summary

- Remove `on-stop-quality.sh` from Stop hook — no more lint/test after every Claude response
- Add `pre-commit-quality.sh` — incremental quality gate for `/git --commit` only
- Lint + test run in **parallel** (background jobs), scoped to **changed files only**

## Why

The Stop hook ran shellcheck + bats on every response, even simple Q&A. This added 5-30s latency after each turn. Quality checks belong in the commit workflow, not the conversation flow.

## Changes

| Before | After |
|--------|-------|
| Quality checks after every response | Quality checks only at commit time |
| Full project scope (all files) | Changed files only (incremental) |
| Sequential (lint → test) | Parallel (lint + test simultaneously) |
| Makefile-first (runs everything) | Scoped-first (language tools on changed files) |

## Test plan

- [x] `pre-commit-quality.sh main` passes on current changes
- [x] `bash tests/hooks/run-all.sh` → 30/30 PASS
- [x] Stop hook no longer includes quality gate
- [x] 14 languages supported (Go, Rust, TS, Python, Shell, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
What
Migrates the quality gate from the Stop hook (post-response) to a new incremental pre-commit step: adds .devcontainer/images/.claude/scripts/pre-commit-quality.sh to run lint + tests in parallel and scoped to changed files, and removes the on-stop-quality hook from settings.

Why
Reduce latency during interactive Claude sessions by avoiding full-project checks after every response and shift heavier quality work to commit time; reserve full-project Makefile targets for CI.

How
- Adds pre-commit-quality.sh which:
  - Accepts an optional base branch (default main).
  - Computes deduplicated changed files via git diff (base...HEAD) plus unstaged/staged diffs.
  - Detects changed languages/extensions (Go, Rust, Node/TS, Python, Shell, Java, C/C++, Ruby, PHP, Elixir, Dart, Scala, Kotlin, Swift).
  - Builds scoped lint and test invocations (per-language), runs lint and test as background jobs, captures outputs, and exits non-zero if either fails.
  - Scoped-first approach: commands run only on changed files/packages; Makefile/full-project targets are avoided for pre-commit.
- Updates commit workflow docs (.devcontainer/images/.claude/commands/git/commit.md) to invoke ~/.claude/scripts/pre-commit-quality.sh main during Phase 4.0.
- Modifies settings.json hooks to remove the on-stop quality hook and moves/adjusts permission-related fields (notably defaultMode relocated inside the permissions object).

Risk
- Concurrency/aggregation: parallel background jobs rely on wait + exit-code aggregation; bugs could mask failures or misreport status.
- Silent success paths: script exits 0 when project directory is missing or when no changed files are detected, which may hide unintended skips.
- Tooling dependencies: behavior depends on many external tools (golangci-lint, go, cargo, npx/eslint/vitest/jest, ruff/pytest, shellcheck, rubocop, phpstan, mix, dart, etc.). Missing tools lead to partial/no checks; the script only gates per-tool availability.
- Configuration/compatibility: moving defaultMode inside permissions (settings.json) may break consumers or tooling that expected the previous schema.
- Removed safety net: removing on-stop-quality eliminates automatic post-response checks; regressions that previously surfaced after responses may only be caught at commit time or CI.
- Supply chain / privileged actions: new script reads git state and runs many language tools; ensure secure handling of untrusted repo contents and that permission changes do not expand risky command allowances.

Notable additions / public-surface changes
- New executable script: .devcontainer/images/.claude/scripts/pre-commit-quality.sh (adds an on-commit quality gate).
- Documentation change: commit workflow updated to call the new script.
- Settings change: Stop hook removed and permissions/defaultMode restructuring in settings.json.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->