### PR TITLE
chore(deps): pin tests workflow actions to latest versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,11 +12,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Bats
         id: setup-bats
-        uses: bats-core/bats-action@5b1e60c2ee94cb1b44a616ea4b1f466f9d6e38ef # v4.0.0
+        uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # v4.1.0
 
       - name: Run tests
         env:
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: coverage-report
           path: ./coverage/


### PR DESCRIPTION
## Summary

Pin all GitHub Actions in tests.yml to latest SHA versions, aligning with docker-images.yml and release.yml.

| Action | Before | After |
|--------|--------|-------|
| actions/checkout | v4 (unpinned) | v6.0.2 (SHA pinned) |
| bats-core/bats-action | v4.0.0 | v4.1.0 (SHA pinned) |
| actions/upload-artifact | v4 (SHA pinned) | v7.0.0 (SHA pinned) |

**Supersedes:** #258, #259, #260 (dependabot PRs)

## Test plan
- [ ] CI tests pass with updated actions