### PR TITLE
feat(devcontainer): accelerate rebuild with volume sync and binary-only tools

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -86,7 +86,7 @@
   // ========== LIFECYCLE COMMANDS ==========
   // Hooks are embedded in the Docker image at /etc/devcontainer-hooks/
   // Only initialize.sh runs on the host (before container build)
-  "waitFor": "postCreateCommand",
+  "waitFor": "onCreateCommand",
   "initializeCommand": "[ -f \"${localWorkspaceFolder}/.devcontainer/hooks/lifecycle/initialize.sh\" ] && bash \"${localWorkspaceFolder}/.devcontainer/hooks/lifecycle/initialize.sh\" || true",
   "onCreateCommand": "/etc/devcontainer-hooks/lifecycle/onCreate.sh",
   "updateContentCommand": "/etc/devcontainer-hooks/lifecycle/updateContent.sh",

--- a/.devcontainer/features/languages/go/install.sh
+++ b/.devcontainer/features/languages/go/install.sh
@@ -237,18 +237,26 @@ echo -e "${GREEN}✓ All Go tools installed${NC}"
 # Install Wails v2 + TinyGo in parallel
 # ─────────────────────────────────────────────────────────────────────────────
 
-# Wails v2 (Desktop GUI Framework)
+# Wails v2 (Desktop GUI Framework) — binary from GitHub Releases, fallback go install
 (
     echo -e "${YELLOW}Installing Wails v2 (desktop GUI framework)...${NC}"
-    if go install github.com/wailsapp/wails/v2/cmd/wails@latest; then
-        if command -v wails &> /dev/null; then
-            WAILS_VERSION=$(wails version 2>/dev/null | head -n 1 || echo "installed")
-            echo -e "${GREEN}✓ Wails ${WAILS_VERSION}${NC}"
-        else
-            echo -e "${YELLOW}⚠ Wails installed but not in PATH yet${NC}"
+    WAILS_VERSION=$(get_github_latest_version_or_empty "wailsapp/wails")
+    WAILS_INSTALLED=false
+    if [[ -n "$WAILS_VERSION" ]]; then
+        WAILS_URL="https://github.com/wailsapp/wails/releases/download/v${WAILS_VERSION}/wails-linux-${GO_ARCH}"
+        if curl -fsSL --connect-timeout 10 --max-time 60 -o "$GOPATH/bin/wails" "$WAILS_URL" 2>/dev/null; then
+            chmod +x "$GOPATH/bin/wails"
+            echo -e "${GREEN}✓ Wails v${WAILS_VERSION} (binary)${NC}"
+            WAILS_INSTALLED=true
         fi
-    else
-        echo -e "${YELLOW}⚠ Wails installation failed${NC}"
+    fi
+    if [[ "$WAILS_INSTALLED" != "true" ]]; then
+        echo -e "${YELLOW}  Fallback to go install...${NC}"
+        if go install github.com/wailsapp/wails/v2/cmd/wails@latest; then
+            echo -e "${GREEN}✓ Wails installed (compiled)${NC}"
+        else
+            echo -e "${YELLOW}⚠ Wails installation failed${NC}"
+        fi
     fi
 ) &
 WAILS_PID=$!
@@ -314,6 +322,10 @@ echo "  - GOPATH: $GOPATH"
 echo "  - GOCACHE: $GOCACHE"
 echo "  - GOMODCACHE: $GOMODCACHE"
 echo ""
+
+# Write version marker for volume sync (Phase 2 acceleration)
+sudo mkdir -p /opt/devcontainer-versions
+go version 2>/dev/null | sudo tee /opt/devcontainer-versions/go >/dev/null
 
 # Install ktn-linter MCP fragment (feature-level, only when Go is enabled)
 # JSON is inlined because OCI feature artifacts don't include mcp.json files

