### PR TITLE
feat(sync): harmonize postStart + /update for .devcontainer/features/

### DIFF
--- a/.devcontainer/images/.claude/commands/update/apply.md
+++ b/.devcontainer/images/.claude/commands/update/apply.md
@@ -144,6 +144,23 @@ apply_devcontainer_tarball() {
         echo "  ✓ mcp-fragments"
     fi
 
+    # DevContainer features (container only) — mirror from tarball.
+    # postStart also force-syncs from the image's embedded copy; /update brings
+    # them current immediately without waiting for the next image rebuild.
+    # The updated .template-version written in §5.7 tells postStart to yield
+    # when the repo is ahead of the image.
+    if [ "$CONTEXT" = "container" ] && [ -d "$src/.devcontainer/features" ]; then
+        mkdir -p ".devcontainer/features"
+        if command -v rsync &>/dev/null; then
+            rsync -a --delete "$src/.devcontainer/features/" ".devcontainer/features/"
+        else
+            rm -rf ".devcontainer/features"
+            mkdir -p ".devcontainer/features"
+            cp -rf "$src/.devcontainer/features/." ".devcontainer/features/"
+        fi
+        echo "  ✓ features"
+    fi
+
     # Design patterns docs
     if [ -d "$src/.devcontainer/images/.claude/docs" ]; then
         mkdir -p "$UPDATE_TARGET/docs"
@@ -484,6 +501,7 @@ echo "  ✓ .template-version updated ($DC_COMMIT)"
     ✓ grepai         (bge-m3 config)
     ✓ mcp-template   (mcp.json.tpl)
     ✓ mcp-fragments  (context7, ktn-linter)
+    ✓ features       (devcontainer features, 25 languages)
     ✓ docs           (design patterns KB)
     ✓ templates      (project/docs templates)
     ✓ devcontainer   (feature refs)

--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -74,9 +74,13 @@ COPY --chown=vscode:vscode mcp-fragments/ /etc/mcp/fragments/
 
 # Template features source — force-synced into /workspace/.devcontainer/features/
 # at every postStart (see hooks/lifecycle/postStart.sh step_sync_features).
-# The features/ directory is staged into the build context by CI before build;
-# for local builds run `cp -r .devcontainer/features .devcontainer/images/features` first.
+# The features/ directory and image-template-version.json are staged into the
+# build context by CI before build; for local builds run:
+#   cp -r .devcontainer/features .devcontainer/images/features
+#   printf '{"commit":"local","updated":"1970-01-01T00:00:00Z"}\n' > .devcontainer/images/image-template-version.json
+# The version marker lets postStart skip sync when repo is ahead of image.
 COPY --chown=root:root features/ /etc/devcontainer-template/features/
+COPY --chown=root:root image-template-version.json /etc/devcontainer-template/.template-version
 
 # GrepAI config template (optimized for 12 languages)
 COPY --chown=vscode:vscode grepai.config.yaml /etc/grepai/config.yaml

--- a/.devcontainer/images/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/images/hooks/lifecycle/postStart.sh
@@ -1661,6 +1661,7 @@ step_sync_features() {
         return 0
     fi
 
+    # Self-exclusion: skip if we ARE the template repo (git HEAD matches marker commit).
     if [ -f "$marker" ] && command -v jq &>/dev/null; then
         local marker_commit current_commit
         marker_commit=$(jq -r '.commit // empty' "$marker" 2>/dev/null || true)
@@ -1668,6 +1669,21 @@ step_sync_features() {
         if [ -n "$marker_commit" ] && [ -n "$current_commit" ] && \
            { [[ "$current_commit" == "$marker_commit"* ]] || [[ "$marker_commit" == "$current_commit"* ]]; }; then
             log_info "Template repo detected (template-version matches HEAD), skipping features sync"
+            return 0
+        fi
+    fi
+
+    # /update harmony: skip sync when consumer's .template-version is newer than
+    # the image's embedded version (consumer ran /update on a fresher template).
+    # Syncing would silently regress /update's work.
+    local image_version="/etc/devcontainer-template/.template-version"
+    if [ -f "$marker" ] && [ -f "$image_version" ] && command -v jq &>/dev/null; then
+        local repo_updated image_updated
+        repo_updated=$(jq -r '.updated // empty' "$marker" 2>/dev/null || true)
+        image_updated=$(jq -r '.updated // empty' "$image_version" 2>/dev/null || true)
+        if [ -n "$repo_updated" ] && [ -n "$image_updated" ] && \
+           [[ "$repo_updated" > "$image_updated" ]]; then
+            log_info "Repo template-version ($repo_updated) newer than image ($image_updated), skipping features sync"
             return 0
         fi
     fi

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -213,12 +213,19 @@ jobs:
             echo "value=stable" >> $GITHUB_OUTPUT
           fi
 
-      # Stage .devcontainer/features/ into the image build context so the
-      # Dockerfile COPY can embed them at /etc/devcontainer-template/features/.
-      # (Build context is .devcontainer/images/, features/ lives one level up.)
-      - name: Stage features into build context
+      # Stage .devcontainer/features/ + image-template-version.json into the
+      # build context so the Dockerfile can embed them. Build context is
+      # .devcontainer/images/; features/ and the version marker live one level up.
+      # The version marker lets postStart skip the sync when the consumer has
+      # already pulled a newer template via /update (avoids /update regression).
+      - name: Stage features and image template-version
         if: steps.base-check.outputs.available == 'true'
-        run: cp -r .devcontainer/features .devcontainer/images/features
+        run: |
+          cp -r .devcontainer/features .devcontainer/images/features
+          printf '{"commit": "%s", "updated": "%s"}\n' \
+            "$(echo "${{ github.sha }}" | cut -c1-7)" \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            > .devcontainer/images/image-template-version.json
 
       # PR: Build only (no push)
       - name: Build image (PR)


### PR DESCRIPTION
## Summary

Follow-up to #320. The force-sync on every `postStart` introduced a silent regression window: if a consumer ran `/update` (which pulls a newer template tarball) but the container kept running an older image, the next `postStart` would overwrite `.devcontainer/features/` with the image's stale version — undoing the work `/update` just did.

This PR teaches `postStart` and `/update` to cooperate via a timestamp compare on `.template-version`.

## Behavior matrix

| Scenario | Who syncs `features/` |
|---|---|
| Consumer rebuilds on a newer image | `postStart` (image wins) |
| Consumer runs `/update` without rebuild | `/update` syncs from tarball, `postStart` yields on next start |
| Consumer rebuilds after `/update`, image is now newer | `postStart` (image has caught up) |
| Consumer rebuilds after `/update`, image still older | `postStart` yields (repo is ahead) |

## Changes

- **`docker-images.yml`** — Stage `image-template-version.json` into the build context (commit = `github.sha[:7]`, updated = build time in UTC). Same step that stages `features/`.
- **`Dockerfile`** — `COPY image-template-version.json /etc/devcontainer-template/.template-version`.
- **`postStart.sh` / `step_sync_features`** — new guard compares `repo .updated` (ISO-8601 UTC) vs `image .updated`. If repo is newer, skip sync. Original self-exclusion (commit match for template repo) is preserved.
- **`.claude/commands/update/apply.md`** — `apply_devcontainer_tarball` now rsyncs `.devcontainer/features/` from the tarball (with `cp -rf` fallback). Combined with the existing §5.7 that updates `.template-version`, `postStart` yields until the next image rebuild catches up.

## Test plan

- [ ] CI `docker-images.yml` builds and pushes image with valid `/etc/devcontainer-template/.template-version`
- [ ] `jq -r .updated /etc/devcontainer-template/.template-version` returns a parseable ISO-8601 timestamp
- [ ] Consumer scenario: run `/update` on a stale features/ → verify files refreshed AND `.template-version.updated` advanced
- [ ] Next `postStart` in the same container → verify log says `Repo template-version (…) newer than image (…), skipping features sync`
- [ ] After rebuilding on a newer image, `postStart` resumes syncing
- [ ] `shellcheck` still clean on `postStart.sh`

Closes the regression gap introduced by #320.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**What**
Harmonizes postStart and /update scripts by introducing a version marker (.template-version with updated timestamp) to prevent postStart from force-syncing .devcontainer/features/ and overwriting recent changes from /update.

**Why**
PR #320 introduced a regression where postStart unconditionally syncs .devcontainer/features/ from the image on every start, overwriting newer consumer state from prior /update operations that pulled updated template tarballs.

**How**
- **docker-images.yml**: Generates `image-template-version.json` during build with the current commit SHA and UTC timestamp, staging it into the Docker build context alongside features/.
- **Dockerfile**: Copies the version file into the image at `/etc/devcontainer-template/.template-version`.
- **postStart.sh** (`step_sync_features`): Adds two guards:
  1. Skips sync if consumer's .template-version commit matches template repo's HEAD (existing self-exclusion).
  2. Skips sync if consumer's .template-version `updated` timestamp is newer than the image's embedded timestamp (enables /update to prevent regression).
- **apply.md** (`apply_devcontainer_tarball`): Now also syncs .devcontainer/features/ from the extracted tarball using rsync (with cp -rf fallback) and updates the consumer's .template-version marker.

**Risk**
**Caching invalidation & state machine**: Version comparison logic introduces timestamp-based state evaluation; parsing and comparison of ISO-8601 UTC timestamps via jq is critical—timestamp format and parsing failures must be handled gracefully to avoid silent skipping or incorrect sync behavior. **Supply chain**: Version marker embedded in image and tarball affects build reproducibility and version tracking; timestamp generation at build time could differ between CI runs. **Behavioral change**: postStart now conditionally skips features synchronization based on timestamps—debugging must account for this conditional behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->