### PR TITLE
docs(claude): bot reviews are non-binding + free-write contexts/plans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,17 @@ Branch conventions: `feat/<desc>` or `fix/<desc>`, commit prefix matches.
 
 **Deep reasoning**: For complex tasks — Peek, Decompose, Parallelize, Synthesize.
 
+**Bot reviews are signal, not orders**: CodeRabbit, Qodo, Codacy and similar AI review bots produce useful hints but their findings are **non-binding**. Triage with judgment — never blindly iterate on every comment. Reject (with a short rationale) any finding that is:
+- A style nitpick, not a real bug
+- Defensive hardening against a threat model that does not apply (e.g., `mktemp` in a root-only devcontainer build)
+- A false positive (run the actual linter / test before accepting the bot's claim)
+- An out-of-scope rewrite that would expand the PR beyond its original intent
+- The third+ new demand on the same PR — after two rounds of fixes, stop, respond with rationale, and merge
+
+If the CI bot says "no" and you have verified the code is correct, the CI is wrong. Post the rationale, move on, merge.
+
+**Intended working directories are writeable without prompting**: `.claude/contexts/` (search outputs), `.claude/plans/` (planning mode), and other agent-managed working directories are configured as writeable in `~/.claude/settings.json`. Never treat them as "sensitive" — they are the agent's scratchpad. If a permission prompt fires for these paths, fix the settings, do not ask the user.
+
 ## Safeguards
 
 Ask before:
@@ -61,6 +72,9 @@ Ask before:
 - Dropping database state, force-push, dependency downgrades
 
 Investigate before deleting unfamiliar state (branches, lock files, unknown files) — it may be user work-in-progress.
+
+Never ask for:
+- Writing new files under `.claude/contexts/` or `.claude/plans/` (configured as free-write in `~/.claude/settings.json`)
 
 When refactoring: move content to separate files, preserve logic.
 


### PR DESCRIPTION
## Summary

- Add a "Bot reviews are signal, not orders" principle to `CLAUDE.md`: CI bots (CodeRabbit, Qodo, Codacy) are non-binding. Triage with judgment, reject nitpicks/false-positives/out-of-scope rewrites with a short rationale, and do not let AI reviewers drive endless PR iterations (stop after the 2nd round of new demands).
- Add an "Intended working directories are writeable without prompting" principle: `.claude/contexts/` and `.claude/plans/` are agent-managed scratchpads, not sensitive files. The user-level `~/.claude/settings.json` is being updated out-of-band to grant `Write`/`Edit` on these paths.
- Add a "Never ask for" subsection in `Safeguards` listing the free-write paths so the contract is visible at a glance.

## Context

Surfaced while merging #302, which went through five rounds of CodeRabbit/Qodo iterations — most of the post-first-round findings were style nitpicks, defensive hardening against non-applicable threat models, or plain false positives. Each round blocked the merge and added churn. Codifying the principle here so the next PR does not repeat the pattern.

## Test plan

- [ ] `CLAUDE.md` still renders cleanly on GitHub
- [ ] Section `Key Principles` contains the two new bullets
- [ ] Section `Safeguards` has the new `Never ask for` subsection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What
Clarifies in CLAUDE.md that CI bots (CodeRabbit, Qodo, Codacy) are non-binding signals and adds agent-managed writeable working directories (.claude/contexts/ and .claude/plans/) plus a "Never ask for" subsection in Safeguards.

## Why
Following PR #302, which required five rounds of bot-driven iterations dominated by style nitpicks, non-applicable hardening, and false positives, this PR codifies triage rules to reduce merge churn and keep maintainers in control.

## How
Documentation-only edits to CLAUDE.md:
- Adds a "Bot reviews are signal, not orders" principle requiring maintainers to reject low-value style nits, irrelevant defensive hardening, confirmed false positives (require lint/test proof), out-of-scope rewrites, and to stop after a second round of new demands—provide brief rationale when rejecting.
- Declares .claude/contexts/ and .claude/plans/ as agent-managed writable scratchpads (configured via ~/.claude/settings.json) and permits mkdir -p to avoid permission prompts.
- Adds a "Never ask for" subsection in Safeguards listing those free-write paths for visibility.

## Risk
Low — documentation-only change. No code, secrets/auth/crypto, database, concurrency, or supply-chain impacts; no new dependencies or public API changes. The only operational note is that the guidance treats specific .claude subpaths as writable by agents; this is a policy change (not an implementation change) and should be reviewed if operational security policies require stricter controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->