### PR TITLE
fix(ci): make main image build wait for base image rebuild

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -143,10 +143,14 @@ jobs:
   # Main image: dynamic layers (Claude, grepai, rtk) — rebuilt daily
   # =============================================================================
   build:
-    # Skip if this is a base-only build (weekly schedule)
+    # Wait for base image if it's being rebuilt; skip waiting otherwise
+    needs: merge-base
     if: >-
+      always() &&
       github.repository == 'kodflow/devcontainer-template' &&
-      github.event.schedule != '0 3 * * 0'
+      github.event.schedule != '0 3 * * 0' &&
+      (needs.merge-base.result == 'success' || needs.merge-base.result == 'skipped') &&
+      !failure() && !cancelled()
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

- Add `needs: merge-base` to `build` job so main image waits for base rebuild
- Use `always()` + result check so build still runs when base is skipped (daily builds)
- Fixes race condition where main image builds against stale base during full rebuild

## Test plan

- [ ] `workflow_dispatch` with `rebuild_base=true`: build waits for merge-base
- [ ] Push to main (no [base]): build runs immediately (merge-base skipped)
- [ ] Weekly schedule: only base builds (build skipped as before)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**What**
The `build` job in the Docker images workflow now explicitly depends on the `merge-base` job with updated conditional logic to prevent building the main image against a stale base image.

**Why**
Addresses a race condition where during a full rebuild (triggered with `rebuild_base=true`), the main image build could start before the base image rebuild completes, causing it to use an outdated base image. The workflow dispatch mechanism needs explicit job ordering to handle this scenario.

**How**
- Added `needs: merge-base` to explicitly declare the job dependency
- Updated the `if` condition to use `always()` (allowing evaluation even when skipped) combined with status checks (`needs.merge-base.result == 'success' || needs.merge-base.result == 'skipped'`)
- Added `!failure() && !cancelled()` guards to prevent execution if the base job fails or is cancelled
- Preserved existing schedule-based exclusion logic for weekly base-only builds

**Risk**
Minimal risk. This is a CI workflow orchestration change with no code, dependency, or security implications. The `always()` pattern with status conditionals is a standard Kubernetes/GitHub Actions practice. Rollback is straightforward—removing the `needs` clause and reverting the `if` condition returns to the previous behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->