### PR TITLE
fix(images): add USER root before grepai/rtk install

### DIFF
--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -25,6 +25,8 @@ ARG GITHUB_TOKEN=
 # Set to current date (YYYY-MM-DD) during scheduled builds to pull latest versions.
 ARG CACHE_BUST_DYNAMIC=stable
 
+USER root
+
 # =============================================================================
 # Dynamic Binary Tools (grepai, rtk) — kubectl/helm/bazelisk/yq are in base
 # =============================================================================


### PR DESCRIPTION
## Summary

- Base image (`Dockerfile.base`) ends with `USER vscode`
- Main image `RUN` step writes grepai/rtk to `/usr/local/bin` which requires root
- This caused `tar: Permission denied` in CI after the two-tier image split (#270)

## Fix

Add `USER root` before the grepai/rtk install step.

## Test plan

- [ ] Verify docker-images.yml build succeeds
- [ ] Verify `ghcr.io/kodflow/devcontainer-template:latest` is published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**What**
Add `USER root` directive before grepai/rtk binary installation in the Docker image build.

**Why**
The base image (`Dockerfile.base`) ends with `USER vscode`, but the subsequent `RUN` step in the main Dockerfile installs grepai and rtk by extracting tarballs to `/usr/local/bin`, which requires root-level permissions. This permission mismatch caused `tar: Permission denied` errors in CI after the two-tier image split (referenced in #270).

**How**
Insert `USER root` immediately after the `ARG CACHE_BUST_DYNAMIC` declaration (line 28) and before the dynamic binary tools installation section. The image later switches back to `USER vscode` for Claude Code installation, then returns to `USER root` for system configuration tasks, maintaining the original execution context flow.

**Risk**
Low. This is a build-time permission fix with no runtime impact. The image still drops privileges to the `vscode` user at runtime (set in `devcontainer.json` via `remoteUser`). No breaking changes or migration required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->