### PR TITLE
feat(go): install buildifier + buildozer alongside Go toolchain

### DIFF
--- a/.devcontainer/features/languages/go/install.sh
+++ b/.devcontainer/features/languages/go/install.sh
@@ -166,6 +166,8 @@ GOLANGCI_VERSION=$(get_github_latest_version_or_empty "golangci/golangci-lint")
 GOSEC_VERSION=$(get_github_latest_version_or_empty "securego/gosec")
 GOFUMPT_VERSION=$(get_github_latest_version_or_empty "mvdan/gofumpt")
 GOTESTSUM_VERSION=$(get_github_latest_version_or_empty "gotestyourself/gotestsum")
+# buildifier + buildozer ship from the same bazelbuild/buildtools release.
+BUILDTOOLS_VERSION=$(get_github_latest_version_or_empty "bazelbuild/buildtools")
 
 # gofumpt uses 'v' prefix in URLs
 [[ -n "$GOFUMPT_VERSION" && "$GOFUMPT_VERSION" != v* ]] && GOFUMPT_VERSION="v${GOFUMPT_VERSION}"
@@ -229,6 +231,24 @@ install_go_tool "ktn-linter" \
     "https://github.com/kodflow/ktn-linter/releases/latest/download/ktn-linter-linux-${GO_ARCH}" \
     "" \
     "binary" &
+
+# Bazel tooling — same release ships both binaries.
+if [[ -n "$BUILDTOOLS_VERSION" ]]; then
+    install_go_tool "buildifier" \
+        "https://github.com/bazelbuild/buildtools/releases/download/v${BUILDTOOLS_VERSION}/buildifier-linux-${GO_ARCH}" \
+        "github.com/bazelbuild/buildtools/buildifier" \
+        "binary" &
+    install_go_tool "buildozer" \
+        "https://github.com/bazelbuild/buildtools/releases/download/v${BUILDTOOLS_VERSION}/buildozer-linux-${GO_ARCH}" \
+        "github.com/bazelbuild/buildtools/buildozer" \
+        "binary" &
+else
+    (echo -e "${YELLOW}buildifier/buildozer: version unavailable, building from source...${NC}" && \
+     go install github.com/bazelbuild/buildtools/buildifier@latest && \
+     go install github.com/bazelbuild/buildtools/buildozer@latest && \
+     echo -e "${GREEN}✓ buildifier + buildozer installed (from source)${NC}" || \
+     echo -e "${YELLOW}⚠ buildifier/buildozer: source build failed, skipping${NC}") &
+fi
 
 wait
 echo -e "${GREEN}✓ All Go tools installed${NC}"
@@ -305,7 +325,7 @@ echo "  - ${GO_INSTALLED}"
 echo "  - Go Modules (package manager)"
 echo ""
 echo "Development tools:"
-for _tool in golangci-lint gosec gofumpt goimports gotestsum ktn-linter; do
+for _tool in golangci-lint gosec gofumpt goimports gotestsum ktn-linter buildifier buildozer; do
     if command -v "$_tool" &>/dev/null; then
         echo "  - $_tool (installed)"
     else


### PR DESCRIPTION
Closes #318

## Summary

Adds **buildifier** (gofmt for `BUILD.bazel` / `WORKSPACE` / `*.bzl`) and **buildozer** (scripted BUILD-target editor) to the Go feature. Both binaries ship from the same `bazelbuild/buildtools` release and are installed in parallel via the existing `install_go_tool` helper, with a `go install` fallback when the GitHub API version lookup is rate-limited.

Rationale in the issue: Bazelisk already lives in `Dockerfile.base`, so these two Go-binary companions belong in `features/languages/go` rather than a near-empty `features/bazel`. The patch reuses the existing parallel `&` + `wait` pattern — ~20 lines, no new abstractions.

## Changes

- `features/languages/go/install.sh`:
  - Fetch `BUILDTOOLS_VERSION` via the same non-fatal `get_github_latest_version_or_empty` helper used for the other tools.
  - Install `buildifier` and `buildozer` in parallel (binary release preferred, `go install` fallback).
  - Extend the final inventory loop to report both tools.

## Verification

- `bash -n` passes on the modified script.
- `shellcheck` passes (only pre-existing SC1091 info on sourced files, unchanged).
- Downstream consumer validation: tested in [kitsunium/sdk#8](https://github.com/kitsunium/sdk/pull/8) — both binaries install and run on `linux/arm64`.

## Test plan

- [ ] Rebuild devcontainer with Go feature enabled
- [ ] Confirm logs show `✓ buildifier installed (binary)` and `✓ buildozer installed (binary)`
- [ ] Run `buildifier --version` and `buildozer --version` in the rebuilt container
- [ ] Confirm final inventory lists both tools as `(installed)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What
Added installation of buildifier and buildozer (Bazel companion tools) to the Go development environment feature, fetching them from the bazelbuild/buildtools GitHub release alongside existing Go tooling.

## Why
Closes #318. Provides Bazel build system companion tooling for developers using the template's Bazelisk. buildifier enables formatting of BUILD.bazel/WORKSPACE/\*.bzl files, while buildozer enables scripted BUILD-target editing. These tools are colocated in the Go feature (not a separate Bazel feature) because they are Go binaries and Bazelisk already exists in the base Dockerfile.

## How
- Fetches `BUILDTOOLS_VERSION` using the existing `get_github_latest_version_or_empty` helper (non-blocking if GitHub API is rate-limited or unavailable)
- Installs buildifier and buildozer in parallel using the existing `install_go_tool` helper function (~15 new lines)
- Prefers architecture-specific prebuilt binaries from `bazelbuild/buildtools` GitHub releases (linux-amd64, linux-arm64, linux-riscv64, linux-s390x) with automatic fallback to `go install @latest` when version lookup fails
- Extended the final inventory loop to report both tools as installed/skipped

## Risk
**Supply chain:** Adds dependency on `bazelbuild/buildtools` GitHub releases. Both binaries ship from the same release, so a single version lookup covers both tools. No breaking changes; graceful fallback to `go install` on network issues or rate-limiting. No new external dependencies introduced—uses existing curl-based download infrastructure and optional `go install` fallback already established for other tools. Minimal code footprint (~21 lines net addition) reuses proven parallel installation patterns to avoid first-run slowdowns or CGO issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->