### PR TITLE
chore(vscode): hide bazel-* output dirs by default

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -70,7 +70,8 @@
         "files.trimTrailingWhitespace": true,
         "files.exclude": {
           "**/.grepai": true,
-          "**/.git": true
+          "**/.git": true,
+          "bazel-*": true
         }
       },
       "extensions": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -55,7 +55,8 @@
     "**/.pytest_cache": true,
     "**/node_modules": true,
     "**/.rtk": true,
-    "**/.claude/logs": true
+    "**/.claude/logs": true,
+    "bazel-*": true
   },
   "search.exclude": {
     "**/.git": true,
@@ -67,7 +68,8 @@
     "**/.claude/plans": true,
     "**/coverage": true,
     "**/vendor": true,
-    "**/target": true
+    "**/target": true,
+    "bazel-*": true
   },
   "files.associations": {
     "*.toml": "toml",


### PR DESCRIPTION
## Summary

Bazel creates `bazel-bin`, `bazel-out`, `bazel-testlogs`, `bazel-<workspace>` symlinks at the workspace root. They clutter the VSCode file explorer and pollute grep/search results.

## Changes

- `.vscode/settings.json` → add `"bazel-*": true` to both `files.exclude` and `search.exclude`
- `.devcontainer/devcontainer.json` → same in `customizations.vscode.settings.files.exclude` (propagated to consumer projects via `/update --vscode`)

## Test plan

- [ ] Open a Bazel project in the devcontainer → `bazel-bin` etc. not visible in Explorer
- [ ] Search for a string known to exist only in `bazel-bin` → 0 results (not indexed)
- [ ] Consumer runs `/update` on a devcontainer-template fork → their `.vscode/settings.json` gets the new exclusions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What
Extended VS Code workspace settings in `.vscode/settings.json` and `.devcontainer/devcontainer.json` to exclude Bazel-generated directories matching the `bazel-*` glob pattern from both file explorer visibility and search indexing.

## Why
Bazel creates workspace-root symlinks (`bazel-bin`, `bazel-out`, `bazel-testlogs`, `bazel-<workspace>`) that clutter the VSCode Explorer and interfere with search results. These directories are build artifacts and should be hidden by default for better IDE usability.

## How
- Updated `.vscode/settings.json` to add `"bazel-*": true` to both `files.exclude` (preventing visibility in Explorer) and `search.exclude` (preventing search indexing)
- Updated `.devcontainer/devcontainer.json` to add the same `bazel-*` exclusion under `customizations.vscode.settings.files.exclude`, ensuring the setting is propagated to consumer projects when they run the `/update --vscode` mechanism

## Risk
This is a low-risk configuration-only change with no code modifications, new dependencies, or public API changes. The exclusions apply only to VSCode settings and do not affect build processes or the actual Bazel directories on disk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->