### PR TITLE
fix(ci): add always() to merge job for skipped base builds

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -265,7 +265,11 @@ jobs:
   # Merge main image architectures into multi-arch manifest
   # =============================================================================
   merge:
-    if: github.repository == 'kodflow/devcontainer-template' && github.event_name != 'pull_request'
+    if: >-
+      always() &&
+      github.repository == 'kodflow/devcontainer-template' &&
+      github.event_name != 'pull_request' &&
+      needs.build.result == 'success'
     runs-on: ubuntu-latest
     needs: build
     permissions:


### PR DESCRIPTION
## Summary

- Add `always()` + `needs.build.result == 'success'` to `merge` job
- Fixes: merge was skipped when base jobs were skipped (workflow_dispatch without rebuild_base)
- Same pattern as the `build` job fix from PR #307

## Test plan

- [ ] `workflow_dispatch` with `rebuild_base=false`: merge runs after build succeeds
- [ ] `workflow_dispatch` with `rebuild_base=true`: full chain base→build→merge
- [ ] Push to main: merge runs normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**What**
The `merge` job condition in the Docker images workflow now includes `always()` and requires `needs.build.result == 'success'` to ensure it runs even when preceding jobs are skipped.

**Why**
The `merge` job was being skipped when base builds were not triggered (e.g., during `workflow_dispatch` with `rebuild_base=false`), preventing manifest merges from completing. This change mirrors the fix applied to the `build` job in PR #307.

**How**
Updated the job condition predicate to evaluate with `always()` while enforcing `needs.build.result == 'success'`. The updated condition also maintains existing repository and event type checks (`github.repository == 'kodflow/devcontainer-template'` and `github.event_name != 'pull_request'`).

**Risk**
This is a CI/workflow configuration change with minimal operational risk. No code modifications, no dependencies added, no API surface changes, and no security-sensitive operations affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->