### PR TITLE
fix(lifecycle): install ktn-linter via binary download in sync-toolchains

### DIFF
--- a/.devcontainer/images/.claude/commands/update/apply.md
+++ b/.devcontainer/images/.claude/commands/update/apply.md
@@ -356,7 +356,11 @@ auto_fix_stale_features() {
     └─ ghcr.io/kodflow/devcontainer-features/go:1
 
   Actions       : GHCR manifest refreshed, BuildKit cache pruned,
-                  devcontainer CLI feature cache wiped
+                  devcontainer CLI feature cache wiped,
+                  sync-toolchains.sh re-run (repopulates $GOPATH/bin on the
+                  package-cache volume — catches binaries that the feature's
+                  install.sh put under a volume-mounted path and which get
+                  masked at container start)
   CTA           : /tmp/claude-rebuild-request.json
 
   Next step     : Command Palette → "Dev Containers: Rebuild Without Cache"

--- a/.devcontainer/images/.claude/scripts/update-feature-refresh.sh
+++ b/.devcontainer/images/.claude/scripts/update-feature-refresh.sh
@@ -57,6 +57,15 @@ docker buildx prune --filter type=regular --force >/dev/null 2>&1 \
 rm -rf "${HOME}/.devcontainer/features" 2>/dev/null || true
 rm -rf "${HOME}/.cache/devcontainer-cli/features" 2>/dev/null || true
 
+# Re-run sync-toolchains in-place so volume-resident tools (Go CLI tools that
+# live under $GOPATH/bin on the package-cache volume) are repopulated IMMEDIATELY
+# without waiting for the next container start. Covers the volume-masking
+# class of issues where install.sh build-time writes are hidden by the volume.
+if [ -x /etc/devcontainer-hooks/lifecycle/sync-toolchains.sh ]; then
+    echo "Re-syncing toolchains (volume-resident binaries)..."
+    /etc/devcontainer-hooks/lifecycle/sync-toolchains.sh >/dev/null 2>&1 || true
+fi
+
 # CTA file — a VS Code extension (or an attentive human) can pick this up.
 mkdir -p /tmp
 cat > /tmp/claude-rebuild-request.json <<JSON

--- a/.devcontainer/images/hooks/lifecycle/sync-toolchains.sh
+++ b/.devcontainer/images/hooks/lifecycle/sync-toolchains.sh
@@ -114,6 +114,19 @@ sync_go() {
                 goimports)
                     go install golang.org/x/tools/cmd/goimports@latest 2>/dev/null || true
                     ;;
+                ktn-linter)
+                    # ktn-linter is published as a release binary on GitHub, NOT as a Go
+                    # module — `go install ktn-linter@latest` silently fails (not a valid
+                    # module path). Must download the release asset directly, and do it
+                    # HERE at runtime so the write lands in the already-mounted
+                    # package-cache volume (build-time writes under $GOPATH/bin are
+                    # masked by the volume at container start).
+                    curl -fsSL --connect-timeout 10 --max-time 60 \
+                         "https://github.com/kodflow/ktn-linter/releases/latest/download/ktn-linter-linux-${GO_ARCH}" \
+                         -o "$GOPATH/bin/ktn-linter" 2>/dev/null \
+                        && chmod +x "$GOPATH/bin/ktn-linter" \
+                        || true
+                    ;;
                 *)
                     go install "${tool}@latest" 2>/dev/null || true
                     ;;


### PR DESCRIPTION
## Summary

- `sync-toolchains.sh` now downloads the ktn-linter release binary instead of trying `go install ktn-linter@latest` (which silently fails — ktn-linter is published as a release asset, not as a Go module path).
- `update-feature-refresh.sh` (downstream `/update` mode) re-runs `sync-toolchains.sh` right after the BuildKit prune, so volume-resident Go tools are repopulated immediately without requiring a container rebuild.
- `update/apply.md` Phase 4.5 output documents the rescue step.

## Why

Root cause of the "ktn-linter silently missing" class of bugs:

1. `/home/vscode/.cache` is the named volume `package-cache` (`docker-compose.yml:21`). `GOPATH=/home/vscode/.cache/go` → `$GOPATH/bin` lives on that volume.
2. The Go feature's `install.sh` downloads release binaries into `$GOPATH/bin` at **build time**. The volume mount at container start **masks** those build-time writes. Any feature that doesn't have a runtime-install fallback ends up silently absent.
3. `sync-toolchains.sh` rescues the other 5 Go tools by running `go install <tool>@latest` at postStart (runtime, after mount). But for ktn-linter the default arm produced `go install ktn-linter@latest` — not a valid module path. `go install` errored, `|| true` swallowed it, and the binary never landed.

Other 5 Go tools (`golangci-lint`, `gosec`, `gofumpt`, `gotestsum`, `goimports`) were unaffected because their short names resolve as valid Go module paths via the module proxy.

## Test plan

- [ ] After merge + rebuild of downstream containers, `which ktn-linter` returns `/home/vscode/.cache/go/bin/ktn-linter` and `ktn-linter --version` works.
- [ ] `postStart.sh` logs `Syncing toolchains…` and does NOT append a ktn-linter entry to `/workspace/.claude/logs/mcp-skipped.json`.
- [ ] `ktn-linter` appears as an active MCP server in `/workspace/mcp.json`.
- [ ] On a downstream project with stale features, running `/update` logs `Re-syncing toolchains` and populates `$GOPATH/bin/ktn-linter` without a container rebuild.
- [ ] `docker-images.yml` republishes `devcontainer-template:latest` with the patched `sync-toolchains.sh` baked in (path matches `.devcontainer/images/**`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What
Install ktn-linter via direct binary download from GitHub releases instead of attempting the invalid `go install` command, and repopulate Go tools in the package-cache volume during container startup without requiring a rebuild.

## Why
The ktn-linter tool is distributed as a release asset, not a Go module, making `go install ktn-linter@latest` invalid. This caused the tool to fail silently during installation, never landing in $GOPATH/bin. Additionally, Docker volume mounts can mask build-time installations by shadowing the package-cache at runtime, requiring explicit runtime repopulation of tool binaries.

## How
- Modified `sync-toolchains.sh` to detect missing ktn-linter and download the appropriate GitHub release binary via `curl` for the computed architecture, placing it directly in `$GOPATH/bin` with executable permissions
- Extended `update-feature-refresh.sh` to conditionally run `sync-toolchains.sh` after cache pruning operations, immediately repopulating volume-resident binaries within the running container
- Updated `update/apply.md` documentation to describe this rescue step in the downstream /update mode workflow

## Risk
- Introduces external dependency on GitHub releases endpoint availability and URL stability; if release structure changes, binary download fails (currently suppressed with `|| true`)
- Adds runtime network I/O during container startup via `curl`; depends on curl availability and network connectivity
- Supply chain consideration: binary download replaces Go module verification; validate release integrity mechanisms are adequate

<!-- end of auto-generated comment: release notes by coderabbit.ai -->