### PR TITLE
fix(security): embed global gitignore in Docker image

### DIFF
--- a/.devcontainer/images/hooks/lifecycle/postCreate.sh
+++ b/.devcontainer/images/hooks/lifecycle/postCreate.sh
@@ -40,18 +40,26 @@ step_git_safe_directory() {
     fi
 }
 
-# Global gitignore — prevent accidental commit of secrets files
-# Belt + suspenders: even if project .gitignore is modified or missing,
-# mcp.json, .env, and credential files are NEVER committable.
+# Global gitignore — additional layer of protection against accidental secret commits.
+# Primary protection is git-guard.sh (PreToolUse hook) which scans staged content
+# for token patterns and blocks commits. This global gitignore is a secondary layer.
 step_git_global_ignore() {
     local IGNORE_DIR="/home/vscode/.config/git"
     local IGNORE_FILE="$IGNORE_DIR/ignore"
-    mkdir -p "$IGNORE_DIR"
-    cat > "$IGNORE_FILE" << 'IGNOREEOF'
-# Global gitignore — managed by DevContainer (never commit secrets)
-# This file is the last line of defense against accidental token leaks.
-# Even `git add -f` respects global gitignore (only `--no-exclude` bypasses).
+    local MARKER="# managed-by: devcontainer-template"
 
+    mkdir -p "$IGNORE_DIR" || { log_error "Failed to create $IGNORE_DIR"; return 1; }
+
+    # If file exists and already has our managed block, skip (idempotent)
+    if [ -f "$IGNORE_FILE" ] && grep -qF "$MARKER" "$IGNORE_FILE" 2>/dev/null; then
+        log_info "Global gitignore already configured"
+        return 0
+    fi
+
+    # Append our patterns (preserve any existing user patterns)
+    cat >> "$IGNORE_FILE" << IGNOREEOF
+
+$MARKER
 # MCP configs (contain API tokens)
 mcp.json
 .mcp.json
@@ -59,9 +67,9 @@ mcp.json
 
 # Environment files (contain secrets)
 .env
-.env.local
-.env.*.local
+.env.*
 **/.env
+**/.env.*
 
 # Credential files
 **/credentials.json
@@ -73,7 +81,8 @@ mcp.json
 # 1Password
 **/op-session-*
 IGNOREEOF
-    git config --global core.excludesfile "$IGNORE_FILE"
+
+    git config --global core.excludesfile "$IGNORE_FILE" || { log_error "Failed to set core.excludesfile"; return 1; }
     log_success "Global gitignore configured ($IGNORE_FILE)"
 }
 


### PR DESCRIPTION
## Summary

Embed a global gitignore in the Docker image lifecycle (postCreate.sh) so it survives container rebuilds.

## Protected patterns
- mcp.json (API tokens)
- .env files (secrets)  
- credentials.json, service-account.json (cloud creds)
- *.pem, id_rsa, id_ed25519 (private keys)
- op-session-* (1Password)

## Test plan
- [x] Function tested locally
- [x] All 30 hook tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
What
Embeds a managed global gitignore into the DevContainer postCreate lifecycle by adding a step (step_git_global_ignore) that configures ~/.config/git/ignore with patterns preventing accidental commits of common secrets and private keys.

Why
Adds defense‑in‑depth against accidental credential/token/key commits that project .gitignore may miss or lose—survives container rebuilds and complements the existing git-guard hook.

How
- Creates /home/vscode/.config/git/ignore (mkdir -p) and appends a marker-managed block (preserves existing user entries via cat >>).
- Idempotent: skips re-appending if the marker "# managed-by: devcontainer-template" is present.
- Sets git config --global core.excludesfile to the ignore file; errors from mkdir or git config return nonzero.
- Patterns added: mcp.json/.mcp.json/**/mcp.json; .env and .env.* variants and their **/ counterparts; **/credentials.json, **/service-account.json; **/*.pem, **/id_rsa, **/id_ed25519; **/op-session-*.
- Integrated into postCreate.sh execution flow as "Git global gitignore" alongside other Git steps. All 30 hook tests pass locally.

Risk
- Security-sensitive: touches exclusion of auth/credential/private-key files (reduces accidental exposure but does not replace scanning hooks); note that excludesfile can be bypassed by explicit git add --no-exclude.
- No public API or new dependencies introduced.
- Migration/rollback: idempotent marker ensures no duplicate entries; rollback requires removing the managed block and unsetting core.excludesfile if desired.
- No database, concurrency, or supply-chain changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->