### PR TITLE
fix(grepai): add comprehensive vendor/cache exclusions for all languages

### DIFF
--- a/.devcontainer/images/grepai.config.yaml
+++ b/.devcontainer/images/grepai.config.yaml
@@ -248,10 +248,10 @@ ignore:
   - "*.egg-info"
   - "*.whl"
 
-  # Go
+  # Go (vendor covers Go + PHP)
   - vendor
   - go.sum
-  - pkg
+  - pkg/mod
 
   # Rust
   - target
@@ -306,12 +306,12 @@ ignore:
   - .bundle
   - Gemfile.lock
 
-  # PHP
-  - vendor
+  # PHP (vendor already covered by Go section)
   - composer.lock
 
-  # .NET / C#
-  - bin
+  # .NET / C# (bin/obj are build outputs, not source)
+  - "**/bin/Debug"
+  - "**/bin/Release"
   - obj
   - "*.nupkg"
   - packages


### PR DESCRIPTION
## Summary

Add 40+ missing ignore patterns to grepai config to prevent indexing vendor/cache directories.

## Why

Opening a project with node_modules, .next, Pods, or .terraform causes grepai to index thousands of irrelevant files, making it extremely slow.

## Added exclusions

| Category | Patterns |
|----------|----------|
| JS frameworks | .next, .nuxt, .svelte-kit, .angular, .turbo, .vercel, .docusaurus |
| Minified | *.min.js, *.min.css, *.map, *.chunk.js, *.bundle.js |
| Python | .tox, .nox, .pixi, __pypackages__, site-packages, *.whl |
| Rust | .cargo |
| Swift/iOS | Pods, DerivedData, *.dSYM |
| Android | *.aar, *.apk |
| .NET | obj, packages, *.nupkg |
| IaC | .terraform, .terragrunt-cache, *.tfstate |
| Binaries | *.dll, *.exe, *.wasm |
| Caches | .parcel-cache, .sass-cache, .eslintcache, storybook-static |

## Test plan
- [x] YAML valid (grepai loads config without error)
- [x] Runtime config synced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**What:** Add 40+ ignore patterns to grepai config to comprehensively exclude vendor/cache, build artifacts, and dependency output directories across many ecosystems.

**Why:** To stop excessive indexing of large directories (e.g., node_modules, .next, Pods, .terraform) that slow down IDE/project opening and search performance.

**How:** Expanded `.devcontainer/images/grepai.config.yaml`'s `ignore` section with targeted globs for JS frameworks (.next, .nuxt, .svelte-kit, .angular, .turbo, .vercel, .docusaurus), minified/bundled files (*.min.js, *.min.css, *.map, *.chunk.js, *.bundle.js), Python envs and artifacts (.tox, .nox, __pypackages__, site-packages, *.whl), Rust/Go caches (.cargo, pkg/mod — preserves Go source packages), Swift/iOS (Pods, DerivedData, *.dSYM), Android (*.aar, *.apk), .NET (obj, packages, *.nupkg; replaced broad bin exclusion with targeted bin/Debug|Release patterns), IaC (.terraform, .terragrunt-cache, *.tfstate), binaries (*.dll, *.exe, *.wasm), and other build/cache dirs (.parcel-cache, .sass-cache, .eslintcache, storybook-static). Also normalized YAML nesting/quoting for `embedder`, `store`, `chunking`, `watch`, `search`, `trace`, and `update`. Small edits: replaced broad `pkg` with `pkg/mod`, removed duplicate PHP `vendor` entry.

**Risk:** Configuration-only change; non-breaking. Primary impacts:
- Caching/indexing: previously indexed vendor/build artifacts will be excluded — projects may need their search/index to be rebuilt or adjusted if a necessary file is unintentionally ignored.
- No auth/crypto/secrets, database migrations, concurrency, supply-chain dependency additions, or public API changes introduced.
Validation: YAML loads without error and runtime config synced. If exclusions are too broad, patterns can be refined or reverted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->