### PR TITLE
fix(go): make Go feature install fail loud instead of silent (closes #324)

### DIFF
--- a/.devcontainer/features/CLAUDE.md
+++ b/.devcontainer/features/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- updated: 2026-04-10T12:00:00Z -->
+<!-- updated: 2026-04-21T15:27:23Z -->
 # DevContainer Features
 
 ## Purpose
@@ -56,3 +56,29 @@ Fragment format:
 2. Add `devcontainer-feature.json` for metadata
 3. Add `install.sh` sourcing `shared/feature-utils.sh`
 4. (Optional) Add `mcp.json` if the language provides an MCP server
+
+## Failure Modes — Fail Loud, Not Silent
+
+Features have ONE job: install the toolchain. A silently-half-installed
+feature produces downstream breakage that is hard to diagnose (issue #324).
+
+Rules for every `install.sh`:
+
+1. **Strict mode** at top of script:
+   ```bash
+   set -Eeuo pipefail
+   trap 'on_error $? $LINENO "$BASH_COMMAND"' ERR
+   ```
+2. **Per-PID tracking** for parallel installs — `wait <pid>` is the only
+   reliable way to surface a subshell failure. A bare `wait` returns 0.
+3. **Critical vs optional** — declare which tools are load-bearing
+   (hooks / MCP depend on them) and `exit 1` when a critical one fails
+   to install.
+4. **Write MCP fragments early** — call `install_mcp_fragment` immediately
+   after the trigger binary is verified, NOT at the end of the script.
+   Otherwise any later failure silently drops the fragment.
+5. **Structured step markers** (e.g. `[INSTALL-GO] step=X status=ok|fail`)
+   so users can grep the devcontainer build log.
+
+Reference implementation: `.devcontainer/features/languages/go/install.sh`.
+Static regression guards: `tests/scripts/go-install.bats`.

--- a/.devcontainer/features/languages/elixir/install.sh
+++ b/.devcontainer/features/languages/elixir/install.sh
@@ -17,8 +17,8 @@ print_banner "Elixir Development Environment" 2>/dev/null || {
 }
 
 # Environment variables (can be overridden)
-export ERLANG_VERSION="${ERLANG_VERSION:-27}"
-export ELIXIR_VERSION="${ELIXIR_VERSION:-1.17.3}"
+export ERLANG_VERSION="${ERLANG_VERSION:-28}"
+export ELIXIR_VERSION="${ELIXIR_VERSION:-1.19.5}"
 export MIX_HOME="${MIX_HOME:-/home/vscode/.cache/mix}"
 export HEX_HOME="${HEX_HOME:-/home/vscode/.cache/hex}"
 export ASDF_DATA_DIR="${ASDF_DATA_DIR:-/home/vscode/.cache/asdf}"

--- a/.devcontainer/features/languages/go/install.sh
+++ b/.devcontainer/features/languages/go/install.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
-set -e
+# =============================================================================
+# Go Development Environment — DevContainer Feature
+# =============================================================================
+# Strict mode: a silent failure here breaks downstream MCP tooling (ktn-linter)
+# and lint hooks. We'd rather fail loud and visible than ship a half-installed
+# container. See GitHub issue #324 for the original silent-skip regression.
+# =============================================================================
+set -Eeuo pipefail
+
+# Global error trap — surfaces the exact line + command that failed so the
+# devcontainer build log pinpoints the regression instead of dying silently.
+on_error() {
+    local code=$1 line=$2 cmd=$3
+    echo -e "\033[0;31m✗ install.sh (go feature) FAILED at line ${line} (exit=${code}): ${cmd}\033[0m" >&2
+    exit "$code"
+}
+trap 'on_error $? $LINENO "$BASH_COMMAND"' ERR
 
 FEATURE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../shared/feature-utils.sh
@@ -32,6 +48,11 @@ source "${FEATURE_DIR}/../shared/feature-utils.sh" 2>/dev/null || {
     }
 }
 
+# Structured step marker — lets users grep the devcontainer build log to see
+# exactly where installation stopped. Keeping the format machine-parseable
+# intentionally (space-delimited key=value).
+step() { echo "[INSTALL-GO] step=$1 status=$2${3:+ detail=$3}"; }
+
 print_banner "Go Development Environment" 2>/dev/null || {
     echo "========================================="
     echo "Installing Go Development Environment"
@@ -48,6 +69,7 @@ export PATH="$GOROOT/bin:$GOPATH/bin:$PATH"
 
 # Install dependencies
 # Includes Wails/WebKitGTK dependencies for Linux desktop apps
+step apt-deps begin
 echo -e "${YELLOW}Installing dependencies...${NC}"
 sudo apt-get update && sudo apt-get install -y \
     curl \
@@ -59,6 +81,7 @@ sudo apt-get update && sudo apt-get install -y \
     libgtk-3-dev \
     libwebkit2gtk-4.1-dev \
     libglib2.0-dev
+step apt-deps ok
 
 # Detect architecture
 ARCH=$(uname -m)
@@ -80,11 +103,19 @@ esac
 
 # Get latest Go version if requested
 if [ "$GO_VERSION" = "latest" ]; then
+    step go-version-resolve begin
     echo -e "${YELLOW}Fetching latest Go version...${NC}"
-    GO_VERSION=$(curl -s https://go.dev/VERSION?m=text | head -n 1 | sed 's/go//')
+    GO_VERSION=$(curl -fsS --connect-timeout 5 --max-time 15 --retry 3 --retry-delay 2 \
+        https://go.dev/VERSION?m=text | head -n 1 | sed 's/go//')
+    if [[ -z "$GO_VERSION" ]]; then
+        err "Failed to resolve latest Go version from go.dev — network or upstream issue."
+        exit 1
+    fi
+    step go-version-resolve ok "$GO_VERSION"
 fi
 
 # Download and install Go
+step go-toolchain begin "$GO_VERSION/$GO_ARCH"
 echo -e "${YELLOW}Installing Go ${GO_VERSION} for ${GO_ARCH}...${NC}"
 GO_TARBALL="go${GO_VERSION}.linux-${GO_ARCH}.tar.gz"
 GO_URL="https://dl.google.com/go/${GO_TARBALL}"
@@ -106,6 +137,7 @@ rm "/tmp/${GO_TARBALL}"
 
 GO_INSTALLED=$(go version)
 echo -e "${GREEN}✓ ${GO_INSTALLED} installed${NC}"
+step go-toolchain ok
 
 # Create necessary directories
 mkdir -p "$GOPATH/bin"
@@ -120,7 +152,8 @@ mkdir -p "$GOMODCACHE"
 echo -e "${YELLOW}Installing Go development tools...${NC}"
 mkdir -p "$HOME/.local/bin"
 
-# Helper function: download from GitHub Releases, fallback to go install
+# Helper function: download from GitHub Releases, fallback to go install.
+# Returns non-zero on failure so the caller's wait <pid> can detect it.
 install_go_tool() {
     local name=$1
     local url=$2
@@ -130,38 +163,69 @@ install_go_tool() {
     echo -e "${YELLOW}Installing ${name}...${NC}"
 
     local tmp_file="/tmp/${name}-download"
+    local installed=0
 
     if curl -fsSL --connect-timeout 10 --max-time 120 "$url" -o "$tmp_file" 2>/dev/null; then
         case "$extract_type" in
             tar.gz)
-                tar -xzf "$tmp_file" -C "$GOPATH/bin/" "$name" 2>/dev/null || \
-                tar -xzf "$tmp_file" --wildcards --strip-components=1 -C "$GOPATH/bin/" "*/$name" 2>/dev/null || \
-                tar -xzf "$tmp_file" -C "/tmp/" && mv "/tmp/$name" "$GOPATH/bin/" 2>/dev/null
+                if tar -xzf "$tmp_file" -C "$GOPATH/bin/" "$name" 2>/dev/null || \
+                   tar -xzf "$tmp_file" --wildcards --strip-components=1 -C "$GOPATH/bin/" "*/$name" 2>/dev/null || \
+                   { tar -xzf "$tmp_file" -C "/tmp/" && mv "/tmp/$name" "$GOPATH/bin/" 2>/dev/null; }; then
+                    installed=1
+                fi
                 ;;
             zip)
-                unzip -o "$tmp_file" "$name" -d "$GOPATH/bin/" 2>/dev/null || \
-                unzip -o "$tmp_file" -d "/tmp/${name}-extracted" && mv "/tmp/${name}-extracted/$name" "$GOPATH/bin/" 2>/dev/null
+                if unzip -o "$tmp_file" "$name" -d "$GOPATH/bin/" 2>/dev/null || \
+                   { unzip -o "$tmp_file" -d "/tmp/${name}-extracted" 2>/dev/null && mv "/tmp/${name}-extracted/$name" "$GOPATH/bin/" 2>/dev/null; }; then
+                    installed=1
+                fi
                 ;;
             binary)
-                mv "$tmp_file" "$GOPATH/bin/$name"
+                if mv "$tmp_file" "$GOPATH/bin/$name" 2>/dev/null; then
+                    installed=1
+                fi
                 ;;
         esac
-        chmod +x "$GOPATH/bin/$name"
-        rm -f "$tmp_file" "/tmp/${name}-extracted" 2>/dev/null
-        echo -e "${GREEN}✓ ${name} installed (binary)${NC}"
-    elif [ -n "$go_pkg" ]; then
-        echo -e "${YELLOW}  Fallback to go install...${NC}"
-        if go install "${go_pkg}@latest" 2>/dev/null; then
-            echo -e "${GREEN}✓ ${name} installed (compiled)${NC}"
-        else
-            echo -e "${YELLOW}⚠ ${name} failed to install${NC}"
+        if [[ "$installed" == "1" ]]; then
+            chmod +x "$GOPATH/bin/$name"
         fi
-    else
-        echo -e "${YELLOW}⚠ ${name} download failed${NC}"
+        rm -f "$tmp_file" "/tmp/${name}-extracted" 2>/dev/null || true
     fi
+
+    if [[ "$installed" == "1" ]]; then
+        echo -e "${GREEN}✓ ${name} installed (binary)${NC}"
+        return 0
+    fi
+
+    if [ -n "$go_pkg" ]; then
+        echo -e "${YELLOW}  ${name}: binary download failed, falling back to go install...${NC}"
+        if go install "${go_pkg}@latest"; then
+            echo -e "${GREEN}✓ ${name} installed (compiled)${NC}"
+            return 0
+        fi
+        err "${name}: both binary download and 'go install' failed"
+        return 1
+    fi
+
+    err "${name}: binary download failed and no 'go install' fallback configured"
+    return 1
+}
+
+# Parallel-install helper: runs install_go_tool in a subshell that MUST exit
+# non-zero on failure. Our ERR trap is suppressed inside these subshells (the
+# caller's `wait <pid>` is what surfaces the failure).
+spawn_tool() {
+    local name=$1; shift
+    # Subshell disables the inherited ERR trap so failures of individual tools
+    # don't crash the whole script before we had a chance to collect them.
+    set +e
+    ( trap - ERR; install_go_tool "$name" "$@" ) &
+    TOOL_PIDS[$name]=$!
+    set -e
 }
 
 # Fetch latest versions (non-fatal: empty string on rate-limit/timeout, retries 3x)
+step fetch-tool-versions begin
 GOLANGCI_VERSION=$(get_github_latest_version_or_empty "golangci/golangci-lint")
 GOSEC_VERSION=$(get_github_latest_version_or_empty "securego/gosec")
 GOFUMPT_VERSION=$(get_github_latest_version_or_empty "mvdan/gofumpt")
@@ -171,94 +235,182 @@ BUILDTOOLS_VERSION=$(get_github_latest_version_or_empty "bazelbuild/buildtools")
 
 # gofumpt uses 'v' prefix in URLs
 [[ -n "$GOFUMPT_VERSION" && "$GOFUMPT_VERSION" != v* ]] && GOFUMPT_VERSION="v${GOFUMPT_VERSION}"
+step fetch-tool-versions ok
 
-# Install all tools in parallel (binary release preferred, go install @latest as fallback)
+# Track each parallel install so we can collect individual exit codes. Without
+# per-PID tracking a silent `&`+`wait` loses failures — the original bug.
+declare -A TOOL_PIDS=()
+declare -A TOOL_STATUS=()
+
+step install-tools begin
 if [[ -n "$GOLANGCI_VERSION" ]]; then
-    install_go_tool "golangci-lint" \
+    spawn_tool "golangci-lint" \
         "https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_VERSION}/golangci-lint-${GOLANGCI_VERSION}-linux-${GO_ARCH}.tar.gz" \
         "github.com/golangci/golangci-lint/v2/cmd/golangci-lint" \
-        "tar.gz" &
+        "tar.gz"
 else
-    (echo -e "${YELLOW}golangci-lint: version unavailable, building from source...${NC}" && \
-     go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest && \
-     echo -e "${GREEN}✓ golangci-lint installed (from source)${NC}" || \
-     echo -e "${YELLOW}⚠ golangci-lint: source build failed, skipping${NC}") &
+    set +e
+    ( trap - ERR; \
+      echo -e "${YELLOW}golangci-lint: version unavailable, building from source...${NC}" && \
+      go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest && \
+      echo -e "${GREEN}✓ golangci-lint installed (from source)${NC}" ) &
+    TOOL_PIDS[golangci-lint]=$!
+    set -e
 fi
 
 if [[ -n "$GOSEC_VERSION" ]]; then
-    install_go_tool "gosec" \
+    spawn_tool "gosec" \
         "https://github.com/securego/gosec/releases/download/v${GOSEC_VERSION}/gosec_${GOSEC_VERSION}_linux_${GO_ARCH}.tar.gz" \
         "github.com/securego/gosec/v2/cmd/gosec" \
-        "tar.gz" &
+        "tar.gz"
 else
-    (echo -e "${YELLOW}gosec: version unavailable, building from source...${NC}" && \
-     go install github.com/securego/gosec/v2/cmd/gosec@latest && \
-     echo -e "${GREEN}✓ gosec installed (from source)${NC}" || \
-     echo -e "${YELLOW}⚠ gosec: source build failed, skipping${NC}") &
+    set +e
+    ( trap - ERR; \
+      echo -e "${YELLOW}gosec: version unavailable, building from source...${NC}" && \
+      go install github.com/securego/gosec/v2/cmd/gosec@latest && \
+      echo -e "${GREEN}✓ gosec installed (from source)${NC}" ) &
+    TOOL_PIDS[gosec]=$!
+    set -e
 fi
 
 if [[ -n "$GOFUMPT_VERSION" ]]; then
-    install_go_tool "gofumpt" \
+    spawn_tool "gofumpt" \
         "https://github.com/mvdan/gofumpt/releases/download/${GOFUMPT_VERSION}/gofumpt_${GOFUMPT_VERSION}_linux_${GO_ARCH}" \
         "mvdan.cc/gofumpt" \
-        "binary" &
+        "binary"
 else
-    (echo -e "${YELLOW}gofumpt: version unavailable, building from source...${NC}" && \
-     go install mvdan.cc/gofumpt@latest && \
-     echo -e "${GREEN}✓ gofumpt installed (from source)${NC}" || \
-     echo -e "${YELLOW}⚠ gofumpt: source build failed, skipping${NC}") &
+    set +e
+    ( trap - ERR; \
+      echo -e "${YELLOW}gofumpt: version unavailable, building from source...${NC}" && \
+      go install mvdan.cc/gofumpt@latest && \
+      echo -e "${GREEN}✓ gofumpt installed (from source)${NC}" ) &
+    TOOL_PIDS[gofumpt]=$!
+    set -e
 fi
 
 if [[ -n "$GOTESTSUM_VERSION" ]]; then
-    install_go_tool "gotestsum" \
+    spawn_tool "gotestsum" \
         "https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_linux_${GO_ARCH}.tar.gz" \
         "gotest.tools/gotestsum" \
-        "tar.gz" &
+        "tar.gz"
 else
-    (echo -e "${YELLOW}gotestsum: version unavailable, building from source...${NC}" && \
-     go install gotest.tools/gotestsum@latest && \
-     echo -e "${GREEN}✓ gotestsum installed (from source)${NC}" || \
-     echo -e "${YELLOW}⚠ gotestsum: source build failed, skipping${NC}") &
+    set +e
+    ( trap - ERR; \
+      echo -e "${YELLOW}gotestsum: version unavailable, building from source...${NC}" && \
+      go install gotest.tools/gotestsum@latest && \
+      echo -e "${GREEN}✓ gotestsum installed (from source)${NC}" ) &
+    TOOL_PIDS[gotestsum]=$!
+    set -e
 fi
 
-(
-    echo -e "${YELLOW}Installing goimports...${NC}"
-    go install golang.org/x/tools/cmd/goimports@latest
-    echo -e "${GREEN}✓ goimports installed${NC}"
-) &
+# goimports has no GitHub release — always compile from source.
+set +e
+( trap - ERR; \
+  echo -e "${YELLOW}Installing goimports...${NC}" && \
+  go install golang.org/x/tools/cmd/goimports@latest && \
+  echo -e "${GREEN}✓ goimports installed${NC}" ) &
+TOOL_PIDS[goimports]=$!
+set -e
 
-install_go_tool "ktn-linter" \
+spawn_tool "ktn-linter" \
     "https://github.com/kodflow/ktn-linter/releases/latest/download/ktn-linter-linux-${GO_ARCH}" \
     "" \
-    "binary" &
+    "binary"
 
 # Bazel tooling — same release ships both binaries.
 if [[ -n "$BUILDTOOLS_VERSION" ]]; then
-    install_go_tool "buildifier" \
+    spawn_tool "buildifier" \
         "https://github.com/bazelbuild/buildtools/releases/download/v${BUILDTOOLS_VERSION}/buildifier-linux-${GO_ARCH}" \
         "github.com/bazelbuild/buildtools/buildifier" \
-        "binary" &
-    install_go_tool "buildozer" \
+        "binary"
+    spawn_tool "buildozer" \
         "https://github.com/bazelbuild/buildtools/releases/download/v${BUILDTOOLS_VERSION}/buildozer-linux-${GO_ARCH}" \
         "github.com/bazelbuild/buildtools/buildozer" \
-        "binary" &
+        "binary"
 else
-    (echo -e "${YELLOW}buildifier/buildozer: version unavailable, building from source...${NC}" && \
-     go install github.com/bazelbuild/buildtools/buildifier@latest && \
-     go install github.com/bazelbuild/buildtools/buildozer@latest && \
-     echo -e "${GREEN}✓ buildifier + buildozer installed (from source)${NC}" || \
-     echo -e "${YELLOW}⚠ buildifier/buildozer: source build failed, skipping${NC}") &
+    set +e
+    ( trap - ERR; \
+      echo -e "${YELLOW}buildifier/buildozer: version unavailable, building from source...${NC}" && \
+      go install github.com/bazelbuild/buildtools/buildifier@latest && \
+      go install github.com/bazelbuild/buildtools/buildozer@latest && \
+      echo -e "${GREEN}✓ buildifier + buildozer installed (from source)${NC}" ) &
+    TOOL_PIDS[buildifier]=$!
+    TOOL_PIDS[buildozer]=$!
+    set -e
 fi
 
-wait
-echo -e "${GREEN}✓ All Go tools installed${NC}"
+# Collect exit codes per tool. `wait <pid>` is the ONLY reliable way to get
+# the child's real exit code after `&`; the bare `wait` returns 0 always.
+for tool in "${!TOOL_PIDS[@]}"; do
+    if wait "${TOOL_PIDS[$tool]}" 2>/dev/null; then
+        TOOL_STATUS[$tool]="ok"
+    else
+        TOOL_STATUS[$tool]="fail"
+    fi
+done
+
+# Classify tools. Critical tools are those the rest of the stack depends on —
+# the Claude Code lint hooks (golangci-lint, gofumpt, goimports) and the MCP
+# server binary (ktn-linter). A missing critical tool is a hard error: ship a
+# broken container and we reproduce exactly issue #324.
+CRITICAL_TOOLS=("golangci-lint" "gofumpt" "goimports" "ktn-linter")
+OPTIONAL_TOOLS=("gosec" "gotestsum" "buildifier" "buildozer")
+
+missing_critical=()
+for tool in "${CRITICAL_TOOLS[@]}"; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        missing_critical+=("$tool")
+    fi
+done
+
+missing_optional=()
+for tool in "${OPTIONAL_TOOLS[@]}"; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        missing_optional+=("$tool")
+    fi
+done
+
+if (( ${#missing_optional[@]} > 0 )); then
+    warn "Optional Go tools missing (non-blocking): ${missing_optional[*]}"
+fi
+
+if (( ${#missing_critical[@]} > 0 )); then
+    err "CRITICAL Go tools missing: ${missing_critical[*]}"
+    err "Per-tool install status:"
+    for tool in "${!TOOL_STATUS[@]}"; do
+        err "  - $tool: ${TOOL_STATUS[$tool]}"
+    done
+    err "Feature installation INCOMPLETE — refusing to ship a half-installed Go toolchain."
+    err "Fix the underlying install failure (network? GitHub rate limit? permissions?) and re-run."
+    exit 1
+fi
+step install-tools ok
+
+# Install ktn-linter MCP fragment IMMEDIATELY after the binary check passes.
+# Previously this was at the very end of the script, so any later failure
+# (e.g. Wails/TinyGo download) would leave /etc/mcp/features/ empty and the
+# MCP server silently absent from the merged mcp.json — the root cause of #324.
+step mcp-fragment begin
+install_mcp_fragment "go" '{
+  "servers": {
+    "ktn-linter": {
+      "command": "ktn-linter",
+      "args": ["serve"],
+      "requires_binary": "ktn-linter"
+    }
+  }
+}'
+step mcp-fragment ok
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Install Wails v2 + TinyGo in parallel
+# Install Wails v2 + TinyGo in parallel (optional — desktop/WASM toolchain)
 # ─────────────────────────────────────────────────────────────────────────────
+step optional-tools begin
 
 # Wails v2 (Desktop GUI Framework) — binary from GitHub Releases, fallback go install
+set +e
 (
+    trap - ERR
     echo -e "${YELLOW}Installing Wails v2 (desktop GUI framework)...${NC}"
     WAILS_VERSION=$(get_github_latest_version_or_empty "wailsapp/wails")
     WAILS_INSTALLED=false
@@ -275,24 +427,27 @@ echo -e "${GREEN}✓ All Go tools installed${NC}"
         if go install github.com/wailsapp/wails/v2/cmd/wails@latest; then
             echo -e "${GREEN}✓ Wails installed (compiled)${NC}"
         else
-            echo -e "${YELLOW}⚠ Wails installation failed${NC}"
+            warn "Wails installation failed (non-blocking)"
         fi
     fi
 ) &
 WAILS_PID=$!
+set -e
 
 # TinyGo (WebAssembly Compiler)
+set +e
 (
+    trap - ERR
     echo -e "${YELLOW}Installing TinyGo (WASM/embedded compiler)...${NC}"
     TINYGO_VERSION=$(get_github_latest_version_or_empty "tinygo-org/tinygo")
     if [[ -z "$TINYGO_VERSION" ]]; then
-        echo -e "${YELLOW}⚠ TinyGo version resolution failed, skipping${NC}"
+        warn "TinyGo version resolution failed (non-blocking)"
         exit 0
     fi
     case "$GO_ARCH" in
         amd64) TINYGO_PKG="tinygo_${TINYGO_VERSION}_amd64.deb" ;;
         arm64) TINYGO_PKG="tinygo_${TINYGO_VERSION}_arm64.deb" ;;
-        *)     echo -e "${YELLOW}⚠ TinyGo not available for ${GO_ARCH}${NC}"; exit 0 ;;
+        *)     warn "TinyGo not available for ${GO_ARCH} (non-blocking)"; exit 0 ;;
     esac
     TINYGO_URL="https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_VERSION}/${TINYGO_PKG}"
     if curl -fsSL --connect-timeout 10 --max-time 120 -o "/tmp/${TINYGO_PKG}" "$TINYGO_URL" 2>/dev/null; then
@@ -305,13 +460,15 @@ WAILS_PID=$!
             echo -e "${GREEN}✓ TinyGo ${TINYGO_VERSION} installed${NC}"
         fi
     else
-        echo -e "${YELLOW}⚠ TinyGo download failed, skipping${NC}"
+        warn "TinyGo download failed (non-blocking)"
     fi
 ) &
 TINYGO_PID=$!
+set -e
 
-wait "$WAILS_PID" 2>/dev/null || true
-wait "$TINYGO_PID" 2>/dev/null || true
+wait "$WAILS_PID" 2>/dev/null || warn "Wails subshell exit code non-zero (non-blocking)"
+wait "$TINYGO_PID" 2>/dev/null || warn "TinyGo subshell exit code non-zero (non-blocking)"
+step optional-tools ok
 
 print_success_banner "Go environment" 2>/dev/null || {
     echo ""
@@ -347,14 +504,4 @@ echo ""
 sudo mkdir -p /opt/devcontainer-versions
 go version 2>/dev/null | sudo tee /opt/devcontainer-versions/go >/dev/null
 
-# Install ktn-linter MCP fragment (feature-level, only when Go is enabled)
-# JSON is inlined because OCI feature artifacts don't include mcp.json files
-install_mcp_fragment "go" '{
-  "servers": {
-    "ktn-linter": {
-      "command": "ktn-linter",
-      "args": ["serve"],
-      "requires_binary": "ktn-linter"
-    }
-  }
-}'
+step finish ok

--- a/.devcontainer/features/languages/python/devcontainer-feature.json
+++ b/.devcontainer/features/languages/python/devcontainer-feature.json
@@ -6,7 +6,7 @@
   "options": {
     "version": {
       "type": "string",
-      "default": "3.13",
+      "default": "3.14",
       "description": "Python version to install"
     }
   },

--- a/.devcontainer/features/languages/python/install.sh
+++ b/.devcontainer/features/languages/python/install.sh
@@ -17,7 +17,7 @@ print_banner "Python Development Environment" 2>/dev/null || {
 }
 
 # Environment variables
-export PYTHON_VERSION="${VERSION:-3.13}"
+export PYTHON_VERSION="${VERSION:-3.14}"
 export PIP_CACHE_DIR="${PIP_CACHE_DIR:-$HOME/.cache/pip}"
 export PYENV_ROOT="${PYENV_ROOT:-$HOME/.cache/pyenv}"
 

--- a/.devcontainer/features/languages/swift/install.sh
+++ b/.devcontainer/features/languages/swift/install.sh
@@ -38,9 +38,9 @@ if [ -z "${SWIFT_VERSION:-}" ] || [ "${SWIFT_VERSION}" = "latest" ]; then
         [[ $_attempt -lt 3 ]] && sleep $((2 ** _attempt))
     done
     if [ -z "$SWIFT_VERSION" ]; then
-        echo -e "${YELLOW}⚠ Failed to resolve latest Swift version from GitHub, using fallback 6.0.3${NC}"
+        echo -e "${YELLOW}⚠ Failed to resolve latest Swift version from GitHub, using fallback 6.3.1${NC}"
     fi
-    SWIFT_VERSION="${SWIFT_VERSION:-6.0.3}"
+    SWIFT_VERSION="${SWIFT_VERSION:-6.3.1}"
 fi
 export SWIFT_VERSION
 export SWIFT_HOME="${SWIFT_HOME:-/usr/share/swift}"

--- a/.devcontainer/images/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/images/hooks/lifecycle/postStart.sh
@@ -599,6 +599,26 @@ step_mcp_configuration() {
     # ALWAYS merge MCP fragments from /etc/mcp/fragments/ (image-level) and /etc/mcp/features/ (feature-level)
     # This runs even when template is cached, so new features/binaries are picked up on restart
     if [ -f "$MCP_OUTPUT" ] && command -v jq >/dev/null 2>&1; then
+        # Expected fragments: when the trigger binary is present we assume the
+        # corresponding feature was enabled, so its fragment MUST exist.
+        # A missing fragment here is the exact regression from issue #324
+        # (Go feature silently failed, MCP server absent). Surfacing it as a
+        # warning is the last line of defense before the user spots it
+        # themselves.
+        declare -A expected_fragments=(
+            [go]=go
+        )
+
+        for trigger in "${!expected_fragments[@]}"; do
+            if command -v "$trigger" >/dev/null 2>&1; then
+                local expected_name="${expected_fragments[$trigger]}"
+                if [ ! -f "/etc/mcp/features/${expected_name}.mcp.json" ]; then
+                    log_warning "Feature trigger '$trigger' is installed but MCP fragment '${expected_name}.mcp.json' is missing — the feature's install.sh may have failed. Check the devcontainer build log for '[INSTALL-${trigger^^}]' markers."
+                fi
+            fi
+        done
+
+        local added=() skipped=()
         local fragment
         for fragment in /etc/mcp/fragments/*.mcp.json /etc/mcp/features/*.mcp.json; do
             [ -f "$fragment" ] || continue
@@ -610,7 +630,7 @@ step_mcp_configuration() {
 
             local server_name
             for server_name in $servers; do
-                # Skip if already present in mcp.json
+                # Skip if already present in mcp.json (idempotent re-run)
                 if jq -e --arg name "$server_name" '.mcpServers[$name]' "$MCP_OUTPUT" >/dev/null 2>&1; then
                     continue
                 fi
@@ -619,10 +639,24 @@ step_mcp_configuration() {
                 requires=$(jq -r --arg s "$server_name" '.servers[$s].requires_binary // empty' "$fragment")
 
                 if [ -n "$requires" ]; then
+                    local requires_ok=true
                     if [ "${requires#/}" != "$requires" ]; then
-                        [ -x "$requires" ] || { log_info "Skipping $server_name MCP ($requires not found)"; continue; }
+                        [ -x "$requires" ] || requires_ok=false
                     else
-                        command -v "$requires" &>/dev/null || { log_info "Skipping $server_name MCP ($requires not found)"; continue; }
+                        command -v "$requires" &>/dev/null || requires_ok=false
+                    fi
+                    if [ "$requires_ok" = "false" ]; then
+                        skipped+=("$server_name ($requires missing)")
+                        # Warn (not info) when the fragment came from a feature
+                        # that is supposed to ship its own trigger binary —
+                        # the feature is the canonical installer for that
+                        # binary, so its absence is a real regression.
+                        if [[ "$fragment" == /etc/mcp/features/* ]]; then
+                            log_warning "Skipping $server_name MCP: required binary '$requires' not found (from $feature_name feature)"
+                        else
+                            log_info "Skipping $server_name MCP ($requires not found)"
+                        fi
+                        continue
                     fi
                 fi
 
@@ -637,6 +671,7 @@ step_mcp_configuration() {
                     mv "$tmp_file" "$MCP_OUTPUT"
                     chown "$(id -u):$(id -g)" "$MCP_OUTPUT" 2>/dev/null || true
                     chmod 600 "$MCP_OUTPUT" 2>/dev/null || true
+                    added+=("$server_name")
                     log_info "Added $server_name MCP (from $feature_name feature)"
                 else
                     log_warning "Failed to add $server_name MCP, keeping original"
@@ -644,6 +679,15 @@ step_mcp_configuration() {
                 fi
             done
         done
+
+        # Summary — makes the final state obvious in the startup log so users
+        # don't have to diff mcp.json manually to spot a missing server.
+        local active
+        active=$(jq -r '.mcpServers | keys | join(", ")' "$MCP_OUTPUT" 2>/dev/null || echo "?")
+        log_info "MCP merge summary: active=[${active}] newly_added=${#added[@]} skipped=${#skipped[@]}"
+        if (( ${#skipped[@]} > 0 )); then
+            log_info "  skipped: ${skipped[*]}"
+        fi
     fi
 }
 

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- updated: 2026-04-10T12:00:00Z -->
+<!-- updated: 2026-04-21T15:27:23Z -->
 # GitHub Actions Workflows
 
 ## Purpose
@@ -47,7 +47,7 @@ CI/CD automation for the devcontainer template.
 
 - **Trigger**: Push to main, PRs
 - **Action**: Runs unit tests for hooks and scripts
-- **Uses**: `bats-core/bats-action@v3`
+- **Uses**: `bats-core/bats-action@4.0.0`
 
 ## Conventions
 

--- a/.github/workflows/publish-features.yml
+++ b/.github/workflows/publish-features.yml
@@ -15,7 +15,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Flatten features for OCI publishing
         run: |
@@ -44,7 +44,7 @@ jobs:
           ls -1 src/
 
       - name: Publish Dev Container Features
-        uses: devcontainers/action@v1
+        uses: devcontainers/action@1082abd5d2bf3a11abccba70eef98df068277772 # v1.4.3
         with:
           publish-features: true
           base-path-to-features: src

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Setup Bats
         id: setup-bats
-        uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # v4.1.0
+        uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
 
       - name: Run tests
         env:

--- a/tests/scripts/go-install.bats
+++ b/tests/scripts/go-install.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+# Static validation tests for the Go feature install.sh — issue #324.
+# Running the actual install requires root + network, so we assert the
+# structural guarantees that prevent silent regressions:
+#   - strict mode is on
+#   - ERR trap surfaces the failing command
+#   - every critical tool is declared
+#   - the MCP fragment is written before optional toolchains
+#   - parallel jobs are tracked per-PID (no bare `wait`)
+
+setup() {
+    load '../helpers/setup'
+    common_setup
+    INSTALL_SH="${BATS_TEST_DIRNAME}/../../.devcontainer/features/languages/go/install.sh"
+    POST_START="${BATS_TEST_DIRNAME}/../../.devcontainer/images/hooks/lifecycle/postStart.sh"
+}
+
+teardown() {
+    common_teardown
+}
+
+# --- install.sh: strict mode & error trap ---
+
+@test "install.sh enables set -Eeuo pipefail" {
+    grep -qE '^set -Eeuo pipefail$' "$INSTALL_SH"
+}
+
+@test "install.sh defines an ERR trap that exits with the failing code" {
+    grep -q "trap 'on_error" "$INSTALL_SH"
+    grep -q "on_error()" "$INSTALL_SH"
+}
+
+@test "install.sh syntax is valid" {
+    bash -n "$INSTALL_SH"
+}
+
+# --- install.sh: critical tools enforcement ---
+
+@test "install.sh declares CRITICAL_TOOLS with ktn-linter" {
+    grep -q 'CRITICAL_TOOLS=' "$INSTALL_SH"
+    grep -E 'CRITICAL_TOOLS=\([^)]*ktn-linter' "$INSTALL_SH"
+}
+
+@test "install.sh declares CRITICAL_TOOLS with golangci-lint, gofumpt, goimports" {
+    grep -E 'CRITICAL_TOOLS=\([^)]*golangci-lint' "$INSTALL_SH"
+    grep -E 'CRITICAL_TOOLS=\([^)]*gofumpt' "$INSTALL_SH"
+    grep -E 'CRITICAL_TOOLS=\([^)]*goimports' "$INSTALL_SH"
+}
+
+@test "install.sh exits with error when critical tools are missing" {
+    grep -q 'Feature installation INCOMPLETE' "$INSTALL_SH"
+    # The exit 1 lives inside the `if ((${#missing_critical[@]} > 0))` block.
+    grep -A12 'missing_critical\[@\]} > 0' "$INSTALL_SH" | grep -q '^    exit 1$'
+}
+
+# --- install.sh: parallel job tracking ---
+
+@test "install.sh tracks individual PIDs for parallel tool installs" {
+    grep -q 'declare -A TOOL_PIDS' "$INSTALL_SH"
+    grep -q 'TOOL_PIDS\[.*\]=\$!' "$INSTALL_SH"
+}
+
+@test "install.sh collects exit codes per-PID via wait <pid>" {
+    grep -qF 'wait "${TOOL_PIDS[$tool]}"' "$INSTALL_SH"
+}
+
+@test "install.sh does NOT rely on bare 'wait' to collect failures" {
+    # Bare `wait` (no argument) always returns 0 — regression from #324.
+    # Only non-critical optional subshells (Wails/TinyGo) may use `wait <pid>`;
+    # the main tool loop must use keyed waits.
+    ! grep -E '^wait$' "$INSTALL_SH"
+}
+
+# --- install.sh: MCP fragment ordering ---
+
+@test "install.sh writes MCP fragment before optional toolchains (Wails/TinyGo)" {
+    local frag_line wails_line
+    frag_line=$(grep -n 'install_mcp_fragment "go"' "$INSTALL_SH" | head -1 | cut -d: -f1)
+    wails_line=$(grep -n 'Installing Wails v2' "$INSTALL_SH" | head -1 | cut -d: -f1)
+    [ -n "$frag_line" ]
+    [ -n "$wails_line" ]
+    [ "$frag_line" -lt "$wails_line" ]
+}
+
+@test "install.sh MCP fragment references ktn-linter binary" {
+    grep -A6 'install_mcp_fragment "go"' "$INSTALL_SH" | grep -q '"ktn-linter"'
+    grep -A6 'install_mcp_fragment "go"' "$INSTALL_SH" | grep -q '"requires_binary"'
+}
+
+# --- install.sh: structured step markers ---
+
+@test "install.sh emits structured [INSTALL-GO] step markers" {
+    grep -q '\[INSTALL-GO\] step=' "$INSTALL_SH"
+}
+
+# --- postStart.sh: observability ---
+
+@test "postStart.sh has syntax valid" {
+    bash -n "$POST_START"
+}
+
+@test "postStart.sh warns when a feature trigger binary exists but fragment is missing" {
+    grep -q 'expected_fragments' "$POST_START"
+    grep -q 'may have failed' "$POST_START"
+}
+
+@test "postStart.sh logs a merge summary listing active MCP servers" {
+    grep -q 'MCP merge summary' "$POST_START"
+}
+
+@test "postStart.sh warns (not info) when a feature fragment requires a missing binary" {
+    # Regression guard: the former behavior was `log_info` which gets lost in
+    # the noise. Feature-level skips must be WARN to be spotted.
+    grep -A3 'fragment"\? == /etc/mcp/features/' "$POST_START" | grep -q 'log_warning'
+}


### PR DESCRIPTION
## Summary

- Go feature `install.sh` now exits non-zero on any failure: `set -Eeuo pipefail` + ERR trap, per-PID `wait "${TOOL_PIDS[$tool]}"`, critical tool enforcement. Fixes the silent-skip regression documented in #324.
- `install_mcp_fragment "go"` moved right after the `ktn-linter` install check (was at the very end of the script, so any later failure silently dropped the fragment).
- `postStart.sh` now warns loudly when a feature trigger binary exists but its MCP fragment is missing, and prints an MCP merge summary so the final state is visible in the startup log.
- 18 static bats regression guards in `tests/scripts/go-install.bats` so the hardening can't drift back.
- Bundled tool version bumps: Python 3.14, Erlang 28, Elixir 1.19.5, Swift 6.3.1 fallback; publish-features workflow SHA-pinned; bats-action tag annotation corrected.

## Test plan

- [ ] CI bats job picks up `tests/scripts/go-install.bats` and passes
- [ ] Fresh devcontainer from this branch installs Go feature cleanly
- [ ] Force a `curl` failure (block dl.google.com in test env) → feature exits non-zero with `[INSTALL-GO]` markers in log
- [ ] `mcp.json` in a fresh container contains `ktn-linter` entry
- [ ] `postStart` log shows `MCP merge summary: active=[...]`
