### PR TITLE
feat(docs): propagate learned patterns to template + lite installer (closes #331)

### DIFF
--- a/.devcontainer/images/.claude/docs/README.md
+++ b/.devcontainer/images/.claude/docs/README.md
@@ -31,6 +31,19 @@ Total: 167 markdown files - 300+ documented patterns
 
 ---
 
+## Learned Patterns
+
+Operational guardrails extracted from real sessions — propagated to all
+consumers via `/update`. Always shipped (even in `install.sh --minimal`)
+because they protect users from concrete past failures.
+
+| Pattern | Description | File |
+|---------|-------------|------|
+| agent-git-stash-destruction | Forbid `git stash/reset/checkout` in agent prompts (cost: 6h of ktn-linter work) | [learned/agent-git-stash-destruction.md](learned/agent-git-stash-destruction.md) |
+| super-claude-auto-mode-fallback | Prefer `--permission-mode auto` over broken bypass on Claude Code v2.1.113+ | [learned/super-claude-auto-mode-fallback.md](learned/super-claude-auto-mode-fallback.md) |
+
+---
+
 ## Quick Lookup by Problem
 
 | I need to... | Patterns | Category |

--- a/.devcontainer/images/.claude/docs/learned/agent-git-stash-destruction.md
+++ b/.devcontainer/images/.claude/docs/learned/agent-git-stash-destruction.md
@@ -1,0 +1,117 @@
+---
+name: agent-git-stash-destruction
+category: learned
+extracted: 2026-04-26T11:00:00+02:00
+confidence: 0.98
+trigger: "Avant de spawner des agents avec accès Bash sur un repo git"
+source: session — 6h de travail perdu sur ktn-linter fix/linter-feedback
+---
+# Agents With Full Bash Access Destroy Git Working Tree via git stash
+
+## Problem
+
+Quand des agents `general-purpose` (avec `Bash` complet) travaillent en parallèle sur un repo git,
+ils tentent souvent de revenir en arrière sur leurs propres erreurs via `git stash`, `git checkout`,
+ou `git reset`. Ces opérations détruisent le travail des autres agents ET leur propre travail.
+
+Symptômes dans le reflog :
+
+```
+56ff8ebe HEAD@{...}: reset: moving to HEAD   ← signature de git stash
+56ff8ebe HEAD@{...}: reset: moving to HEAD   ← idem, 17 fois en 6h
+```
+
+Dangling commits WIP dans `git fsck --dangling` = preuve que des stashes ont été créés :
+
+```
+dangling commit 91e7c996...  WIP on fix/linter-feedback: 56ff8ebe
+dangling commit f6171cc6...  WIP on fix/linter-feedback: 56ff8ebe
+```
+
+Ces stashes sont souvent **incomplets** (untracked new files absents) → irrécupérables.
+
+**Résultat** : 6h de travail de 5 vagues × 10 agents (775 → 0 violations) PERDU en une nuit.
+
+## Solution
+
+### 1. Interdiction explicite dans chaque prompt agent (OBLIGATOIRE)
+
+```markdown
+## GIT OPERATIONS — STRICTLY FORBIDDEN
+- NEVER run: git stash, git stash pop, git stash apply
+- NEVER run: git reset (any form)
+- NEVER run: git checkout -- <file> (to revert files)
+- NEVER run: git restore
+- IF your edit is wrong: use Edit/Write tools to fix it directly — NEVER revert via git
+- IF you need to investigate: READ files, do NOT checkout old versions
+```
+
+### 2. Commit après chaque wave réussie (OBLIGATOIRE)
+
+Après chaque vague d'agents, avant de lancer la suivante :
+
+```bash
+go build ./... && go test ./... && ktn-linter prompt ./...
+# Si OK :
+git add -A && git commit -m "fix(linter): wave N — X violations fixed"
+```
+
+Un commit protège le travail des stashes accidentels futurs.
+
+### 3. Utiliser la restriction de scope via isolation="worktree" (RECOMMANDÉ)
+
+```python
+Agent(
+    description="Fix pkg/foo",
+    isolation="worktree",  # worktree propre, pas de pollution du repo principal
+    ...
+)
+```
+
+Chaque agent dans son worktree ne peut pas toucher le worktree principal.
+
+### 4. Ne jamais utiliser `general-purpose` pour des fix multi-fichiers sans whitelist git
+
+```
+BAD:  subagent_type: "general-purpose"  # a tous les outils dont git
+GOOD: subagent_type: "developer-specialist-go"  # Read/Glob/Grep/Bash/WebFetch seulement
+                                                  # pas d'Edit/Write → orchestrateur applique
+```
+
+Ou utiliser `general-purpose` avec le prompt GIT FORBIDDEN ci-dessus.
+
+## Exemple de prompt agent sûr
+
+```markdown
+# Task: Fix KTN violations in pkg/foo/
+
+## GIT OPERATIONS — STRICTLY FORBIDDEN
+- NEVER: git stash, git reset, git checkout --, git restore
+- To undo a bad edit: use Edit/Write to correct directly
+
+## SCOPE
+- ONLY edit files in /workspace/pkg/foo/
+
+## VERIFICATION
+1. go build ./pkg/foo/...
+2. go test ./pkg/foo/...
+3. ./builds/ktn-linter lint ./pkg/foo/... → 0 warnings
+```
+
+## When to Use
+
+**TOUJOURS** avant de spawner des agents qui font des modifications de code sur un repo git :
+
+- Multi-agent waves (10 agents en parallèle)
+- Agents long-running (>5 min)
+- Sessions "je vais me coucher" / autonomous mode
+
+## Evidence
+
+Session ktn-linter 2026-04-26 :
+
+- 5 waves × 10 agents, 775 → 0 violations atteint
+- Agent validate-fix (22 min, 187 tool_uses) a utilisé git pour investigation
+- 17 `reset: moving to HEAD` dans reflog = 17 stash operations
+- Dangling commits WIP récupérables mais INCOMPLETS (untracked files absents)
+- Travail irrécupérable, retour à l'état initial (775 violations)

--- a/.devcontainer/images/.claude/docs/learned/super-claude-auto-mode-fallback.md
+++ b/.devcontainer/images/.claude/docs/learned/super-claude-auto-mode-fallback.md
@@ -1,0 +1,83 @@
+---
+name: super-claude-auto-mode-fallback
+category: learned
+extracted: 2026-04-26T10:45:00Z
+confidence: 0.95
+trigger: "When updating super-claude() function or launch config for Claude Code"
+source: session
+---
+# super-claude: Auto Mode with Bypass Fallback
+
+## Problem
+
+Claude Code `--dangerously-skip-permissions` (and `defaultMode: "bypassPermissions"` in settings.json)
+is BROKEN for `.claude/` and `.git/` paths since **v2.1.113** (April 17, 2026). These paths are
+hardcoded as always-protected, ignoring both `permissions.allow` rules and `bypassPermissions` mode.
+The user is prompted repeatedly for routine operations (e.g., writing to `.claude/contexts/`,
+`.claude/plans/`, `.git/index.lock`).
+
+Root cause: Anthropic tightened sensitive-file protection in v2.1.113 and intentionally chose NOT
+to fix bypass — pivoting to Auto Mode instead.
+
+Confirmed by: GitHub issues `anthropics/claude-code#43953`, `#37253`, `#42366`, `#36168`.
+
+## Solution
+
+Replace the hardcoded `--dangerously-skip-permissions` in `super-claude()` with a version-aware
+flag: prefer `--permission-mode auto` when Claude Code supports `--permission-mode` (v2.1.113+),
+fallback to `--dangerously-skip-permissions` for older containers.
+
+Detection at shell init (once per session, not per invocation):
+
+```bash
+if claude --help 2>&1 | grep -q -- '--permission-mode'; then
+    _CLAUDE_PERM_FLAG="--permission-mode auto"
+else
+    _CLAUDE_PERM_FLAG="--dangerously-skip-permissions"
+fi
+```
+
+## Example
+
+```bash
+# BAD — hardcoded bypass (broken on v2.1.113+ for .claude/ .git/)
+super-claude() {
+    claude --dangerously-skip-permissions "$@"
+}
+
+# GOOD — auto mode with fallback
+if claude --help 2>&1 | grep -q -- '--permission-mode'; then
+    _CLAUDE_PERM_FLAG="--permission-mode auto"
+else
+    _CLAUDE_PERM_FLAG="--dangerously-skip-permissions"
+fi
+
+super-claude() {
+    claude ${_CLAUDE_PERM_FLAG} "$@"
+}
+```
+
+## When to Use
+
+- Any time `super-claude()` is defined or regenerated (postCreate.sh, devcontainer-env.sh)
+- When a user reports "bypass mode still prompts" on `.claude/` or `.git/` paths
+- When building a new container image that should work without user interaction
+
+## Why Auto Mode is Better Than Bypass
+
+| | bypass (broken v2.1.113+) | --permission-mode auto |
+|---|---|---|
+| `.claude/`, `.git/` prompts | YES (regression) | No |
+| Truly destructive ops | Sometimes no prompt | Prompted (model judges) |
+| Mechanism | Hardcoded path list | ML classifier per-action |
+| Future-proof | No (more paths added) | Yes |
+
+## Files to Update
+
+- `~/.devcontainer-env.sh` — live shell function (current container)
+- `.devcontainer/images/hooks/lifecycle/postCreate.sh` — template (new containers)
+
+## Evidence
+
+Discovered 2026-04-26 after user reported 11 consecutive permission prompts during `/search`
+parallel agent execution. Research confirmed via 10 parallel agents + GitHub issue analysis.

--- a/.devcontainer/images/hooks/lifecycle/postCreate.sh
+++ b/.devcontainer/images/hooks/lifecycle/postCreate.sh
@@ -300,17 +300,22 @@ sdk() {
 # ----------------------------------------------------------------------------
 
 # Detect permission flag once at shell init — avoids re-running `claude --help`
-# on every super-claude invocation. Auto mode (v2.1.113+) is Anthropic's
+# on every super-claude invocation. Auto mode (v2.1.113+) is the upstream
 # replacement for --dangerously-skip-permissions, which has been broken since
 # v2.1.113 for `.claude/` and `.git/` paths (regression: hardcoded protected
 # directories ignore bypassPermissions). Older containers without
 # --permission-mode fall back to the legacy bypass flag automatically.
+#
+# Stored as a bash ARRAY so the multi-token "--permission-mode auto" form
+# expands to two argv entries without unquoted word-splitting (shellcheck
+# SC2086, Qodo finding on PR #332). Use "${_CLAUDE_PERM_FLAG[@]}" at call sites.
 # See: ~/.claude/docs/learned/super-claude-auto-mode-fallback.md
 if claude --help 2>&1 | grep -q -- '--permission-mode'; then
-    _CLAUDE_PERM_FLAG="--permission-mode auto"
+    _CLAUDE_PERM_FLAG=(--permission-mode auto)
 else
-    _CLAUDE_PERM_FLAG="--dangerously-skip-permissions"
+    _CLAUDE_PERM_FLAG=(--dangerously-skip-permissions)
 fi
+export _CLAUDE_PERM_FLAG
 
 # super-claude: runs claude with auto/bypass mode + MCP config if available
 super-claude() {
@@ -320,17 +325,17 @@ super-claude() {
     if ! command -v jq &>/dev/null; then
         echo "Warning: jq not found, skipping MCP config validation" >&2
         if [ -s "$mcp_config" ] && LC_ALL=C tr -d ' \t\r\n' < "$mcp_config" 2>/dev/null | head -c 1 | grep -q '{'; then
-            claude ${_CLAUDE_PERM_FLAG} --mcp-config "$mcp_config" "$@"
+            claude "${_CLAUDE_PERM_FLAG[@]}" --mcp-config "$mcp_config" "$@"
         else
-            claude ${_CLAUDE_PERM_FLAG} "$@"
+            claude "${_CLAUDE_PERM_FLAG[@]}" "$@"
         fi
         return
     fi
 
     if [ -f "$mcp_config" ] && jq empty "$mcp_config" 2>/dev/null; then
-        claude ${_CLAUDE_PERM_FLAG} --mcp-config "$mcp_config" "$@"
+        claude "${_CLAUDE_PERM_FLAG[@]}" --mcp-config "$mcp_config" "$@"
     else
-        claude ${_CLAUDE_PERM_FLAG} "$@"
+        claude "${_CLAUDE_PERM_FLAG[@]}" "$@"
     fi
 }
 

--- a/.devcontainer/images/hooks/lifecycle/postCreate.sh
+++ b/.devcontainer/images/hooks/lifecycle/postCreate.sh
@@ -299,26 +299,38 @@ sdk() {
 # Aliases
 # ----------------------------------------------------------------------------
 
-# super-claude: runs claude with MCP config if available, otherwise without
+# Detect permission flag once at shell init — avoids re-running `claude --help`
+# on every super-claude invocation. Auto mode (v2.1.113+) is Anthropic's
+# replacement for --dangerously-skip-permissions, which has been broken since
+# v2.1.113 for `.claude/` and `.git/` paths (regression: hardcoded protected
+# directories ignore bypassPermissions). Older containers without
+# --permission-mode fall back to the legacy bypass flag automatically.
+# See: ~/.claude/docs/learned/super-claude-auto-mode-fallback.md
+if claude --help 2>&1 | grep -q -- '--permission-mode'; then
+    _CLAUDE_PERM_FLAG="--permission-mode auto"
+else
+    _CLAUDE_PERM_FLAG="--dangerously-skip-permissions"
+fi
+
+# super-claude: runs claude with auto/bypass mode + MCP config if available
 super-claude() {
     local mcp_config="/workspace/mcp.json"
 
     # Check if jq is available for JSON validation
     if ! command -v jq &>/dev/null; then
         echo "Warning: jq not found, skipping MCP config validation" >&2
-        # Still use mcp config if it looks like JSON (skip leading whitespace/newlines)
         if [ -s "$mcp_config" ] && LC_ALL=C tr -d ' \t\r\n' < "$mcp_config" 2>/dev/null | head -c 1 | grep -q '{'; then
-            claude --dangerously-skip-permissions --mcp-config "$mcp_config" "$@"
+            claude ${_CLAUDE_PERM_FLAG} --mcp-config "$mcp_config" "$@"
         else
-            claude --dangerously-skip-permissions "$@"
+            claude ${_CLAUDE_PERM_FLAG} "$@"
         fi
         return
     fi
 
     if [ -f "$mcp_config" ] && jq empty "$mcp_config" 2>/dev/null; then
-        claude --dangerously-skip-permissions --mcp-config "$mcp_config" "$@"
+        claude ${_CLAUDE_PERM_FLAG} --mcp-config "$mcp_config" "$@"
     else
-        claude --dangerously-skip-permissions "$@"
+        claude ${_CLAUDE_PERM_FLAG} "$@"
     fi
 }
 

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -40,7 +40,7 @@ Usage:
   DC_TARGET=/path curl -fsSL URL | bash    # Custom target directory
 
 Options:
-  --minimal    Skip documentation installation (saves ~2.4MB, 155 files)
+  --minimal    Skip 155 design-pattern docs (saves ~2.4MB). Learned patterns (operational guardrails) are still downloaded.
   --no-teams   Force-disable Agent Teams feature even if Claude Code supports it.
                Skills will always use the legacy Task-tool dispatch. Use this on
                third-party containers where you want zero experimental behavior.
@@ -511,8 +511,22 @@ download_scripts() {
 download_docs() {
     local target_dir="$1"
 
+    # Even in --minimal mode, always pull the `learned/` patterns. They are
+    # operational guardrails (e.g. "agents must not git stash") that protect
+    # the user's work and are cheap to ship (typically a handful of files).
+    # Skipping them in minimal mode silently drops protections users rely on.
     if [ "$INSTALL_MINIMAL" = true ]; then
-        echo "→ Skipping documentation (--minimal mode)"
+        mkdir -p "$target_dir/docs/learned"
+        echo "→ Downloading learned patterns only (--minimal mode)..."
+        local learned_files learned_count=0
+        learned_files=$(github_api_call "$API/.devcontainer/images/.claude/docs/learned" 2>/dev/null \
+            | jq -r '.[].name' 2>/dev/null | grep '\.md$' || echo "")
+        for file in $learned_files; do
+            if safe_download "$BASE/.devcontainer/images/.claude/docs/learned/$file" "$target_dir/docs/learned/$file"; then
+                learned_count=$((learned_count + 1))
+            fi
+        done
+        echo "  ✓ Downloaded $learned_count learned pattern(s) (full design-patterns docs skipped)"
         return 0
     fi
 

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -518,14 +518,54 @@ download_docs() {
     if [ "$INSTALL_MINIMAL" = true ]; then
         mkdir -p "$target_dir/docs/learned"
         echo "→ Downloading learned patterns only (--minimal mode)..."
-        local learned_files learned_count=0
-        learned_files=$(github_api_call "$API/.devcontainer/images/.claude/docs/learned" 2>/dev/null \
-            | jq -r '.[].name' 2>/dev/null | grep '\.md$' || echo "")
-        for file in $learned_files; do
+
+        # Hard-coded fallback list — learned patterns are the operational
+        # guardrails users depend on, and silently shipping zero of them
+        # because the GitHub API or jq returned nothing defeats the whole
+        # reason this branch exists. The list MUST be kept in sync with
+        # .devcontainer/images/.claude/docs/learned/*.md (CodeRabbit/Qodo, #332).
+        local learned_fallback=(
+            "agent-git-stash-destruction.md"
+            "super-claude-auto-mode-fallback.md"
+        )
+
+        # Try API discovery first; fall back to the hard-coded list on failure.
+        local discovered_files
+        discovered_files=$(github_api_call "$API/.devcontainer/images/.claude/docs/learned" 2>/dev/null \
+            | jq -r '.[]?.name // empty' 2>/dev/null | grep '\.md$' || echo "")
+
+        local learned_files=()
+        if [ -n "$discovered_files" ]; then
+            # Read line-by-line so filenames with whitespace stay intact.
+            while IFS= read -r f; do
+                # Only accept simple basenames (defense against API
+                # poisoning / path traversal).
+                case "$f" in
+                    */*|.*|"") continue ;;
+                    *.md) learned_files+=("$f") ;;
+                esac
+            done <<<"$discovered_files"
+        fi
+
+        if [ "${#learned_files[@]}" -eq 0 ]; then
+            echo "  ⚠ API discovery returned no learned files — falling back to hard-coded list"
+            learned_files=("${learned_fallback[@]}")
+        fi
+
+        local learned_count=0
+        for file in "${learned_files[@]}"; do
             if safe_download "$BASE/.devcontainer/images/.claude/docs/learned/$file" "$target_dir/docs/learned/$file"; then
                 learned_count=$((learned_count + 1))
             fi
         done
+
+        if [ "$learned_count" -eq 0 ]; then
+            echo "  ✗ Downloaded 0 learned pattern(s) — operational guardrails missing!" >&2
+            echo "    This is a hard failure: install MUST ship the safety patterns." >&2
+            echo "    Check network access to raw.githubusercontent.com." >&2
+            return 1
+        fi
+
         echo "  ✓ Downloaded $learned_count learned pattern(s) (full design-patterns docs skipped)"
         return 0
     fi


### PR DESCRIPTION
## Summary

Closes #331. Two operational guardrails — extracted from real session failures — are now shipped to every consumer of the devcontainer template (built-in image, OCI features, standalone `install.sh` including `--minimal` mode).

### The two patterns

| Pattern | Origin | Cost of NOT having it |
|---|---|---|
| `agent-git-stash-destruction` | ktn-linter session 2026-04-26 | **6h of work erased** — parallel `general-purpose` agents `git stash`'d each other's WIP, dangling commits incomplete (17 `reset: moving to HEAD` in reflog) |
| `super-claude-auto-mode-fallback` | bypass regression session 2026-04-26 | Continuous "yes/yes" prompts on every `.claude/` and `.git/` write since Claude Code v2.1.113 broke `bypassPermissions` |

### Distribution flow

The `learned/` directory now reaches consumers through every channel:

| Channel | Mechanism |
|---|---|
| Built-in image | Already restored at `postStart` from `/etc/claude-defaults/` (no change) |
| `claude-assets.tar.gz` | `generate-assets-archive.sh` already archives `docs/` (no change) — verified locally that the new `learned/*.md` are bundled |
| `install.sh` (full) | Auto-discovered via the existing GitHub category-list scan (no change) |
| `install.sh --minimal` | **NEW**: explicitly downloads `learned/` even when it skips the 155 design-pattern docs. Operational guardrails are too important to skip |

### Files changed

| File | Change |
|---|---|
| `.devcontainer/images/.claude/docs/learned/agent-git-stash-destruction.md` | NEW — full pattern with reproduction, evidence, fix, examples |
| `.devcontainer/images/.claude/docs/learned/super-claude-auto-mode-fallback.md` | NEW — bypass→auto migration with version detection |
| `.devcontainer/images/.claude/docs/README.md` | New "Learned Patterns" section indexing both |
| `.devcontainer/images/hooks/lifecycle/postCreate.sh` | `super-claude()` uses `--permission-mode auto` with `--dangerously-skip-permissions` fallback for old containers (detection runs once per shell init, not per invocation) |
| `.devcontainer/install.sh` | `--minimal` mode now still downloads `learned/`; help text updated |

### Verification

```text
$ bash .devcontainer/scripts/generate-assets-archive.sh --output /tmp/test.tar.gz
  ✓ Archive created: 864K, 420 files
$ tar -tzf /tmp/test.tar.gz | grep learned/
docs/learned/
docs/learned/agent-git-stash-destruction.md
docs/learned/super-claude-auto-mode-fallback.md
$ bash -n .devcontainer/install.sh && bash -n .devcontainer/images/hooks/lifecycle/postCreate.sh
  syntax OK on both
```

### Not in this PR (out of scope)

The user-facing `super-claude()` change is structurally compatible with the running session (already applied to `~/.devcontainer-env.sh` for the current container). New containers will pick it up automatically via `postCreate.sh`.

## Test plan

- [x] Archive contains both `learned/*.md` (verified locally)
- [x] `install.sh` syntax OK
- [x] `postCreate.sh` syntax OK
- [x] `super-claude()` runtime detection works (`claude --help | grep -q -- '--permission-mode'` returns true on v2.1.119, picks `--permission-mode auto`)
- [x] Fallback path inert on current version (would only fire on pre-v2.1.113 containers)
- [ ] CI green (this PR)
- [ ] Manual: verify on a stale container that lacks `--permission-mode` that the fallback picks `--dangerously-skip-permissions`

Closes #331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**What**
Propagates two learned operational guardrail patterns to all devcontainer consumers: `agent-git-stash-destruction` (forbids destructive git operations in multi-agent workflows to prevent data loss) and `super-claude-auto-mode-fallback` (detects and adapts to Claude CLI permission-mode API changes across versions).

**Why**
Addresses issue #331 by distributing guardrails learned from production incidents. The git stash/reset/checkout destruction pattern caused ~6 hours of work loss when parallel general-purpose agents ran these commands. The super-claude permission flag pattern prevents breakage when Claude CLI versions ≥v2.1.113 changed from `--dangerously-skip-permissions` to `--permission-mode auto`.

**How**
- Added two new learned pattern documentation files (`agent-git-stash-destruction.md` and `super-claude-auto-mode-fallback.md`) under `.devcontainer/images/.claude/docs/learned/`
- Updated `docs/README.md` with "Learned Patterns" section indexing the new guardrails
- Modified `postCreate.sh` to detect Claude CLI capability (`claude --help | grep --permission-mode`) at shell init and set `_CLAUDE_PERM_FLAG` bash array with the appropriate flag, falling back to `--dangerously-skip-permissions` for older versions
- Extended `install.sh --minimal` to explicitly download learned patterns via GitHub API discovery with hard-coded fallback list and safe file filtering
- Updated install.sh help text to clarify that learned patterns are included even in minimal mode

**Risk**
- **Bash compatibility**: `postCreate.sh` changed to use bash arrays (`"${_CLAUDE_PERM_FLAG[@]}"`) for proper variable expansion; requires bash (not POSIX sh)
- **API fallback robustness**: install.sh relies on GitHub API enumeration with hard-coded fallback list; discovery failures now cause explicit installation error rather than silent omission
- **Path traversal protection**: install.sh now sanitizes learned filenames and rejects dotfiles/non-`.md` entries to prevent injection
- **Version detection timing**: super-claude permission flag detection runs once per shell session; if Claude CLI is installed/upgraded mid-session, the flag may become stale
- **Behavioral change**: install.sh --minimal now always downloads learned patterns; previously downloaded nothing; requires network access even in minimal mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->