### PR TITLE
feat(update): preserve per-project adjustments via devcontainer.local.json

### DIFF
--- a/.devcontainer/CLAUDE.md
+++ b/.devcontainer/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- updated: 2026-04-10T12:00:00Z -->
+<!-- updated: 2026-04-18T00:00:00Z -->
 # DevContainer Configuration
 
 ## Purpose
@@ -9,11 +9,12 @@ Development container setup for consistent dev environments across languages.
 
 ```text
 .devcontainer/
-├── devcontainer.json    # Main config
-├── docker-compose.yml   # Multi-service setup
-├── Dockerfile           # Extends images/ base
-├── install.sh           # Standalone Claude installer
-├── scripts/             # Build utilities
+├── devcontainer.json         # Main config (synced from template on /update)
+├── devcontainer.local.json   # Optional per-project overrides (preserved across /update)
+├── docker-compose.yml        # Multi-service setup
+├── Dockerfile                # Extends images/ base
+├── install.sh                # Standalone Claude installer
+├── scripts/                  # Build utilities
 │   └── generate-assets-archive.sh
 ├── features/            # Language & tool features
 │   ├── languages/       # 25 languages + shared/
@@ -45,3 +46,33 @@ Development container setup for consistent dev environments across languages.
 
 Features are enabled in `devcontainer.json` under `features`.
 Language conventions are enforced by specialist agents (e.g., `developer-specialist-go`).
+
+## Local Overrides (`devcontainer.local.json`)
+
+`/update` re-syncs `devcontainer.json` from the template on every run. To persist
+per-project adjustments (enabled features, extra extensions, custom env vars),
+create `.devcontainer/devcontainer.local.json` — a strict JSON file with only the
+keys you want to override or add. The update flow deep-merges template + override
+(override wins) and writes the result to `devcontainer.json`.
+
+- No override file → template copied verbatim (JSONC comments preserved)
+- Override file present → merged JSON written (comments stripped)
+- Arrays are replaced wholesale (not concatenated) — copy template defaults if you need them
+- Commit `devcontainer.local.json` so teammates get the same toolchain
+
+Example (`.devcontainer/devcontainer.local.json`):
+
+```json
+{
+  "features": {
+    "ghcr.io/kodflow/devcontainer-features/go:1": {},
+    "ghcr.io/kodflow/devcontainer-features/python:1": { "version": "3.12" }
+  },
+  "customizations": {
+    "vscode": { "extensions": ["golang.go", "ms-python.python"] }
+  }
+}
+```
+
+Merge logic lives in `images/scripts/merge-devcontainer-json.mjs`, wired from
+`images/.claude/commands/update/apply.md` (`update_devcontainer_json_from_tarball`).

--- a/.devcontainer/images/.claude/commands/update/apply.md
+++ b/.devcontainer/images/.claude/commands/update/apply.md
@@ -158,10 +158,9 @@ apply_devcontainer_tarball() {
         echo "  ✓ templates"
     fi
 
-    # devcontainer.json (container only - update feature refs)
+    # devcontainer.json (container only - merge template + local override)
     if [ "$CONTEXT" = "container" ] && [ -f "$src/.devcontainer/devcontainer.json" ]; then
-        cp -f "$src/.devcontainer/devcontainer.json" ".devcontainer/devcontainer.json"
-        echo "  ✓ devcontainer.json"
+        update_devcontainer_json_from_tarball "$src"
     fi
 
     # Dockerfile (container only - update FROM reference)
@@ -328,6 +327,55 @@ update_compose_from_tarball() {
     else
         mv "$backup_file" "$compose_file"
         echo "  ✗ Compose validation failed, restored backup"
+        return 1
+    fi
+}
+```
+
+### 5.3.1: devcontainer.json merge (from tarball)
+
+```bash
+# Merge template devcontainer.json with local override
+# - Template: structure, feature refs (GHCR URLs), lifecycle commands → always updated
+# - devcontainer.local.json (optional, project-managed): enabled features with options,
+#   custom extensions, env vars, mounts → always preserved across /update runs
+#
+# No override file → template copied as-is (preserves JSONC comments for discovery)
+# Override file exists → deep merge written as strict JSON (comments stripped)
+update_devcontainer_json_from_tarball() {
+    local src="$1"
+    local template_file="$src/.devcontainer/devcontainer.json"
+    local target_file=".devcontainer/devcontainer.json"
+    local override_file=".devcontainer/devcontainer.local.json"
+    local merge_script="$src/.devcontainer/images/scripts/merge-devcontainer-json.mjs"
+
+    if [ ! -f "$override_file" ]; then
+        # Advisory: warn if local diverges from template — user likely needs a local override
+        if [ -f "$target_file" ] && ! cmp -s "$target_file" "$template_file"; then
+            echo "  ⚠ devcontainer.json differs from template and no devcontainer.local.json found"
+            echo "    Local customizations will be overwritten. To preserve them, create"
+            echo "    .devcontainer/devcontainer.local.json with your overrides (see .devcontainer/CLAUDE.md)."
+        fi
+        cp -f "$template_file" "$target_file"
+        echo "  ✓ devcontainer.json (template, no override)"
+        return 0
+    fi
+
+    if ! command -v node >/dev/null 2>&1 || [ ! -f "$merge_script" ]; then
+        echo "  ⚠ devcontainer.json merge skipped (node or merge script missing); copying template"
+        cp -f "$template_file" "$target_file"
+        return 0
+    fi
+
+    local backup_file="${target_file}.backup"
+    [ -f "$target_file" ] && cp "$target_file" "$backup_file"
+
+    if node "$merge_script" "$template_file" "$override_file" "$target_file" 2>/dev/null; then
+        rm -f "$backup_file"
+        echo "  ✓ devcontainer.json (template + devcontainer.local.json merged)"
+    else
+        [ -f "$backup_file" ] && mv "$backup_file" "$target_file"
+        echo "  ✗ devcontainer.json merge failed, restored backup"
         return 1
     fi
 }

--- a/.devcontainer/images/scripts/merge-devcontainer-json.mjs
+++ b/.devcontainer/images/scripts/merge-devcontainer-json.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/*
+ * Deep-merges a JSONC template with a JSON override.
+ * Template wins on structure/refs (feature URLs, lifecycle commands);
+ * override wins on user choices (enabled features, extensions, env).
+ *
+ * Usage: node merge-devcontainer-json.mjs <template.jsonc> <override.json> <output.json>
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+
+function stripJsonc(src) {
+  let out = "";
+  let i = 0;
+  const n = src.length;
+  let inString = false;
+  let stringChar = "";
+  while (i < n) {
+    const c = src[i];
+    const next = src[i + 1];
+    if (inString) {
+      out += c;
+      if (c === "\\" && i + 1 < n) {
+        out += src[i + 1];
+        i += 2;
+        continue;
+      }
+      if (c === stringChar) inString = false;
+      i++;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      inString = true;
+      stringChar = c;
+      out += c;
+      i++;
+      continue;
+    }
+    if (c === "/" && next === "/") {
+      while (i < n && src[i] !== "\n") i++;
+      continue;
+    }
+    if (c === "/" && next === "*") {
+      i += 2;
+      while (i < n && !(src[i] === "*" && src[i + 1] === "/")) i++;
+      i += 2;
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out.replace(/,(\s*[\]}])/g, "$1");
+}
+
+function deepMerge(base, over) {
+  if (over === undefined) return base;
+  if (Array.isArray(over)) return over;
+  if (over === null || typeof over !== "object") return over;
+  if (base === null || typeof base !== "object" || Array.isArray(base)) {
+    return { ...over };
+  }
+  const out = { ...base };
+  for (const k of Object.keys(over)) {
+    out[k] = deepMerge(base[k], over[k]);
+  }
+  return out;
+}
+
+const [, , tmplPath, overPath, outPath] = process.argv;
+if (!tmplPath || !overPath || !outPath) {
+  console.error(
+    "usage: merge-devcontainer-json.mjs <template> <override> <output>",
+  );
+  process.exit(2);
+}
+
+const tmpl = JSON.parse(stripJsonc(readFileSync(tmplPath, "utf8")));
+const over = JSON.parse(readFileSync(overPath, "utf8"));
+const merged = deepMerge(tmpl, over);
+
+writeFileSync(outPath, JSON.stringify(merged, null, 2) + "\n");

--- a/.devcontainer/tests/unit/test-merge-devcontainer-json.sh
+++ b/.devcontainer/tests/unit/test-merge-devcontainer-json.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# Tests for .devcontainer/images/scripts/merge-devcontainer-json.mjs
+
+set +e
+
+SCRIPT="/workspace/.devcontainer/images/scripts/merge-devcontainer-json.mjs"
+if [ ! -f "$SCRIPT" ]; then
+    echo "FATAL: merge script not found at $SCRIPT"
+    exit 1
+fi
+if ! command -v node >/dev/null 2>&1; then
+    echo "SKIP: node not available"
+    exit 0
+fi
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+pass() { echo "  ✓ $1"; PASS=$((PASS + 1)); }
+fail() { echo "  ✗ $1"; FAIL=$((FAIL + 1)); FAILED_TESTS+=("$1"); }
+
+TMPDIR_T=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_T"' EXIT
+
+run_merge() {
+    local tmpl="$TMPDIR_T/template.json"
+    local over="$TMPDIR_T/override.json"
+    local out="$TMPDIR_T/out.json"
+    printf '%s' "$1" > "$tmpl"
+    printf '%s' "$2" > "$over"
+    node "$SCRIPT" "$tmpl" "$over" "$out" 2>&1
+    cat "$out" 2>/dev/null
+}
+
+test_jsonc_comments_stripped() {
+    echo "=== jsonc-comments-stripped ==="
+    local tmpl='{
+  // line comment
+  /* block
+     comment */
+  "name": "base",
+  "features": {
+    // "ghcr.io/x/go:1": {}
+  }
+}'
+    local over='{}'
+    local out
+    out=$(run_merge "$tmpl" "$over")
+    if echo "$out" | jq -e '.name == "base"' >/dev/null 2>&1; then
+        pass "comments stripped, JSON parseable"
+    else
+        fail "comments stripped (got: $out)"
+    fi
+}
+
+test_url_double_slash_preserved() {
+    echo "=== url-double-slash-preserved ==="
+    local tmpl='{"url": "https://example.com/path"}'
+    local over='{}'
+    local out
+    out=$(run_merge "$tmpl" "$over")
+    if echo "$out" | jq -e '.url == "https://example.com/path"' >/dev/null 2>&1; then
+        pass "URL with // preserved inside string"
+    else
+        fail "URL mangled (got: $out)"
+    fi
+}
+
+test_trailing_commas_tolerated() {
+    echo "=== trailing-commas-tolerated ==="
+    local tmpl='{"a": 1, "b": [1, 2,], "c": {"x": 1,},}'
+    local over='{}'
+    local out
+    out=$(run_merge "$tmpl" "$over")
+    if echo "$out" | jq -e '.a == 1 and .b[1] == 2 and .c.x == 1' >/dev/null 2>&1; then
+        pass "trailing commas accepted"
+    else
+        fail "trailing commas (got: $out)"
+    fi
+}
+
+test_deep_merge_objects() {
+    echo "=== deep-merge-objects ==="
+    local tmpl='{"features": {"ghcr.io/x/node:1": {}, "ghcr.io/x/k8s:1": {}}}'
+    local over='{"features": {"ghcr.io/x/go:1": {}, "ghcr.io/x/python:1": {"version": "3.12"}}}'
+    local out
+    out=$(run_merge "$tmpl" "$over")
+    local node go py_ver
+    node=$(echo "$out" | jq -r '.features."ghcr.io/x/node:1"')
+    go=$(echo "$out" | jq -r '.features."ghcr.io/x/go:1"')
+    py_ver=$(echo "$out" | jq -r '.features."ghcr.io/x/python:1".version')
+    if [ "$node" = "{}" ] && [ "$go" = "{}" ] && [ "$py_ver" = "3.12" ]; then
+        pass "deep merge: template feature kept + override features added with options"
+    else
+        fail "deep merge (node=$node go=$go py=$py_ver)"
+    fi
+}
+
+test_arrays_replaced_not_concatenated() {
+    echo "=== arrays-replaced ==="
+    local tmpl='{"forwardPorts": [80, 443]}'
+    local over='{"forwardPorts": [3000]}'
+    local out
+    out=$(run_merge "$tmpl" "$over")
+    local len first
+    len=$(echo "$out" | jq '.forwardPorts | length')
+    first=$(echo "$out" | jq '.forwardPorts[0]')
+    if [ "$len" = "1" ] && [ "$first" = "3000" ]; then
+        pass "arrays replaced (override wins)"
+    else
+        fail "arrays should replace (len=$len first=$first)"
+    fi
+}
+
+test_override_wins_on_scalars() {
+    echo "=== override-wins-scalars ==="
+    local tmpl='{"remoteUser": "vscode", "shutdownAction": "none"}'
+    local over='{"remoteUser": "root"}'
+    local out
+    out=$(run_merge "$tmpl" "$over")
+    local user shut
+    user=$(echo "$out" | jq -r .remoteUser)
+    shut=$(echo "$out" | jq -r .shutdownAction)
+    if [ "$user" = "root" ] && [ "$shut" = "none" ]; then
+        pass "override wins on scalars, template kept where absent"
+    else
+        fail "scalar merge (user=$user shut=$shut)"
+    fi
+}
+
+test_missing_args_fails() {
+    echo "=== missing-args-fails ==="
+    if node "$SCRIPT" 2>/dev/null; then
+        fail "should fail without args"
+    else
+        pass "exits non-zero without args"
+    fi
+}
+
+test_nested_vscode_settings() {
+    echo "=== nested-vscode-settings ==="
+    local tmpl='{"customizations": {"vscode": {"settings": {"editor.formatOnSave": true}, "extensions": ["a"]}}}'
+    local over='{"customizations": {"vscode": {"settings": {"editor.tabSize": 2}}}}'
+    local out
+    out=$(run_merge "$tmpl" "$over")
+    local fos ts ext
+    fos=$(echo "$out" | jq -r '.customizations.vscode.settings."editor.formatOnSave"')
+    ts=$(echo "$out" | jq -r '.customizations.vscode.settings."editor.tabSize"')
+    ext=$(echo "$out" | jq -r '.customizations.vscode.extensions[0]')
+    if [ "$fos" = "true" ] && [ "$ts" = "2" ] && [ "$ext" = "a" ]; then
+        pass "nested merge: template settings kept, override settings added, extensions array preserved when not overridden"
+    else
+        fail "nested merge (fos=$fos ts=$ts ext=$ext)"
+    fi
+}
+
+echo "═══════════════════════════════════════════════"
+echo "  merge-devcontainer-json — Unit Tests"
+echo "═══════════════════════════════════════════════"
+
+test_jsonc_comments_stripped
+test_url_double_slash_preserved
+test_trailing_commas_tolerated
+test_deep_merge_objects
+test_arrays_replaced_not_concatenated
+test_override_wins_on_scalars
+test_missing_args_fails
+test_nested_vscode_settings
+
+echo ""
+echo "═══════════════════════════════════════════════"
+TOTAL=$((PASS + FAIL))
+echo "  Results: $PASS/$TOTAL passed ($FAIL failed)"
+if [ "$FAIL" -gt 0 ]; then
+    echo "  Failed tests:"
+    for t in "${FAILED_TESTS[@]}"; do
+        echo "    - $t"
+    done
+fi
+echo "═══════════════════════════════════════════════"
+
+exit $FAIL

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -44,7 +44,7 @@
     "*.sh": "${capture}.bats, ${capture}_test.sh, ${capture}.bash, ${capture}.zsh",
     "*.bash": "${capture}_test.sh, ${capture}.bats",
     "install.sh": "devcontainer-feature.json, mcp.json, README.md, NOTES.md",
-    "devcontainer.json": "docker-compose.yml, docker-compose.*.yml, Dockerfile, Dockerfile.*, .env, .env.*",
+    "devcontainer.json": "devcontainer.local.json, devcontainer.*.json, .template-version, docker-compose.yml, docker-compose.*.yml, Dockerfile, Dockerfile.*, .env, .env.*",
     "Dockerfile.base": "Dockerfile, .dockerignore, docker-compose.yml, mcp.json.tpl, .p10k.zsh, grepai.config.yaml"
   },
   "files.exclude": {


### PR DESCRIPTION
## Summary

- `/update` no longer blindly overwrites `devcontainer.json`; when `.devcontainer/devcontainer.local.json` is present, the template and override are deep-merged (override wins) so project features/extensions survive upgrades
- Merge script `merge-devcontainer-json.mjs` uses a string-aware JSONC parser (handles `//` inside URLs, block/line comments, trailing commas)
- Safety advisory warns if `devcontainer.json` diverges from template without an override file, pointing users to create one
- `.vscode/settings.json` now nests `devcontainer.local.json`, `devcontainer.*.json`, `.template-version` under `devcontainer.json`
- Pattern documented in `.devcontainer/CLAUDE.md` with usage example
- 8 unit tests covering comments, URL edge cases, trailing commas, deep merge, array replacement

