### PR TITLE
fix(ci): rename main digests to avoid collision with base artifacts

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -256,7 +256,7 @@ jobs:
         if: github.event_name != 'pull_request' && steps.base-check.outputs.available == 'true'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: digests-${{ steps.platform.outputs.pair }}
+          name: digests-main-${{ steps.platform.outputs.pair }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -281,7 +281,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: /tmp/digests
-          pattern: digests-*
+          pattern: digests-main-*
           merge-multiple: true
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Summary

- Rename build artifacts from `digests-{platform}` to `digests-main-{platform}`
- Update merge job download pattern from `digests-*` to `digests-main-*`
- Fixes: merge job was downloading both base AND main digests, then failing because base digests don't exist in the main image registry

## Root cause

`digests-*` pattern matched both `digests-base-linux-amd64` (base build) and `digests-linux-amd64` (main build). The merge job tried to create a manifest with base digests against the main image registry, causing "not found" errors.

## Test plan

- [ ] Full rebuild with `rebuild_base=true`: all 6 jobs succeed
- [ ] Normal push: build + merge succeed (base skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**What**  
Renamed main image digest artifacts from `digests-{platform}` to `digests-main-{platform}` and updated the corresponding download pattern to match.

**Why**  
The previous artifact naming pattern (`digests-*`) matched both base digests (named `digests-base-{platform}`) and main digests, causing the merge job to download base digests instead of main digests. This led to "not found" errors when attempting to create a manifest against the main image registry, since base digests do not exist in the main registry.

**How**  
Updated two locations in `.github/workflows/docker-images.yml`:
- The main build job's upload step now uses `name: digests-main-${{ steps.platform.outputs.pair }}` instead of `digests-${{ steps.platform.outputs.pair }}`
- The merge job's download step now uses `pattern: digests-main-*` instead of `digests-*`

**Risk**  
No breaking changes or migration required. This is a self-contained CI/CD artifact naming change with no impact on external consumers or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->