### PR TITLE
fix(agent-teams): sanitize inputs, portable version check, NONE enforcement, teammate timeouts

### DIFF
--- a/.devcontainer/images/.claude/commands/infra.md
+++ b/.devcontainer/images/.claude/commands/infra.md
@@ -155,7 +155,7 @@ Each task embeds a task-contract v1 block:
 - `access_mode: "read-only"` for plan/validate operations (default)
 - `access_mode: "write"` with explicit `owned_paths` for apply operations (user confirmation required)
 
-Wait for all teammates → aggregate plan outputs → Phase 4.0 validation. Token ceiling ≤ 2x (cloud ops are IO-bound).
+Wait for all teammates (timeout: 300s per teammate, 600s total) → aggregate plan outputs → Phase 4.0 validation. Token ceiling ≤ 2x (cloud ops are IO-bound). If a teammate fails to report within timeout, proceed with partial results and log a warning.
 
 ---
 

--- a/.devcontainer/images/.claude/commands/review/triage.md
+++ b/.devcontainer/images/.claude/commands/review/triage.md
@@ -325,10 +325,12 @@ Create an agent team for this review. Spawn 5 teammates and have each claim its 
 Wait for all 5 teammates to stop before synthesizing. Do NOT do the review work yourself.
 ```
 
-**Step 3 — Wait + collect + cleanup**:
-- Wait for all 5 TeammateIdle events
+**Step 3 — Wait + collect + cleanup** (bounded):
+- Wait for TeammateIdle events (timeout: 120s per teammate, 300s total)
+- If a teammate times out: proceed with partial results, annotate missing agents in report
 - Collect teammate reports from shared task list
 - Pass findings to Phase 11.0 (Merge & Dedupe) — same schema as SUBAGENTS path
+- If 0 reports received (all timed out): fall back to SUBAGENTS path
 - Call team cleanup when done
 
 After Phase 10.0 TEAMS completes, **skip directly to Phase 11.0** (the SUBAGENTS block below is the fallback, not additive).

--- a/.devcontainer/images/.claude/scripts/task-created.sh
+++ b/.devcontainer/images/.claude/scripts/task-created.sh
@@ -36,7 +36,10 @@ fi
 
 SUBJECT=$(printf '%s' "$INPUT"     | jq -r '.task_subject // ""' 2>/dev/null)
 DESCRIPTION=$(printf '%s' "$INPUT" | jq -r '.task_description // ""' 2>/dev/null)
+# Sanitize team_name to prevent path traversal
 TEAM=$(printf '%s' "$INPUT"        | jq -r '.team_name // "default"' 2>/dev/null)
+TEAM=$(echo "$TEAM" | tr -cd 'A-Za-z0-9._-' | head -c 64)
+TEAM="${TEAM:-default}"
 TASK_ID=$(printf '%s' "$INPUT"     | jq -r '.task_id // ""' 2>/dev/null)
 TEAMMATE=$(printf '%s' "$INPUT"    | jq -r '.teammate_name // ""' 2>/dev/null)
 

--- a/.devcontainer/images/.claude/scripts/team-mode-primitives.sh
+++ b/.devcontainer/images/.claude/scripts/team-mode-primitives.sh
@@ -84,6 +84,13 @@ detect_runtime_mode() {
     cap=$(cat "${HOME}/.claude/.team-capability" 2>/dev/null || echo NONE)
     team_mode_debug_log "capability-read: $cap"
 
+    # Kill switch: NONE means hard-disable, always SUBAGENTS
+    if [ "$cap" = "NONE" ]; then
+        team_mode_debug_log "runtime-mode: SUBAGENTS (capability=NONE, kill switch)"
+        echo "SUBAGENTS"
+        return
+    fi
+
     # Env flag required for any TEAMS mode
     if [ "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}" != "1" ]; then
         team_mode_debug_log "runtime-mode: SUBAGENTS (env flag off)"
@@ -95,7 +102,7 @@ detect_runtime_mode() {
     if command -v claude >/dev/null 2>&1; then
         local current min="2.1.32"
         current=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-        if [ -z "$current" ] || ! printf '%s\n%s\n' "$min" "$current" | sort -VC 2>/dev/null; then
+        if [ -z "$current" ] || ! version_at_least "$min" "$current"; then
             team_mode_debug_log "runtime-mode: SUBAGENTS (claude=${current:-none} < $min)"
             echo "SUBAGENTS"
             return
@@ -195,5 +202,16 @@ version_at_least() {
     # Strip any pre-release suffix (e.g. 2.1.32-beta → 2.1.32)
     current=$(printf '%s' "$current" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' | head -1)
     [ -z "$current" ] && return 1
-    printf '%s\n%s\n' "$required" "$current" | sort -VC 2>/dev/null
+    # Portable version comparison (works on GNU, BSD, busybox, Alpine)
+    local IFS=.
+    set -- $required
+    local r1="${1:-0}" r2="${2:-0}" r3="${3:-0}"
+    set -- $current
+    local c1="${1:-0}" c2="${2:-0}" c3="${3:-0}"
+    [ "$c1" -gt "$r1" ] && return 0
+    [ "$c1" -lt "$r1" ] && return 1
+    [ "$c2" -gt "$r2" ] && return 0
+    [ "$c2" -lt "$r2" ] && return 1
+    [ "$c3" -ge "$r3" ] && return 0
+    return 1
 }

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -291,6 +291,16 @@ classify_terminal_install() {
 
 detect_agent_teams_support() {
     local min="2.1.32"
+    # Portable version comparison (works on GNU, BSD, busybox, Alpine)
+    _version_gte() {
+        local IFS=.
+        set -- $1; local r1="${1:-0}" r2="${2:-0}" r3="${3:-0}"
+        set -- $2; local c1="${1:-0}" c2="${2:-0}" c3="${3:-0}"
+        [ "$c1" -gt "$r1" ] && return 0; [ "$c1" -lt "$r1" ] && return 1
+        [ "$c2" -gt "$r2" ] && return 0; [ "$c2" -lt "$r2" ] && return 1
+        [ "$c3" -ge "$r3" ] && return 0; return 1
+    }
+
     local cap="NONE"
     local current=""
     local reason=""
@@ -310,7 +320,7 @@ detect_agent_teams_support() {
         if [ -z "$current" ]; then
             cap="NONE"
             reason="claude CLI not found or version unreadable"
-        elif ! printf '%s\n%s\n' "$min" "$current" | sort -VC 2>/dev/null; then
+        elif ! _version_gte "$min" "$current"; then
             cap="NONE"
             reason="claude $current < required $min"
         else


### PR DESCRIPTION
## Summary

- Sanitize team_name in task-created.sh to prevent path traversal
- Enforce NONE capability as hard kill switch in detect_runtime_mode
- Replace sort -VC with portable IFS-based version comparison (GNU/BSD/busybox/Alpine)
- Add teammate wait timeouts to prevent deadlocks in /infra and /review

## Test plan

- [ ] task-created.sh rejects team_name with ../
- [ ] echo NONE > ~/.claude/.team-capability forces SUBAGENTS mode
- [ ] version_at_least works on Alpine (busybox sort)
- [ ] /review TEAMS mode times out gracefully if teammate crashes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What

Fix agent-teams mode robustness and portability by: (1) sanitizing team_name input against path traversal, (2) enforcing NONE capability as a hard-kill switch to SUBAGENTS mode, (3) replacing non-portable `sort -VC` with a manual semver comparison, and (4) adding timeout-with-fallback logic for teammate coordination to prevent deadlocks.

## Why

The changes address four distinct reliability and security concerns:
- **Security**: team_name passed directly to file operations can be exploited for path traversal attacks.
- **Portability**: `sort -VC` is unavailable or incompatible on Alpine/busybox-based systems, blocking version detection entirely.
- **Availability**: Indefinite waits for teammate reports can deadlock the agent when a teammate crashes, leaving the primary agent stuck.
- **Override mechanism**: NONE capability needs explicit enforcement as a kill switch to force SUBAGENTS fallback mode.

## How

- **task-created.sh**: Sanitizes `team_name` using `tr -cd` to allow only `[A-Za-z0-9._-]` and truncates to 64 chars; defaults to `"default"` if empty.
- **team-mode-primitives.sh**: 
  - Adds early NONE check in `detect_runtime_mode()` that immediately returns SUBAGENTS if capability file contains `NONE`.
  - Replaces `sort -VC` version check with portable `version_at_least()` helper that parses major.minor.patch components and compares numerically.
- **install.sh**: Adds inline `_version_gte()` helper using the same portable semver logic for Claude version detection.
- **Documentation** (infra.md, review/triage.md): Introduces timeout windows:
  - **infra**: 300s per-teammate + 600s total timeout; continues with partial aggregated results and warning if timeout occurs.
  - **review/triage**: 120s per-teammate + 300s total timeout; falls back to SUBAGENTS path if zero teammate reports received (all timed out).

## Risk

- **Behavioral change — Partial results**: Agent will now proceed with incomplete data if teammates timeout, rather than waiting indefinitely. If downstream phases depend on complete team data, they may produce degraded outputs.
- **Version comparison edge case**: Manual semver parsing may behave differently from `sort -VC` in corner cases (e.g., non-numeric components or single-component versions); ensure test coverage on Alpine and target platforms.
- **Timeout tuning**: 120s/300s review timeouts may be too aggressive in high-latency environments; monitor for false negatives.
- **NONE enforcement**: Immediate switch to SUBAGENTS bypasses all mode detection; verify this is the intended behavior when NONE is set and that no stateful mode configuration depends on the detection flow.

**Breaking change note**: Code paths relying on indefinite teammate waits will now receive timeouts; review downstream aggregation logic for robustness to partial/missing reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->