--- a/.devcontainer/features/languages/rust/install.sh
+++ b/.devcontainer/features/languages/rust/install.sh
@@ -118,9 +118,12 @@ CORE_TOOLS=(
     cargo-watch       # Auto-rebuild on file changes
     cargo-nextest     # Fast test runner
     cargo-deny        # Dependency security + license checker
-    cargo-outdated    # Dependency update checker
-    cargo-tarpaulin   # Code coverage tool
-    wasm-bindgen-cli  # JS bindings generator for WASM
+)
+
+BINSTALL_ONLY_TOOLS=(
+    cargo-outdated    # Dependency update checker (skip if no binary — 3min compile)
+    cargo-tarpaulin   # Code coverage tool (skip if no binary — 5min compile)
+    wasm-bindgen-cli  # JS bindings generator (skip if no binary — 3min compile)
 )
 
 # Phase 1: Parallel binstall (fast binary downloads)
@@ -148,7 +151,7 @@ for i in "${!BINSTALL_PIDS[@]}"; do
     fi
 done
 
-# Phase 2: Sequential fallback for failures (cargo install)
+# Phase 2: Sequential fallback for CORE tools only (cargo install)
 for tool in "${TOOLS_TO_RETRY[@]}"; do
     echo -e "${YELLOW}Compiling ${tool} (no binary available)...${NC}"
     if cargo install --locked "$tool" 2>/dev/null; then
@@ -156,6 +159,19 @@ for tool in "${TOOLS_TO_RETRY[@]}"; do
     else
         warn "${tool} failed"
         FAILED_TOOLS+=("$tool")
+    fi
+done
+
+# Phase 3: Binary-only tools (skip compilation — too slow for devcontainer builds)
+for tool in "${BINSTALL_ONLY_TOOLS[@]}"; do
+    if command -v "${tool}" &>/dev/null 2>&1; then
+        ok "${tool} (cached)"
+        continue
+    fi
+    if cargo binstall --no-confirm --disable-strategies compile "$tool" 2>/dev/null; then
+        ok "${tool} (binary)"
+    else
+        warn "${tool}: no pre-built binary, install with: cargo install ${tool}"
     fi
 done
 
@@ -267,6 +283,10 @@ echo "  - RUSTUP_HOME: $RUSTUP_HOME"
 echo ""
 echo "Note: WebKitGTK/Tauri libs are pre-installed in base image"
 echo ""
+
+# Write version marker for volume sync (Phase 2 acceleration)
+sudo mkdir -p /opt/devcontainer-versions
+{ rustc --version 2>/dev/null; cargo --version 2>/dev/null; } | sudo tee /opt/devcontainer-versions/rust >/dev/null
 
 # Install MCP fragment (rust-analyzer MCP server)
 # JSON is inlined because OCI feature artifacts don't include mcp.json files

--- a/.devcontainer/images/hooks/lifecycle/onCreate.sh
+++ b/.devcontainer/images/hooks/lifecycle/onCreate.sh
@@ -42,4 +42,10 @@ if [ -f "$CLAUDE_FEATURE_DIR/CLAUDE.md" ]; then
     fi
 fi
 
+# Sync toolchains from image to volume (fast if already synced)
+if [ -f "$SCRIPT_DIR/sync-toolchains.sh" ]; then
+    log_info "Syncing toolchains to volume..."
+    bash "$SCRIPT_DIR/sync-toolchains.sh" || log_warn "Toolchain sync had warnings"
+fi
+
 log_success "onCreate: Initial container setup complete"

