### PR TITLE
fix(features): separate OCI namespace from Docker image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,42 +7,42 @@
   "features": {
     // ========== LANGUAGES ==========
     // Node.js enabled by default (required for MCP servers)
-    "ghcr.io/kodflow/devcontainer-template/nodejs:1": {},
+    "ghcr.io/kodflow/devcontainer-features/nodejs:1": {},
     // Uncomment other languages as needed
-    // "ghcr.io/kodflow/devcontainer-template/c:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/cpp:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/java:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/csharp:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/python:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/go:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/rust:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/ruby:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/php:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/elixir:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/scala:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/dart-flutter:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/kotlin:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/swift:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/r:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/perl:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/lua:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/fortran:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/ada:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/cobol:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/pascal:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/vbnet:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/matlab:1": {},
-    // "ghcr.io/kodflow/devcontainer-template/assembly:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/c:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/cpp:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/java:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/csharp:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/python:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/go:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/rust:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/ruby:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/php:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/elixir:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/scala:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/dart-flutter:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/kotlin:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/swift:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/r:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/perl:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/lua:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/fortran:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/ada:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/cobol:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/pascal:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/vbnet:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/matlab:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/assembly:1": {},
     // ========== BROWSER ==========
     // Browser automation with Playwright (chromium + MCP server)
-    // "ghcr.io/kodflow/devcontainer-template/browser:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/browser:1": {},
     // ========== KUBERNETES ==========
     // Local Kubernetes development with kind (requires docker-outside-of-docker)
-    "ghcr.io/kodflow/devcontainer-template/kubernetes:1": {},
+    "ghcr.io/kodflow/devcontainer-features/kubernetes:1": {},
     // ========== INFRASTRUCTURE ==========
     // Infra tools: terragrunt, tflint, infracost, cfssl, ansible-lint, molecule
     // Recommended companions: python (for ansible-lint/molecule), go (for Terratest)
-    // "ghcr.io/kodflow/devcontainer-template/infrastructure:1": {},
+    // "ghcr.io/kodflow/devcontainer-features/infrastructure:1": {},
     // ========== NETWORKING ==========
     // VPN clients (OpenVPN, WireGuard, IPsec, PPTP) are built into the base image
     // Configure credentials in .env with op:// references (see .env.example)

--- a/.devcontainer/features/infrastructure/CLAUDE.md
+++ b/.devcontainer/features/infrastructure/CLAUDE.md
@@ -41,7 +41,7 @@ Enable in `devcontainer.json`:
 
 ```json
 "features": {
-  "ghcr.io/kodflow/devcontainer-template/infrastructure:1": {
+  "ghcr.io/kodflow/devcontainer-features/infrastructure:1": {
     "terragruntVersion": "latest",
     "tflintVersion": "latest",
     "infracostVersion": "latest",

--- a/.devcontainer/features/kubernetes/CLAUDE.md
+++ b/.devcontainer/features/kubernetes/CLAUDE.md
@@ -33,7 +33,7 @@ Enable in `devcontainer.json`:
 
 ```json
 "features": {
-  "ghcr.io/kodflow/devcontainer-template/kubernetes:1": {
+  "ghcr.io/kodflow/devcontainer-features/kubernetes:1": {
     "kindVersion": "latest",
     "enableHelm": true,
     "enableRegistry": true

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -32,7 +32,7 @@ CI/CD automation for the devcontainer template.
 
 - **Trigger**: Push to main (features changed), workflow_dispatch
 - **Action**: Flattens features, embeds shared utils, publishes as OCI artifacts
-- **Registry**: `ghcr.io/kodflow/devcontainer-template/<feature>:v<version>`
+- **Registry**: `ghcr.io/kodflow/devcontainer-features/<feature>:v<version>`
 - **Uses**: `devcontainers/action@v1`
 
 ## release.yml

--- a/.github/workflows/publish-features.yml
+++ b/.github/workflows/publish-features.yml
@@ -49,6 +49,6 @@ jobs:
           publish-features: true
           base-path-to-features: src
           oci-registry: ghcr.io
-          features-namespace: kodflow/devcontainer-template
+          features-namespace: kodflow/devcontainer-features
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ Les langages sont ajoutés via **DevContainer Features** selon vos besoins :
 ```jsonc
 // Dans devcontainer.json, décommenter les langages souhaités :
 "features": {
-  "ghcr.io/kodflow/devcontainer-template/go:1": {},
-  "ghcr.io/kodflow/devcontainer-template/python:1": {},
-  "ghcr.io/kodflow/devcontainer-template/rust:1": {}
+  "ghcr.io/kodflow/devcontainer-features/go:1": {},
+  "ghcr.io/kodflow/devcontainer-features/python:1": {},
+  "ghcr.io/kodflow/devcontainer-features/rust:1": {}
 }
 ```
 
-25 langages disponibles sur `ghcr.io/kodflow/devcontainer-template/`
+25 langages disponibles sur `ghcr.io/kodflow/devcontainer-features/`
 
 ## Installation
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -76,7 +76,7 @@ In `devcontainer.json`, uncomment features as needed:
     "ghcr.io/devcontainers/features/node:1": {},
 
     // Uncomment for local Kubernetes
-    // "ghcr.io/kodflow/devcontainer-template/kubernetes:latest": {
+    // "ghcr.io/kodflow/devcontainer-features/kubernetes:latest": {
     //     "kindVersion": "0.31.0",
     //     "kubectlVersion": "1.35.0"
     // },


### PR DESCRIPTION
## Summary

- **Root cause**: `devcontainers/action@v1` publishes a collection manifest at the namespace root (`ghcr.io/kodflow/devcontainer-template:latest`), overwriting the Docker image with a devcontainer OCI artifact (`application/vnd.devcontainers`). This breaks `docker compose build` with: `encountered unknown type application/vnd.devcontainers; children may not be fetched`
- **Fix**: Move features namespace from `kodflow/devcontainer-template` to `kodflow/devcontainer-features` so Docker image and devcontainer features use separate GHCR paths
- **Files**: Updated `publish-features.yml`, `devcontainer.json`, and all docs referencing the old namespace

## Changes

| File | Change |
|------|--------|
| `.github/workflows/publish-features.yml` | `features-namespace: kodflow/devcontainer-features` |
| `.devcontainer/devcontainer.json` | All feature refs updated (28 occurrences) |
| `.devcontainer/features/*/CLAUDE.md` | Example snippets updated |
| `.github/workflows/CLAUDE.md` | Registry docs updated |
| `README.md` | Feature usage examples updated |
| `docs/getting-started/configuration.md` | Config example updated |

## Post-merge actions

1. Delete the stale GHCR package at `ghcr.io/kodflow/devcontainer-template:latest` (the devcontainer collection artifact) from GitHub Packages settings
2. Re-trigger `docker-images.yml` workflow to republish the real Docker image
3. Features will auto-publish at new namespace on next push to main

## Test plan

- [ ] Verify `publish-features.yml` publishes to `ghcr.io/kodflow/devcontainer-features/`
- [ ] Verify `docker-images.yml` re-publishes Docker image at `ghcr.io/kodflow/devcontainer-template:latest`
- [ ] Verify devcontainer builds successfully with `devcontainer up`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What
Relocates DevContainer features from the Docker image namespace to a separate GHCR namespace (`ghcr.io/kodflow/devcontainer-template` → `ghcr.io/kodflow/devcontainer-features`) to prevent OCI namespace collision.

## Why
The `devcontainers/action@v1` publishes a collection manifest at the GHCR namespace root, which was overwriting the Docker image with a devcontainer OCI artifact (application/vnd.devcontainers) and causing docker compose build failures. Separating the namespaces prevents this collision.

## How
- Updated `publish-features.yml` workflow to set `features-namespace: kodflow/devcontainer-features`
- Updated all 28 feature references in `.devcontainer/devcontainer.json` to point to the new namespace
- Updated all documentation and example snippets in CLAUDE.md files, README.md, and configuration.md to reflect the new registry path

## Risk
**Supply chain update**: Changes GHCR publishing paths for DevContainer features. **Breaking change**: Users referencing the old `ghcr.io/kodflow/devcontainer-template/{feature}` namespace must update to `ghcr.io/kodflow/devcontainer-features/{feature}` (affected count: 25 language features documented).

**Post-merge remediation required**:
1. Delete stale GHCR package `ghcr.io/kodflow/devcontainer-template:latest` (devcontainer collection artifact)
2. Re-trigger `docker-images.yml` workflow to republish Docker image to the now-cleared namespace
3. New features will auto-publish to the new namespace on next push to main

**Caching invalidation**: Existing cached GHCR manifests at the old namespace should be purged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->