## Test plan

- [ ] `bash .devcontainer/tests/unit/test-merge-devcontainer-json.sh` → 8/8 pass
- [ ] Run `/update` on a project without `devcontainer.local.json` → template copied verbatim (JSONC comments preserved)
- [ ] Run `/update` on a project with `devcontainer.local.json` enabling Go → Go feature retained post-update, template refs still refreshed
- [ ] Run `/update` on a project whose `devcontainer.json` diverges with no override → advisory warning shown before overwrite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**What**  
Adds an opt-in override mechanism (`devcontainer.local.json`) that enables dev container customizations (features, extensions) to persist across template updates via deep merge instead of file overwrite.

**Why**  
Projects maintain per-project adjustments (e.g., enabled language features) that would otherwise be lost when `/update` syncs `devcontainer.json` from the template. This provides a non-destructive update path while keeping the template in sync.

**How**  
- New Node.js CLI script (`merge-devcontainer-json.mjs`) implements a string-aware JSONC parser and recursive deep-merge logic where override values win over template values and arrays are replaced wholesale. The parser correctly handles line comments (`//`), block comments (`/* */`), and string literals with escape sequences to avoid stripping `//` within URLs.
- Updated `/update` flow in `apply.md` to detect `devcontainer.local.json` and conditionally call the merge script; falls back to template copy if Node is unavailable.
- Adds a safety advisory warning if `devcontainer.json` diverges from template and no override file exists, guiding users to create one.
- Merged output becomes strict JSON with JSONC comments stripped.
- Documented the pattern in `CLAUDE.md` with usage guidance and updated `.vscode/settings.json` to nest related files under `devcontainer.json`.
- Added 8 unit tests covering comment handling, URL edge cases, trailing commas, deep merge, and array replacement behavior.

**Risk**  
- **New runtime dependency**: Node.js required for merge functionality (graceful fallback to template copy if unavailable).
- **Output format change**: Merged JSON strips JSONC comments and becomes strict JSON; projects relying on comment preservation in merged files will lose them.
- **Behavioral change**: `/update` behavior differs based on override file existence—without migration guidance, users unfamiliar with the feature may not understand why their customizations persist.
- **Rollback consideration**: Projects cannot easily revert to overwrite behavior; would require manual devcontainer.local.json deletion.
- No breaking API changes, authentication/cryptography/secrets changes, database migrations, concurrency concerns, or supply chain updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->