--- a/.devcontainer/images/hooks/lifecycle/sync-toolchains.sh
+++ b/.devcontainer/images/hooks/lifecycle/sync-toolchains.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# ============================================================================
+# sync-toolchains.sh — Sync toolchains from image to volume on version mismatch
+# Called by onCreateCommand (volumes already mounted)
+#
+# Problem: Features install to ~/.cache/ during build. Volume mounts OVER that
+# path at runtime. On rebuild, the volume has OLD tools.
+#
+# Solution: Features write version markers to /opt/devcontainer-versions/.
+# This script compares with volume markers and re-installs only on mismatch.
+# ============================================================================
+
+set -e
+
+VERSIONS_DIR="/opt/devcontainer-versions"
+CACHE_DIR="${HOME}/.cache"
+
+[ -d "$VERSIONS_DIR" ] || exit 0
+
+sync_lang() {
+    local lang="$1"
+    local image_ver volume_ver
+
+    image_ver=$(cat "${VERSIONS_DIR}/${lang}" 2>/dev/null) || return 0
+    volume_ver=$(cat "${CACHE_DIR}/.toolchain-version-${lang}" 2>/dev/null || echo "")
+
+    if [ "$image_ver" = "$volume_ver" ]; then
+        echo "  ${lang}: up to date (volume cache hit)"
+        return 0
+    fi
+
+    echo "  ${lang}: version mismatch (image=${image_ver} volume=${volume_ver:-none})"
+    echo "  ${lang}: syncing from image..."
+
+    case "$lang" in
+        rust)
+            sync_rust
+            ;;
+        go)
+            sync_go
+            ;;
+        python)
+            sync_python
+            ;;
+        node)
+            sync_node
+            ;;
+        *)
+            echo "  ${lang}: no sync handler, skipping"
+            return 0
+            ;;
+    esac
+
+    echo "$image_ver" > "${CACHE_DIR}/.toolchain-version-${lang}"
+    echo "  ${lang}: synced"
+}
+
+sync_rust() {
+    export CARGO_HOME="${CARGO_HOME:-${CACHE_DIR}/cargo}"
+    export RUSTUP_HOME="${RUSTUP_HOME:-${CACHE_DIR}/rustup}"
+    export PATH="${CARGO_HOME}/bin:${PATH}"
+
+    if ! command -v rustup &>/dev/null; then
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path 2>/dev/null
+    fi
+
+    [ -f "${CARGO_HOME}/env" ] && source "${CARGO_HOME}/env"
+    rustup toolchain install stable --profile minimal 2>/dev/null
+    rustup default stable 2>/dev/null
+    rustup component add rust-analyzer clippy rustfmt 2>/dev/null
+
+    if command -v cargo-binstall &>/dev/null || {
+        curl -L --proto '=https' --tlsv1.2 -sSf \
+            https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash 2>/dev/null
+    }; then
+        local tools=(cargo-watch cargo-nextest cargo-deny)
+        for tool in "${tools[@]}"; do
+            command -v "$tool" &>/dev/null || cargo binstall --no-confirm --locked "$tool" 2>/dev/null || true
+        done
+        local binstall_only=(cargo-outdated cargo-tarpaulin wasm-bindgen-cli cargo-expand)
+        for tool in "${binstall_only[@]}"; do
+            command -v "$tool" &>/dev/null || cargo binstall --no-confirm --disable-strategies compile "$tool" 2>/dev/null || true
+        done
+    fi
+}
+
+sync_go() {
+    export GOROOT="${GOROOT:-/usr/local/go}"
+    export GOPATH="${GOPATH:-${CACHE_DIR}/go}"
+    export GOCACHE="${GOCACHE:-${CACHE_DIR}/go-build}"
+    export PATH="${GOROOT}/bin:${GOPATH}/bin:${PATH}"
+
+    mkdir -p "${GOPATH}/bin"
+
+    if ! command -v go &>/dev/null; then
+        echo "  go: binary missing (requires rebuild)"
+        return 1
+    fi
+
+    local ARCH
+    ARCH=$(uname -m)
+    local GO_ARCH
+    case "$ARCH" in
+        x86_64) GO_ARCH="amd64" ;;
+        aarch64|arm64) GO_ARCH="arm64" ;;
+        *) GO_ARCH="amd64" ;;
+    esac
+
+    local tools=(golangci-lint gosec gofumpt gotestsum goimports ktn-linter)
+    for tool in "${tools[@]}"; do
+        if ! command -v "$tool" &>/dev/null; then
+            echo "    installing ${tool}..."
+            case "$tool" in
+                goimports)
+                    go install golang.org/x/tools/cmd/goimports@latest 2>/dev/null || true
+                    ;;
+                *)
+                    go install "${tool}@latest" 2>/dev/null || true
+                    ;;
+            esac
+        fi
+    done
+}
+
+sync_python() {
+    if ! command -v python3 &>/dev/null; then
+        echo "  python: binary missing (requires rebuild)"
+        return 1
+    fi
+    local tools=(ruff pylint mypy bandit pytest)
+    for tool in "${tools[@]}"; do
+        command -v "$tool" &>/dev/null || python3 -m pip install --quiet "$tool" 2>/dev/null || true
+    done
+}
+
+sync_node() {
+    if ! command -v node &>/dev/null; then
+        echo "  node: binary missing (requires rebuild)"
+        return 1
+    fi
+}
+
+echo "Syncing toolchains (image → volume)..."
+for marker in "${VERSIONS_DIR}"/*; do
+    [ -f "$marker" ] || continue
+    lang=$(basename "$marker")
+    sync_lang "$lang"
+done
+echo "Toolchain sync complete."


### PR DESCRIPTION
## Summary

- Rust: move cargo-outdated, cargo-tarpaulin, wasm-bindgen-cli to binary-only install (skip 8-11 min compilation fallback)
- Go: download wails binary from GitHub Releases instead of `go install` (skip ~2 min compilation)
- Add `sync-toolchains.sh`: volume-aware toolchain sync comparing version markers between image and volume
- Features write version markers to `/opt/devcontainer-versions/` for sync detection
- Change `waitFor` to `onCreateCommand` so terminal is available during post-create hooks

## Test plan

- [ ] Rebuild devcontainer with Rust feature enabled — verify cargo tools install via binstall (no compilation)
- [ ] Rebuild devcontainer with Go feature enabled — verify wails installs from binary
- [ ] Second rebuild without version changes — verify sync-toolchains.sh skips (volume cache hit)
- [ ] Verify terminal available during postCreateCommand execution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What
Accelerates devcontainer rebuild cycles by implementing binary-only downloads for three Rust tools (cargo-outdated, cargo-tarpaulin, wasm-bindgen-cli) and the Go wails binary, paired with a new volume-aware toolchain sync mechanism that skips reinstalls when version markers match between the container image and mounted cache.

## Why
Current rebuilds take 15–20 minutes due to slow fallback compilation of Rust tools and Go wails via `go install`. Binary downloads combined with persistent volume caching enable subsequent rebuilds with unchanged versions to complete in ~30 seconds, and rebuilds with new versions in 3–5 minutes.

## How
- **Rust tools**: Modified `install.sh` to disable compilation strategies (`--disable-strategies compile`) for three specified tools, logging a warning and fallback instruction when no pre-built binary is available.
- **Go wails**: Changed `install.sh` to attempt platform-specific binary download from GitHub Releases first, falling back to `go install` only on failure.
- **Lifecycle hook reordering**: Changed `devcontainer.json` `waitFor` from `postCreateCommand` to `onCreateCommand` to ensure terminal availability.
- **Volume sync**: Added `.devcontainer/images/hooks/lifecycle/sync-toolchains.sh`—a 149-line Bash script that:
  - Reads per-language version markers from `/opt/devcontainer-versions/` (written by install scripts)
  - Compares against cached markers in `~/.cache/.toolchain-version-<lang>`
  - Re-installs language toolchains (Rust, Go, Python, Node) only on mismatch
  - Updates cache markers on successful sync
- Both install scripts now write version markers (`rustc --version`, `cargo --version`, `go version`) to `/opt/devcontainer-versions/` for sync detection.
- Modified `onCreate.sh` to invoke `sync-toolchains.sh` as an optional post-setup step.

## Risk
**Caching invalidation**: The entire rebuild acceleration strategy depends on reliable version marker creation and comparison. If markers are missing, corrupted, or inconsistent between image and volume, sync logic fails silently (warnings logged, but rebuilds proceed). Volume cache pollution or stale markers could cause out-of-date toolchains to persist across rebuilds.

**Supply chain**: Wails and Rust tool binaries are now downloaded directly from GitHub Releases without checksum verification. No integrity checks are performed on downloaded binaries, increasing exposure to compromised releases or network-in-the-middle attacks.

**Fallback behavior**: Rust tools with `--disable-strategies compile` will fail entirely if no pre-built binary exists, breaking builds for unsupported architectures or platforms without pre-release binaries. Users must manually invoke `cargo install` with fallback enabled.

**Lifecycle ordering**: Moving `waitFor` to `onCreateCommand` changes initialization sequencing; if `onCreateCommand` fails or hangs, `postCreateCommand` may execute in an undefined state or with unavailable resources.

**Silent failures**: The `sync-toolchains.sh` script logs warnings but continues on non-zero exit (e.g., if `go`, `python3`, or `node` binaries are missing during sync). This could mask environment setup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->