### PR TITLE
chore(deps): bump github actions (supersedes #296, #310, #313)

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -67,7 +67,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -81,7 +81,7 @@ jobs:
 
       - name: Build and push base by digest
         id: build
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .devcontainer/images
           file: .devcontainer/images/Dockerfile.base
@@ -97,7 +97,7 @@ jobs:
           touch "/tmp/digests-base/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-base-${{ steps.platform.outputs.pair }}
           path: /tmp/digests-base/*
@@ -125,7 +125,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -172,7 +172,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -216,7 +216,7 @@ jobs:
       # PR: Build only (no push)
       - name: Build image (PR)
         if: github.event_name == 'pull_request' && steps.base-check.outputs.available == 'true'
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .devcontainer/images
           file: .devcontainer/images/Dockerfile
@@ -232,7 +232,7 @@ jobs:
       - name: Build and push by digest
         if: github.event_name != 'pull_request' && steps.base-check.outputs.available == 'true'
         id: build
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .devcontainer/images
           file: .devcontainer/images/Dockerfile
@@ -254,7 +254,7 @@ jobs:
 
       - name: Upload digest
         if: github.event_name != 'pull_request' && steps.base-check.outputs.available == 'true'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-main-${{ steps.platform.outputs.pair }}
           path: /tmp/digests/*
@@ -288,7 +288,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
           path: ./coverage/


### PR DESCRIPTION
## Summary

Consolidates three open dependabot PRs into a single update.

- `actions/upload-artifact`: v7.0.0 → v7.0.1 (closes #313)
- `docker/build-push-action`: v7.0.0 → v7.1.0 (closes #310)
- `docker/login-action`: v4.0.0 → v4.1.0 (closes #296)

All bumps are pinned by commit SHA with version comment, matching existing repo convention.

## Test plan

- [ ] CI pipeline passes on all jobs (`docker-images.yml`, `tests.yml`)
- [ ] Image build + push succeeds with new `build-push-action` version
- [ ] Coverage artifact upload succeeds with new `upload-artifact` version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What
Consolidates three GitHub Actions dependency updates into a single PR, bumping `docker/login-action` from v4.0.0 to v4.1.0, `docker/build-push-action` from v7.0.0 to v7.1.0, and `actions/upload-artifact` from v7.0.0 to v7.0.1 across CI workflows.

## Why
Supersedes three open dependabot PRs (#296, #310, #313) with consolidated updates to keep GitHub Actions dependencies current. Notable fixes included: docker/login-action v4.1.0 addresses scoped Docker Hub cleanup when registry is omitted; docker/build-push-action v7.1.0 adds Git context query-format URL support; actions/upload-artifact v7.0.1 includes readme updates and typespec dependency bump.

## How
Updated action references in `.github/workflows/docker-images.yml` (bumped `docker/login-action` and `docker/build-push-action` across base, build, and merge jobs) and `.github/workflows/tests.yml` (bumped `actions/upload-artifact` for coverage report upload). All action versions pinned by commit SHA with version comments following the repository's existing convention. No changes to workflow logic, conditions, or step configuration.

## Risk
**Supply chain update**: GitHub Actions dependencies updated; verify CI pipeline passes (docker-images.yml and tests.yml jobs confirmed in test plan). Docker/login-action fix for scoped Docker Hub cleanup is low-risk but ensures correct credential handling. No breaking changes or migration steps required; existing workflows remain unchanged except for action versions. Transitive dependency updates within actions (lodash, glob, undici, vite, aws-sdk clients, proxy agents) have no direct exposure in workflow definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->