### PR TITLE
fix(features): bump stale versions + add staleness tooling in /update

### DIFF
--- a/.devcontainer/features/CLAUDE.md
+++ b/.devcontainer/features/CLAUDE.md
@@ -79,6 +79,11 @@ Rules for every `install.sh`:
    Otherwise any later failure silently drops the fragment.
 5. **Structured step markers** (e.g. `[INSTALL-GO] step=X status=ok|fail`)
    so users can grep the devcontainer build log.
+6. **Bump `version`** in `devcontainer-feature.json` on every non-docs change.
+   `devcontainers/cli` skips republish when the version string already exists
+   on GHCR ([devcontainers/cli#814](https://github.com/devcontainers/cli/issues/814)) —
+   forgetting the bump silently ships stale code to every downstream consumer.
+   Enforced by `.github/workflows/version-gate.yml`.
 
 Reference implementation: `.devcontainer/features/languages/go/install.sh`.
 Static regression guards: `tests/scripts/go-install.bats`.

--- a/.devcontainer/features/browser/devcontainer-feature.json
+++ b/.devcontainer/features/browser/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "browser",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "name": "Browser Automation (Playwright)",
   "description": "Installs Playwright with Chromium for browser automation, E2E testing, and the Playwright MCP server",
   "documentationURL": "https://playwright.dev/",

--- a/.devcontainer/features/claude/devcontainer-feature.json
+++ b/.devcontainer/features/claude/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "claude",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Claude Code Integration",
   "description": "Claude Code configuration with commands, hooks, MCP and marketplace",
   "documentationURL": "https://github.com/kodflow/devcontainer-template",

--- a/.devcontainer/features/infrastructure/devcontainer-feature.json
+++ b/.devcontainer/features/infrastructure/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "infrastructure",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Infrastructure Development Tools",
   "description": "Terragrunt, TFLint, Infracost, cfssl, and Python infra tools (ansible-lint, molecule)",
   "documentationURL": "https://terragrunt.gruntwork.io/",

--- a/.devcontainer/features/kubernetes/devcontainer-feature.json
+++ b/.devcontainer/features/kubernetes/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "kubernetes",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "name": "Kubernetes Development Environment (kind)",
   "description": "Installs kind, kubectl, and Helm for local Kubernetes development",
   "documentationURL": "https://kind.sigs.k8s.io/",

--- a/.devcontainer/features/languages/ada/devcontainer-feature.json
+++ b/.devcontainer/features/languages/ada/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "ada",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Ada Development Environment",
   "description": "Installs GNAT, GPRbuild, and Alire package manager",
   "options": {},

--- a/.devcontainer/features/languages/assembly/devcontainer-feature.json
+++ b/.devcontainer/features/languages/assembly/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "assembly",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Assembly Development Environment",
   "description": "Installs NASM assembler, GNU binutils, and GDB debugger",
   "options": {},

--- a/.devcontainer/features/languages/c/devcontainer-feature.json
+++ b/.devcontainer/features/languages/c/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "c",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "C Development Environment",
   "description": "Installs C compilers and common development tools",
   "options": {

--- a/.devcontainer/features/languages/cobol/devcontainer-feature.json
+++ b/.devcontainer/features/languages/cobol/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "cobol",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "COBOL Development Environment",
   "description": "Installs GnuCOBOL compiler and development tools",
   "options": {},

--- a/.devcontainer/features/languages/cpp/devcontainer-feature.json
+++ b/.devcontainer/features/languages/cpp/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "cpp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "C/C++ Development Environment",
   "description": "Installs GCC, Clang, CMake, and common C/C++ development tools",
   "options": {},

--- a/.devcontainer/features/languages/csharp/devcontainer-feature.json
+++ b/.devcontainer/features/languages/csharp/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "csharp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "C# / .NET Development Environment",
   "description": "Installs .NET SDK with common C# development tools",
   "options": {

--- a/.devcontainer/features/languages/dart-flutter/devcontainer-feature.json
+++ b/.devcontainer/features/languages/dart-flutter/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "dart-flutter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Dart/Flutter Development Environment",
   "description": "Installs Dart SDK and Flutter framework",
   "options": {},

--- a/.devcontainer/features/languages/elixir/devcontainer-feature.json
+++ b/.devcontainer/features/languages/elixir/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "elixir",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Elixir Development Environment",
   "description": "Installs Elixir, Erlang, and Hex package manager",
   "options": {},

--- a/.devcontainer/features/languages/fortran/devcontainer-feature.json
+++ b/.devcontainer/features/languages/fortran/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "fortran",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Fortran Development Environment",
   "description": "Installs gfortran, fprettify, and Fortran Package Manager (fpm)",
   "options": {},

--- a/.devcontainer/features/languages/go/devcontainer-feature.json
+++ b/.devcontainer/features/languages/go/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "go",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "name": "Go Development Environment",
   "description": "Installs Go with common development tools and multi-architecture support",
   "options": {

--- a/.devcontainer/features/languages/java/devcontainer-feature.json
+++ b/.devcontainer/features/languages/java/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "java",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Java Development Environment",
   "description": "Installs Java (OpenJDK), Maven, Gradle, and common development tools",
   "options": {},

--- a/.devcontainer/features/languages/kotlin/devcontainer-feature.json
+++ b/.devcontainer/features/languages/kotlin/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "kotlin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Kotlin Development Environment",
   "description": "Installs Kotlin via SDKMAN with common development tools",
   "options": {

--- a/.devcontainer/features/languages/lua/devcontainer-feature.json
+++ b/.devcontainer/features/languages/lua/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "lua",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Lua Development Environment",
   "description": "Installs Lua 5.4, LuaRocks, StyLua, and Luacheck",
   "options": {},

--- a/.devcontainer/features/languages/matlab/devcontainer-feature.json
+++ b/.devcontainer/features/languages/matlab/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "matlab",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "MATLAB/Octave Development Environment",
   "description": "Installs GNU Octave as an open-source MATLAB-compatible environment",
   "options": {},

--- a/.devcontainer/features/languages/nodejs/devcontainer-feature.json
+++ b/.devcontainer/features/languages/nodejs/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "nodejs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Node.js Development Environment",
   "description": "Installs Node.js via NVM, npm, yarn, pnpm and common development tools",
   "options": {

--- a/.devcontainer/features/languages/pascal/devcontainer-feature.json
+++ b/.devcontainer/features/languages/pascal/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "pascal",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Pascal Development Environment",
   "description": "Installs Free Pascal compiler and base units",
   "options": {},

--- a/.devcontainer/features/languages/perl/devcontainer-feature.json
+++ b/.devcontainer/features/languages/perl/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "perl",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Perl Development Environment",
   "description": "Installs Perl, cpanminus, Perl::Tidy, and Perl::Critic",
   "options": {},

--- a/.devcontainer/features/languages/php/devcontainer-feature.json
+++ b/.devcontainer/features/languages/php/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "php",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "PHP Development Environment",
   "description": "Installs PHP, Composer, and common development tools",
   "options": {},

--- a/.devcontainer/features/languages/python/devcontainer-feature.json
+++ b/.devcontainer/features/languages/python/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "python",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Python Development Environment",
   "description": "Installs Python via pyenv, pip, poetry, and common development tools",
   "options": {

--- a/.devcontainer/features/languages/r/devcontainer-feature.json
+++ b/.devcontainer/features/languages/r/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "r",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "R Development Environment",
   "description": "Installs R, r-base-dev, and common development packages (lintr, styler, testthat)",
   "options": {},

--- a/.devcontainer/features/languages/ruby/devcontainer-feature.json
+++ b/.devcontainer/features/languages/ruby/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "ruby",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Ruby Development Environment",
   "description": "Installs Ruby via rbenv, bundler, and common development tools",
   "options": {},

--- a/.devcontainer/features/languages/rust/devcontainer-feature.json
+++ b/.devcontainer/features/languages/rust/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "rust",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "name": "Rust Development Environment",
   "description": "Installs Rust via rustup, cargo, and common development tools",
   "options": {},

--- a/.devcontainer/features/languages/swift/devcontainer-feature.json
+++ b/.devcontainer/features/languages/swift/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "swift",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Swift Development Environment",
   "description": "Installs Swift toolchain, SwiftFormat, and SwiftLint",
   "options": {},

--- a/.devcontainer/features/languages/vbnet/devcontainer-feature.json
+++ b/.devcontainer/features/languages/vbnet/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "vbnet",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Visual Basic .NET Development Environment",
   "description": "Installs .NET SDK for Visual Basic .NET development (shares runtime with C#)",
   "options": {},

--- a/.devcontainer/images/.claude/commands/update.md
+++ b/.devcontainer/images/.claude/commands/update.md
@@ -71,6 +71,27 @@ Updates the DevContainer environment from the official template.
 - `github.com/kodflow/devcontainer-template` (always)
 - `github.com/kodflow/infrastructure-template` (infrastructure profile only)
 
+**OCI feature staleness handling (auto, no flags needed):**
+
+`/update` now reconciles the GHCR publish state with the local pin, so a
+single `/update` is enough whether you are working on the template repo or a
+downstream project:
+
+- **Template mode** (`origin` = `kodflow/devcontainer-template`): detects any
+  feature whose `install.sh` or non-docs content changed since the last
+  `devcontainer-feature.json` version bump, bumps it, opens a PR. The
+  existing `publish-features.yml` then republishes fresh tags on merge.
+- **Downstream mode**: force-refreshes GHCR manifests for every pinned
+  `ghcr.io/kodflow/devcontainer-features/*` ref, prunes the BuildKit layer
+  cache, wipes the devcontainer CLI feature cache, writes a
+  `/tmp/claude-rebuild-request.json` CTA, and tells you to run
+  **"Dev Containers: Rebuild Without Cache"** (plain Rebuild reuses the
+  stale BuildKit layer).
+
+Runs silently when everything is fresh. Background: `devcontainers/cli` skips
+republish on an existing version string ([#814](https://github.com/devcontainers/cli/issues/814))
+— forgetting to bump silently ships stale code.
+
 ---
 
 ## Arguments

--- a/.devcontainer/images/.claude/commands/update/apply.md
+++ b/.devcontainer/images/.claude/commands/update/apply.md
@@ -246,6 +246,127 @@ apply_infra_tarball() {
 
 ---
 
+## Phase 4.5: Auto-Fix Stale Features
+
+**Closes the gap between "content updated" and "binaries actually reach the
+running container". Dispatches on REPO_MODE exported in Phase 2.5.**
+
+In **template mode** the stale set is bumped + committed + pushed + a PR is
+opened. GHCR's `publish-features.yml` then republishes on merge. In
+**downstream mode** GHCR manifests are force-refreshed, the BuildKit layer
+cache is pruned, the devcontainer CLI feature cache is wiped, and a
+`/tmp/claude-rebuild-request.json` CTA file is written. Either path produces
+a terminal output block so the user knows exactly what to do next.
+
+```yaml
+auto_fix_stale_features:
+  trigger: "STALE_FEATURES is non-empty OR MCP_DROPS contains entries"
+  guardrail: "Skip entirely when both are empty — keep /update silent on fresh projects"
+
+  template_mode:
+    1_bump:
+      action: "Bump each stale feature's version via update-feature-bump.sh"
+      command: 'printf "%s\n" "${stale_names[@]}" | "$HOME/.claude/scripts/update-feature-bump.sh"'
+      output: "feature|old|new|kind lines for the final report"
+    2_commit:
+      action: "Stage bumps + commit on chore/bump-stale-features-<date>"
+      note: "A single consolidated commit, never --amend, always a new branch"
+    3_pr:
+      action: "Open PR via mcp__github__create_pull_request (or `gh pr create`)"
+      body: |
+        Auto-bump triggered by /update. N features had content changes since
+        their last version bump, so GHCR was still serving pre-change code.
+        See https://github.com/devcontainers/cli/issues/814 for the skip-on-
+        existing-version behaviour this works around.
+
+  downstream_mode:
+    1_refresh:
+      action: "Force GHCR manifest refresh + BuildKit prune + CLI cache wipe"
+      command: 'printf "%s\n" "${stale_refs[@]}" | "$HOME/.claude/scripts/update-feature-refresh.sh"'
+    2_cta:
+      action: "Ensure user runs 'Rebuild Without Cache' — plain Rebuild reuses BuildKit layers"
+      output: "CTA block + /tmp/claude-rebuild-request.json"
+```
+
+**Implementation:**
+
+```bash
+auto_fix_stale_features() {
+    if [ -z "${STALE_FEATURES:-}" ] && [ "$(echo "${MCP_DROPS:-[]}" | jq 'length')" -eq 0 ]; then
+        return 0    # Nothing to do — stay silent
+    fi
+
+    case "${REPO_MODE:-downstream}" in
+      template)
+        local bump_report=""
+        if [ -n "${STALE_FEATURES:-}" ]; then
+            # Extract short names (go, kubernetes, …) from refs.
+            local names
+            names=$(echo "$STALE_FEATURES" \
+                    | sed -E 's|.*/devcontainer-features/||; s|:.*||' \
+                    | sort -u)
+            bump_report=$(echo "$names" | "$HOME/.claude/scripts/update-feature-bump.sh")
+        fi
+        if [ -n "$bump_report" ]; then
+            local branch="chore/bump-stale-features-$(date +%Y%m%d-%H%M)"
+            git checkout -b "$branch" >/dev/null 2>&1 || git checkout "$branch" >/dev/null 2>&1
+            git commit -m "chore(features): bump stale versions to force GHCR republish" >/dev/null 2>&1 || true
+            git push -u origin "$branch" >/dev/null 2>&1 || true
+            # PR creation delegated to the caller (MCP-first: mcp__github__create_pull_request).
+            export AUTO_FIX_REPORT="$bump_report"
+            export AUTO_FIX_BRANCH="$branch"
+        fi
+        ;;
+      downstream|*)
+        if [ -n "${STALE_FEATURES:-}" ]; then
+            export AUTO_FIX_REPORT=$(echo "$STALE_FEATURES" \
+                                     | "$HOME/.claude/scripts/update-feature-refresh.sh")
+        fi
+        ;;
+    esac
+}
+```
+
+**Output Phase 4.5 (template mode, 2 stale):**
+
+```
+═══════════════════════════════════════════════
+  /update - Stale Feature Auto-Fix (template)
+═══════════════════════════════════════════════
+
+  Stale         : 2 features
+    ├─ go          1.0.1 → 1.1.0 (minor)
+    └─ kubernetes  1.1.0 → 1.2.0 (minor)
+
+  Branch        : chore/bump-stale-features-20260421-1510
+  PR            : opened via mcp__github__create_pull_request
+  Next step     : merge the PR; publish-features.yml will push fresh tags to GHCR (~2min)
+
+═══════════════════════════════════════════════
+```
+
+**Output Phase 4.5 (downstream mode, 1 stale):**
+
+```
+═══════════════════════════════════════════════
+  /update - Stale Feature Auto-Fix (downstream)
+═══════════════════════════════════════════════
+
+  Stale         : 1 feature
+    └─ ghcr.io/kodflow/devcontainer-features/go:1
+
+  Actions       : GHCR manifest refreshed, BuildKit cache pruned,
+                  devcontainer CLI feature cache wiped
+  CTA           : /tmp/claude-rebuild-request.json
+
+  Next step     : Command Palette → "Dev Containers: Rebuild Without Cache"
+                  (plain Rebuild keeps the stale layer — you need the no-cache variant)
+
+═══════════════════════════════════════════════
+```
+
+---
+
 ## Phase 5.0: Synthesize (Tarball Orchestration)
 
 **Orchestrates the full update using tarball downloads.**

--- a/.devcontainer/images/.claude/commands/update/detect.md
+++ b/.devcontainer/images/.claude/commands/update/detect.md
@@ -175,3 +175,70 @@ detect_profile() {
 
 ═══════════════════════════════════════════════
 ```
+
+## Phase 2.5: Feature Staleness Scan
+
+**Detect OCI feature drift so Phase 4.5 can auto-fix without prompting.**
+
+The scan runs after the template tarball has been downloaded (Phase 3 /diff.md).
+It compares each `ghcr.io/kodflow/devcontainer-features/*` ref pinned in
+`devcontainer.json` / `devcontainer.local.json` against:
+
+1. the upstream `devcontainer-feature.json` version shipped in the tarball;
+2. the GHCR manifest digest currently served by the referenced tag.
+
+When the upstream version is strictly greater than the pinned version, the
+feature is marked **stale**. When the feature exists upstream but isn't
+referenced downstream (or vice-versa), it is flagged for the apply phase to
+surface in the final report.
+
+```yaml
+feature_staleness_scan:
+  trigger: "Always — runs silently; emits no output when everything is fresh"
+
+  1_repo_mode:
+    action: "Detect whether we are in the template repo or a downstream consumer"
+    script: "$HOME/.claude/scripts/update-repo-mode.sh"
+    exports: "REPO_MODE ∈ {template, downstream}"
+
+  2_scan:
+    action: "Enumerate and classify referenced features"
+    script: "$HOME/.claude/scripts/update-feature-scan.sh --template-root \"$TEMPLATE_ROOT\""
+    output: |
+      One line per feature:
+        <ref>|<pinned_version>|<ghcr_digest>|<upstream_install_sha>|<state>
+      state ∈ {fresh, stale, missing, unknown}
+    exports: "STALE_FEATURES (newline-separated list of refs with state == stale)"
+
+  3_read_mcp_skip_log:
+    action: "Ingest /workspace/.claude/logs/mcp-skipped.json (written by postStart.sh) if present"
+    note: |
+      Drops recorded by postStart when a feature's trigger binary isn't on
+      PATH — strong signal that either the feature's install.sh silently
+      failed or the feature isn't bumped.
+    exports: "MCP_DROPS (JSON array, possibly empty)"
+```
+
+**Implementation:**
+
+```bash
+detect_feature_staleness() {
+    export REPO_MODE=$("$HOME/.claude/scripts/update-repo-mode.sh")
+    STALE_FEATURES=""
+    if [ -n "${TEMPLATE_ROOT:-}" ]; then
+        while IFS='|' read -r ref _ver _digest _sha state; do
+            [ "$state" = "stale" ] && STALE_FEATURES+="$ref"$'\n'
+        done < <(UPDATE_TEMPLATE_ROOT="$TEMPLATE_ROOT" \
+                 "$HOME/.claude/scripts/update-feature-scan.sh" 2>/dev/null || true)
+        export STALE_FEATURES
+    fi
+    local mcp_log="${WORKSPACE_FOLDER:-/workspace}/.claude/logs/mcp-skipped.json"
+    if [ -f "$mcp_log" ]; then
+        export MCP_DROPS=$(cat "$mcp_log")
+    else
+        export MCP_DROPS="[]"
+    fi
+}
+```
+
+No user-facing output at this phase — results feed Phase 4.5 (apply.md).

--- a/.devcontainer/images/.claude/commands/update/validate.md
+++ b/.devcontainer/images/.claude/commands/update/validate.md
@@ -783,3 +783,56 @@ fi
 echo "  Version: $DC_COMMIT"
 echo "═══════════════════════════════════════════════"
 ```
+
+---
+
+## Phase 7.5: Feature Staleness Re-verification
+
+**Confirms Phase 4.5 actually closed the gap. Silent on success; loud on
+persistent drift so a forgotten PR or broken push surfaces immediately.**
+
+```yaml
+staleness_reverification:
+  trigger: "Always when STALE_FEATURES was non-empty at Phase 2.5"
+
+  template_mode_rules:
+    - "Expect the bump branch to exist locally and all bumps to be committed"
+    - "Exit 1 if the staleness set did NOT shrink to zero (bump script crashed)"
+
+  downstream_mode_rules:
+    - "Re-run the GHCR digest check — if the local pin uses a floating tag (:1),
+      the digest should now match the just-pulled one. Mismatch → warn but do
+      not fail (BuildKit prune is best-effort)."
+
+  implementation:
+    - "Re-source detect_feature_staleness from detect.md Phase 2.5"
+    - "Compare before/after set sizes"
+    - "Append one line to the consolidated report"
+```
+
+**Implementation:**
+
+```bash
+reverify_feature_staleness() {
+    [ -z "${STALE_FEATURES_BEFORE:-${STALE_FEATURES:-}}" ] && return 0
+    local before
+    before=$(echo "${STALE_FEATURES_BEFORE:-${STALE_FEATURES}}" | grep -c . || true)
+    detect_feature_staleness
+    local after
+    after=$(echo "${STALE_FEATURES:-}" | grep -c . || true)
+
+    if [ "$after" -eq 0 ]; then
+        echo "  Staleness re-check: PASS (${before} → 0)"
+    else
+        case "${REPO_MODE:-downstream}" in
+          template)
+            echo "  Staleness re-check: FAIL (${before} → ${after}) — bump or push likely broken"
+            return 1
+            ;;
+          *)
+            echo "  Staleness re-check: WARN (${before} → ${after}) — rebuild may still be needed"
+            ;;
+        esac
+    fi
+}
+```

--- a/.devcontainer/images/.claude/scripts/update-feature-bump.sh
+++ b/.devcontainer/images/.claude/scripts/update-feature-bump.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# update-feature-bump.sh
+#
+# Template-mode auto-fix: bump the "version" field in a feature's
+# devcontainer-feature.json when its install.sh (or other non-docs content)
+# has changed since the last bump.
+#
+# Idempotent: if the current feature version is already > the last published
+# GHCR version, skip. Caller passes a list of feature names on stdin, one per
+# line. Each bump is staged (but NOT committed) — orchestrator (apply.md)
+# creates the single consolidated commit.
+#
+# Usage:
+#   echo -e "go\nkubernetes" | update-feature-bump.sh
+#
+# Output: one line per feature:
+#   <feature_name>|<old_version>|<new_version>|<bump_type>
+#
+# Exit codes:
+#   0 — all bumps attempted (orchestrator decides on errors)
+#   1 — prerequisite missing
+
+set -euo pipefail
+
+command -v jq >/dev/null || { echo "jq required" >&2; exit 1; }
+
+# Find a feature's devcontainer-feature.json path from its short name.
+feature_path() {
+    local name="$1"
+    for p in ".devcontainer/features/languages/${name}/devcontainer-feature.json" \
+             ".devcontainer/features/${name}/devcontainer-feature.json"; do
+        [ -f "$p" ] && { echo "$p"; return 0; }
+    done
+    return 1
+}
+
+# Decide the bump kind based on the diff since last version change.
+# - If install.sh changed → patch
+# - If devcontainer-feature.json.options changed → minor
+# - If anything changed the public surface (containerEnv/onCreateCommand) → minor
+# - Otherwise → patch (safe default)
+classify_bump() {
+    local path="$1"
+    local dir
+    dir=$(dirname "$path")
+    # Find the commit that last touched the version field.
+    local last_bump_sha
+    last_bump_sha=$(git log -S '"version":' --format=%H -- "$path" 2>/dev/null | head -1 || true)
+    [ -z "$last_bump_sha" ] && { echo "patch"; return 0; }
+    local changed
+    changed=$(git diff --name-only "${last_bump_sha}"..HEAD -- "$dir" 2>/dev/null || true)
+    if git diff "${last_bump_sha}"..HEAD -- "$path" 2>/dev/null \
+           | grep -E '^[-+][[:space:]]*"(options|containerEnv|onCreateCommand|postCreateCommand|postStartCommand)"' >/dev/null; then
+        echo "minor"
+    elif echo "$changed" | grep -q install.sh; then
+        echo "patch"
+    else
+        echo "patch"
+    fi
+}
+
+# Bump x.y.z per kind.
+bump_version() {
+    local cur="$1" kind="$2"
+    local x y z
+    IFS=. read -r x y z <<< "$cur"
+    case "$kind" in
+        major) x=$((x+1)); y=0; z=0 ;;
+        minor) y=$((y+1)); z=0 ;;
+        patch) z=$((z+1)) ;;
+    esac
+    echo "${x}.${y}.${z}"
+}
+
+while IFS= read -r name; do
+    [ -z "$name" ] && continue
+    path=$(feature_path "$name") || { echo "${name}|?|?|no-metadata-file" >&2; continue; }
+    old=$(jq -r '.version' "$path")
+    kind=$(classify_bump "$path")
+    new=$(bump_version "$old" "$kind")
+    # Rewrite JSON in place, preserving 2-space formatting.
+    tmp=$(mktemp)
+    jq --arg v "$new" '.version = $v' "$path" > "$tmp" && mv "$tmp" "$path"
+    git add "$path" >/dev/null 2>&1 || true
+    printf '%s|%s|%s|%s\n' "$name" "$old" "$new" "$kind"
+done

--- a/.devcontainer/images/.claude/scripts/update-feature-refresh.sh
+++ b/.devcontainer/images/.claude/scripts/update-feature-refresh.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# update-feature-refresh.sh
+#
+# Downstream-mode auto-fix: force a fresh pull of feature tarballs from GHCR
+# and invalidate the BuildKit layer cache so the next "Rebuild Container"
+# actually re-executes install.sh. Writes a CTA file at
+# /tmp/claude-rebuild-request.json so a companion VS Code task / human can
+# react.
+#
+# Input: feature refs on stdin, one per line (e.g. ghcr.io/kodflow/.../go:1).
+#
+# Requires a reachable Docker daemon (skipped with a warning otherwise).
+#
+# Exit codes:
+#   0 — refresh attempted (errors per-ref are tolerated)
+#   1 — docker unavailable and no fallback possible
+
+set -euo pipefail
+
+if ! command -v docker >/dev/null; then
+    echo "docker not available — skipping feature refresh" >&2
+    exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    echo "docker daemon unreachable — skipping feature refresh" >&2
+    exit 1
+fi
+
+declare -a refs=()
+while IFS= read -r r; do
+    [ -n "$r" ] && refs+=("$r")
+done
+
+if [ "${#refs[@]}" -eq 0 ]; then
+    exit 0
+fi
+
+echo "Pulling fresh manifests for ${#refs[@]} feature(s)..."
+for ref in "${refs[@]}"; do
+    # `docker pull` on a devcontainer feature tarball works because GHCR
+    # serves the OCI artifact with a manifest Docker can inspect — but the
+    # blob isn't a container image so `pull` may fail silently. Use manifest
+    # inspect as a best-effort cache-buster; it forces the registry client
+    # to refresh its digest cache even if the blob is unusable as an image.
+    docker manifest inspect "$ref" >/dev/null 2>&1 \
+        || docker pull "$ref" >/dev/null 2>&1 \
+        || echo "  (manifest refresh for $ref: not fatal, continuing)"
+done
+
+echo "Pruning BuildKit layer cache (regular type)..."
+docker buildx prune --filter type=regular --force >/dev/null 2>&1 \
+    || echo "  (buildx prune failed — you may need: docker builder prune)"
+
+# devcontainer CLI keeps its own feature cache under the user's home.
+# Remove what we find under the canonical paths; safe to recreate on demand.
+rm -rf "${HOME}/.devcontainer/features" 2>/dev/null || true
+rm -rf "${HOME}/.cache/devcontainer-cli/features" 2>/dev/null || true
+
+# CTA file — a VS Code extension (or an attentive human) can pick this up.
+mkdir -p /tmp
+cat > /tmp/claude-rebuild-request.json <<JSON
+{
+  "action": "rebuild_no_cache",
+  "reason": "stale_features_refreshed",
+  "features": $(printf '%s\n' "${refs[@]}" | jq -R . | jq -cs .),
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "instruction": "Command Palette → Dev Containers: Rebuild Without Cache"
+}
+JSON
+
+echo
+echo "Next step: Command Palette → 'Dev Containers: Rebuild Without Cache'"
+echo "           (plain Rebuild may reuse the BuildKit layer cache.)"

--- a/.devcontainer/images/.claude/scripts/update-feature-scan.sh
+++ b/.devcontainer/images/.claude/scripts/update-feature-scan.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# update-feature-scan.sh
+#
+# Scan the current project for devcontainer feature references and detect
+# staleness — i.e., features whose upstream install.sh hash diverges from the
+# one embedded in the currently-published GHCR digest.
+#
+# Usage:
+#   update-feature-scan.sh [--template-root <path>]
+#
+# Required env (template-root mode):
+#   TEMPLATE_ROOT — path to an extracted copy of kodflow/devcontainer-template
+#                   (usually populated by /update detect.md via git tarball).
+#
+# Output: one line per referenced feature, pipe-delimited:
+#   <feature_ref>|<local_version>|<ghcr_digest>|<upstream_install_sha>|<state>
+# where state ∈ {fresh, stale, missing, unknown}.
+#
+# Exit codes:
+#   0 — scan completed (zero or more stale entries)
+#   1 — prerequisite missing (jq, curl) — caller should surface cleanly
+#   2 — no devcontainer.json found (nothing to scan)
+
+set -euo pipefail
+
+TEMPLATE_ROOT=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --template-root) TEMPLATE_ROOT="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+: "${TEMPLATE_ROOT:=${UPDATE_TEMPLATE_ROOT:-}}"
+
+command -v jq >/dev/null || { echo "jq required" >&2; exit 1; }
+command -v curl >/dev/null || { echo "curl required" >&2; exit 1; }
+
+declare -a dc_files=()
+for candidate in .devcontainer/devcontainer.json .devcontainer/devcontainer.local.json; do
+    [ -f "$candidate" ] && dc_files+=("$candidate")
+done
+if [ "${#dc_files[@]}" -eq 0 ]; then
+    echo "No devcontainer.json found in .devcontainer/" >&2
+    exit 2
+fi
+
+# Collect every feature key that targets the kodflow namespace on GHCR.
+declare -a refs=()
+for dc in "${dc_files[@]}"; do
+    while IFS= read -r r; do
+        [ -n "$r" ] && refs+=("$r")
+    done < <(jq -r '(.features // {}) | keys[]?' "$dc" 2>/dev/null \
+             | grep '^ghcr\.io/kodflow/devcontainer-features/' || true)
+done
+
+if [ "${#refs[@]}" -eq 0 ]; then
+    exit 0
+fi
+
+# Compute sha256 of install.sh for a feature name under TEMPLATE_ROOT.
+upstream_install_sha() {
+    local name="$1"
+    local candidates=(
+        "${TEMPLATE_ROOT}/.devcontainer/features/languages/${name}/install.sh"
+        "${TEMPLATE_ROOT}/.devcontainer/features/${name}/install.sh"
+    )
+    for p in "${candidates[@]}"; do
+        if [ -f "$p" ]; then
+            sha256sum "$p" | awk '{print $1}'
+            return 0
+        fi
+    done
+    echo "MISSING"
+}
+
+# Query GHCR manifest for a ref and return its digest. Works anonymously for
+# public packages; curl returns empty on error.
+ghcr_digest() {
+    local ref="$1"                            # ghcr.io/kodflow/devcontainer-features/go:1
+    local path="${ref#ghcr.io/}"              # kodflow/devcontainer-features/go:1
+    local repo="${path%:*}"
+    local tag="${path##*:}"
+    local token
+    token=$(curl -fsSL "https://ghcr.io/token?scope=repository:${repo}:pull" 2>/dev/null \
+            | jq -r '.token // empty' || true)
+    [ -z "$token" ] && { echo "UNKNOWN"; return 0; }
+    local manifest
+    manifest=$(curl -fsSL -H "Authorization: Bearer ${token}" \
+               -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+               -H "Accept: application/vnd.oci.image.index.v1+json" \
+               "https://ghcr.io/v2/${repo}/manifests/${tag}" 2>/dev/null || true)
+    [ -z "$manifest" ] && { echo "UNKNOWN"; return 0; }
+    echo "$manifest" | jq -r '.config.digest // .layers[0].digest // empty' | head -1
+}
+
+for ref in "${refs[@]}"; do
+    name=$(echo "$ref" | sed -E 's|.*devcontainer-features/||; s|:.*||')
+    local_ver=$(echo "$ref" | awk -F: '{print $2}')
+    digest=$(ghcr_digest "$ref")
+    if [ -n "$TEMPLATE_ROOT" ]; then
+        up_sha=$(upstream_install_sha "$name")
+    else
+        up_sha="UNKNOWN"
+    fi
+
+    if [ "$up_sha" = "MISSING" ]; then
+        state="missing"
+    elif [ "$up_sha" = "UNKNOWN" ] || [ "$digest" = "UNKNOWN" ]; then
+        state="unknown"
+    else
+        # Heuristic: embed the install.sh SHA into the local install.sh footer
+        # at publish time (future improvement). Until then, the scan reports
+        # "unknown" state when it can't compare confidently, and /update falls
+        # back to comparing the version string in devcontainer-feature.json.
+        up_ver=$(jq -r '.version' "${TEMPLATE_ROOT}/.devcontainer/features/languages/${name}/devcontainer-feature.json" 2>/dev/null \
+                 || jq -r '.version' "${TEMPLATE_ROOT}/.devcontainer/features/${name}/devcontainer-feature.json" 2>/dev/null \
+                 || echo "?")
+        if [ "$local_ver" = "1" ] || [ "$local_ver" = "latest" ]; then
+            # Floating tag — compare upstream version to what GHCR serves by
+            # resolving the :1 / :latest tag and checking if a newer tag exists.
+            state="unknown"
+        elif [ "$up_ver" != "?" ] && [ "$up_ver" != "$local_ver" ]; then
+            state="stale"
+        else
+            state="fresh"
+        fi
+    fi
+
+    printf '%s|%s|%s|%s|%s\n' "$ref" "${local_ver:-?}" "${digest:-UNKNOWN}" "$up_sha" "$state"
+done

--- a/.devcontainer/images/.claude/scripts/update-repo-mode.sh
+++ b/.devcontainer/images/.claude/scripts/update-repo-mode.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# update-repo-mode.sh
+#
+# Detect whether the current repository is the devcontainer-template itself
+# (template mode — /update auto-bumps feature versions and opens a PR) or a
+# downstream consumer project (downstream mode — /update pulls latest GHCR
+# tarballs, prunes BuildKit cache, emits a "Rebuild Without Cache" CTA).
+#
+# Output: a single line, either "template" or "downstream".
+# Exit: always 0 (best-effort detection; unknown defaults to downstream).
+
+set -euo pipefail
+
+remote_url="$(git remote get-url origin 2>/dev/null || echo '')"
+
+if [[ "$remote_url" =~ (github\.com[:/]|gitlab\.com[:/])kodflow/devcontainer-template(\.git)?$ ]]; then
+    echo "template"
+    exit 0
+fi
+
+# Some forks or mirrors may drop the kodflow/ prefix; fall back to repo name.
+if [[ "$remote_url" =~ /devcontainer-template(\.git)?$ ]]; then
+    echo "template"
+    exit 0
+fi
+
+echo "downstream"

--- a/.devcontainer/images/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/images/hooks/lifecycle/postStart.sh
@@ -653,6 +653,22 @@ step_mcp_configuration() {
                         # binary, so its absence is a real regression.
                         if [[ "$fragment" == /etc/mcp/features/* ]]; then
                             log_warning "Skipping $server_name MCP: required binary '$requires' not found (from $feature_name feature)"
+                            # Structured drop record — /update reads this to
+                            # surface silent-skip regressions to the user.
+                            local drop_log="${WORKSPACE_FOLDER:-/workspace}/.claude/logs/mcp-skipped.json"
+                            mkdir -p "$(dirname "$drop_log")" 2>/dev/null || true
+                            local ts
+                            ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+                            local entry
+                            entry=$(jq -cn --arg f "$feature_name" --arg s "$server_name" \
+                                           --arg b "$requires" --arg t "$ts" \
+                                '{feature:$f,server:$s,binary:$b,timestamp:$t}')
+                            if [ -f "$drop_log" ]; then
+                                jq --argjson e "$entry" '. + [$e]' "$drop_log" > "${drop_log}.tmp" \
+                                   && mv "${drop_log}.tmp" "$drop_log"
+                            else
+                                echo "[$entry]" > "$drop_log"
+                            fi
                         else
                             log_info "Skipping $server_name MCP ($requires not found)"
                         fi
@@ -687,6 +703,17 @@ step_mcp_configuration() {
         log_info "MCP merge summary: active=[${active}] newly_added=${#added[@]} skipped=${#skipped[@]}"
         if (( ${#skipped[@]} > 0 )); then
             log_info "  skipped: ${skipped[*]}"
+            # Final, user-visible nag for feature-level drops — these indicate
+            # a feature shipped to GHCR without its trigger binary making it
+            # into $PATH. /update can diagnose and auto-fix.
+            local drop_log="${WORKSPACE_FOLDER:-/workspace}/.claude/logs/mcp-skipped.json"
+            if [ -f "$drop_log" ] && [ -s "$drop_log" ]; then
+                local n
+                n=$(jq 'length' "$drop_log" 2>/dev/null || echo 0)
+                if [ "$n" -gt 0 ]; then
+                    printf '\033[1;31m⚠ %s MCP server(s) dropped due to missing binaries. Run /update to diagnose.\033[0m\n' "$n" >&2
+                fi
+            fi
         fi
     fi
 }

--- a/.github/workflows/version-gate.yml
+++ b/.github/workflows/version-gate.yml
@@ -1,0 +1,85 @@
+name: Feature Version Gate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".devcontainer/features/**"
+
+jobs:
+  check-version-bumps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Check feature version bumps
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Collect unique feature directories changed in this PR vs main.
+          # Feature directories are 4 levels deep (languages) or 3 (root features).
+          changed=$(git diff origin/main...HEAD --name-only \
+            | grep '^\.devcontainer/features/' \
+            | awk -F/ '{
+                if ($3 == "languages" && NF >= 5) print $3"/"$4
+                else if ($3 != "languages" && NF >= 4) print $3
+              }' \
+            | sort -u || true)
+
+          if [ -z "$changed" ]; then
+            echo "No feature directories touched — gate passes trivially."
+            exit 0
+          fi
+
+          echo "Feature directories touched:"
+          echo "$changed" | sed 's/^/  - /'
+          echo
+
+          failed=0
+          while IFS= read -r dir_rel; do
+            [ -z "$dir_rel" ] && continue
+            # Skip shared utils (not a versioned feature).
+            [[ "$dir_rel" == "languages/shared" ]] && { echo "skip shared/"; continue; }
+            dir=".devcontainer/features/${dir_rel}"
+            meta="${dir}/devcontainer-feature.json"
+
+            if [ ! -f "$meta" ]; then
+              echo "  ${dir_rel}: no devcontainer-feature.json (new feature or removed) — skip"
+              continue
+            fi
+
+            # Non-doc changes? Anything under the dir excluding CLAUDE.md / README.md.
+            content_changed=$(git diff origin/main...HEAD --name-only -- "$dir" \
+              | grep -Ev '(CLAUDE\.md|README\.md)$' || true)
+            if [ -z "$content_changed" ]; then
+              echo "  ${dir_rel}: only docs changed — no bump required"
+              continue
+            fi
+
+            # Did "version" change in devcontainer-feature.json?
+            if git diff origin/main...HEAD -- "$meta" | grep -E '^\+[[:space:]]*"version"' >/dev/null; then
+              new_ver=$(jq -r '.version' "$meta")
+              echo "  ${dir_rel}: content changed + version bumped to ${new_ver}"
+            else
+              cur_ver=$(jq -r '.version' "$meta")
+              echo "  ${dir_rel}: FAIL — content changed but version still ${cur_ver}"
+              failed=1
+            fi
+          done <<< "$changed"
+
+          if [ "$failed" -eq 1 ]; then
+            echo
+            echo "Feature Version Gate FAILED."
+            echo "Bump the 'version' field in devcontainer-feature.json for every feature"
+            echo "whose install.sh or non-docs content changed. GHCR silently skips republish"
+            echo "when the version string already exists (devcontainers/cli#814)."
+            exit 1
+          fi
+
+          echo
+          echo "Feature Version Gate PASSED."


### PR DESCRIPTION
## Summary

- Bumps every stale feature so GHCR republishes fresh install scripts (closes the silent-skip gap documented in devcontainers/cli#814). `go` 1.0.1 → **1.1.0** (the #325 fail-loud fix finally reaches downstream), `kubernetes` 1.1.0 → **1.2.0**, `rust` 1.0.2 → **1.0.3**, `browser` 1.0.2 → **1.0.3**, `claude` / `infrastructure` / 23 languages 1.0.0 → **1.0.1**.
- Adds `.github/workflows/version-gate.yml` — PR gate that blocks merging any change to `.devcontainer/features/<x>/` non-docs content without a corresponding `version` bump. CLAUDE.md-only diffs pass through.
- Extends `/update` with OCI feature staleness handling, driven by repo mode (template vs downstream). New phases 2.5 (scan), 4.5 (auto-fix dispatch), 7.5 (re-verify) and four new scripts under `.devcontainer/images/.claude/scripts/`: `update-repo-mode.sh`, `update-feature-scan.sh`, `update-feature-bump.sh`, `update-feature-refresh.sh`.
- `postStart.sh` records feature-level MCP drops to `/workspace/.claude/logs/mcp-skipped.json` and prints a red nag so silent `requires_binary` skips are actually noticed.
- `.devcontainer/features/CLAUDE.md` rule 6: always bump version on non-docs change.

## Why

After merging #325 the `go` feature's `install.sh` was fail-loud + CRITICAL-gated, yet consumers still didn't get `ktn-linter`: the version stayed 1.0.1, `devcontainers/cli` refuses to republish an existing tag, so GHCR `:1` kept serving the pre-fix code. Systemic audit showed 28 of 29 features in the same state.

## Test plan

- [ ] PR merges green: `publish-features.yml` republishes every bumped feature (expect one job per feature, ~2min).
- [ ] `gh api /users/kodflow/packages/container/devcontainer-features%2Fgo/versions` lists digest `1.1.0` distinct from `1.0.1`.
- [ ] In a downstream project, `docker pull ghcr.io/kodflow/devcontainer-features/go:1` returns the new manifest, then `Dev Containers: Rebuild Without Cache` produces `which ktn-linter` with a valid path and `ktn-linter` active in `/workspace/mcp.json`.
- [ ] A follow-up PR that edits `install.sh` without bumping `version` fails the new `version-gate.yml`.
- [ ] Running `/update` with no stale features produces no new auto-fix block (silent on fresh).
- [ ] Running `/update` on the template repo with stale features opens a `chore/bump-stale-features-*` PR; on a downstream project it writes `/tmp/claude-rebuild-request.json` and asks for a no-cache rebuild.