### PR TITLE
feat(kubernetes): fall back to preinstalled kubectl when dl.k8s.io is unreachable

### DIFF
--- a/.devcontainer/features/kubernetes/devcontainer-feature.json
+++ b/.devcontainer/features/kubernetes/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "kubernetes",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "name": "Kubernetes Development Environment (kind)",
   "description": "Installs kind, kubectl, and Helm for local Kubernetes development",
   "documentationURL": "https://kind.sigs.k8s.io/",

--- a/.devcontainer/features/kubernetes/install.sh
+++ b/.devcontainer/features/kubernetes/install.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 FEATURE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source-path=SCRIPTDIR
 # shellcheck source=../languages/shared/feature-utils.sh
+source "${FEATURE_DIR}/feature-utils.sh" 2>/dev/null || \
 source "${FEATURE_DIR}/../languages/shared/feature-utils.sh" 2>/dev/null || {
     RED='\033[0;31m'
     GREEN='\033[0;32m'
@@ -284,11 +285,18 @@ else
             sleep $((attempt * 2))
         done
         if [[ -z "$KUBECTL_VERSION" ]]; then
-            echo -e "${RED}✗ Failed to resolve latest kubectl version${NC}"
-            echo -e "${RED}  dl.k8s.io may be rate-limited. Try setting an explicit kubectlVersion.${NC}"
-            exit 1
+            if [[ "$KUBECTL_PREINSTALLED" == "true" ]]; then
+                echo -e "${YELLOW}⚠ Could not resolve latest kubectl version, keeping preinstalled version${NC}"
+            else
+                echo -e "${RED}✗ Failed to resolve latest kubectl version${NC}"
+                echo -e "${RED}  dl.k8s.io may be rate-limited. Try setting an explicit kubectlVersion.${NC}"
+                exit 1
+            fi
         fi
     fi
+
+    # Only proceed with download if we resolved a version
+    if [[ -n "$KUBECTL_VERSION" ]]; then
     [[ "$KUBECTL_VERSION" != v* ]] && KUBECTL_VERSION="v${KUBECTL_VERSION}"
 
     KUBECTL_URL="https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH_KUBECTL}/kubectl"
@@ -305,6 +313,7 @@ else
     else
         echo -e "${RED}✗ kubectl installation failed${NC}"
         exit 1
+    fi
     fi
 fi
 


### PR DESCRIPTION
## Summary
- Bump kubernetes feature to **1.1.0**
- Keep the preinstalled kubectl when `https://dl.k8s.io/release/stable.txt` is unreachable, instead of aborting the devcontainer build (`✗ Failed to resolve latest kubectl version`, exit 1)
- Source `feature-utils.sh` from the flattened OCI layout first, with a fallback to the in-tree `languages/shared/` path for local-feature builds

## Why
Transient failures on `dl.k8s.io/release/stable.txt` broke every fresh devcontainer build because the v1.0.0 `install.sh` aborted even though the base image already shipped a working `kubectl` (`v1.35.4`). See the build log for a reproducer: 3 retries × ~4 s = ~13 s → `exit 1`. The fix only takes effect when kubectl is already present on the image, so explicit `kubectlVersion` pins still fail-fast as before.

## Publishing
Merging to `main` triggers `.github/workflows/publish-features.yml`, which flattens the feature and publishes:
- `ghcr.io/kodflow/devcontainer-features/kubernetes:1`
- `ghcr.io/kodflow/devcontainer-features/kubernetes:1.1.0`

After merge + publish, rebuilding the devcontainer should succeed without any `kubectlVersion` override.

## Test plan
- [x] `bash -n install.sh` (syntax OK)
- [x] `jq . devcontainer-feature.json` (JSON OK)
- [ ] After merge: verify the publish workflow succeeds
- [ ] Devcontainer rebuild passes on `ghcr.io/kodflow/devcontainer-features/kubernetes:1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What
Bumped the Kubernetes devcontainer feature to version 1.1.0 and modified the kubectl installation logic to fall back to the preinstalled kubectl when the remote version endpoint (https://dl.k8s.io/release/stable.txt) is unreachable, rather than failing the build.

## Why
Transient network failures when fetching the stable kubectl version caused fresh devcontainer builds to fail with exit 1, even though the base image already included a working kubectl binary. This PR preserves successful builds when the version endpoint is temporarily unavailable while maintaining strict fail-fast behavior when kubectlVersion is explicitly pinned.

## How
- Added early sourcing of `feature-utils.sh` from the flattened OCI layout with fallback to the in-tree `languages/shared/` path for local builds
- Modified kubectl version resolution failure handling: when version cannot be resolved and `KUBECTL_PREINSTALLED==true`, the script logs a warning and continues; otherwise it exits with the original rate-limiting error
- Adjusted control flow to skip the download/checksum/install block when `KUBECTL_VERSION` is empty, allowing the preinstalled kubectl to remain in use

## Risk
Changes the build's failure semantics from always fail-fast to conditionally resilient when a version cannot be determined and a preinstalled kubectl is available. Builds with explicitly pinned `kubectlVersion` remain unaffected and still fail if the version cannot be installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->