### PR TITLE
fix(ci): repair release workflow_run trigger + extend path filters

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,21 @@ jobs:
         run: |
           TAG="v$(date -u +'%Y.%m.%d')-${TARGET_SHA::7}"
 
-          # Delete existing 'latest' release if it exists (keep only one)
+          # Delete pre-existing release for THIS dated tag — same commit
+          # can produce TWO release.yml runs (push paths + workflow_run
+          # after Build Docker Images), and `gh release create $TAG`
+          # would fail on the second run because the tag already exists.
+          # Identified by Qodo on PR #333.
+          gh release delete "$TAG" --yes --cleanup-tag 2>/dev/null || true
+
+          # Delete the legacy "latest" tag too (back-compat with the
+          # pre-dated-tag scheme some old releases still use).
           gh release delete latest --yes 2>/dev/null || true
           git push origin :refs/tags/latest 2>/dev/null || true
 
-          # Create new release tagged 'latest' + dated tag
+          # Create new release tagged dated + flagged --latest. Idempotent
+          # now: a re-run for the same SHA/day will delete and recreate
+          # rather than fail.
           gh release create "$TAG" \
             claude-assets.tar.gz \
             --title "Release $TAG" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,22 @@ name: Release
 on:
   push:
     branches: [main]
+    # Path filters: any change that gets bundled into claude-assets.tar.gz
+    # MUST trigger a re-release. The standalone install.sh fast-path downloads
+    # this archive — if it's stale, new users miss the latest patterns/agents.
     paths:
       - ".devcontainer/features/**"
       - ".devcontainer/hooks/**"
+      - ".devcontainer/images/.claude/**"
+      - ".devcontainer/scripts/generate-assets-archive.sh"
       - ".github/workflows/release.yml"
   workflow_run:
-    workflows: ["Build Docker Image"]
+    # MUST match the `name:` field of docker-images.yml exactly. Was
+    # "Build Docker Image" (singular) — typo silently broke the chain so
+    # release was only refreshed when push paths matched. Now `Build Docker
+    # Images` (plural), matching `name: Build Docker Images` in
+    # docker-images.yml. Verified by grep on 2026-04-26.
+    workflows: ["Build Docker Images"]
     types: [completed]
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Two related bugs in `release.yml` prevented `claude-assets.tar.gz` from being regenerated whenever changes hit `.devcontainer/images/.claude/**` (docs, learned patterns, agents, slash commands, hook scripts) — the very content the standalone `install.sh` fast-path downloads.

### Bug 1: typo in `workflow_run` (silent regression)

```diff
-    workflows: ["Build Docker Image"]
+    workflows: ["Build Docker Images"]
```

`docker-images.yml` declares `name: Build Docker Images` (plural). GitHub Actions matches `workflow_run` by exact string — the singular form here meant the chain **never fired**. Releases only happened when the `push` path filter matched.

Discovered today after merging #332 (a docs-only change touching `.devcontainer/images/.claude/docs/learned/*`): the docker-images build ran, the workflow_run chain didn't fire, and `claude-assets.tar.gz` stayed pinned at the pre-#332 SHA. Manual `gh workflow run release.yml` fixed it for that release, but the underlying bug was the typo.

### Bug 2: push path filter too narrow

The filter listed `features/`, `hooks/`, and the workflow itself — but `generate-assets-archive.sh` archives everything under `.devcontainer/images/.claude/` (agents, commands, scripts, docs, settings.json). Changes there must trigger a re-release.

```diff
     paths:
       - ".devcontainer/features/**"
       - ".devcontainer/hooks/**"
+      - ".devcontainer/images/.claude/**"
+      - ".devcontainer/scripts/generate-assets-archive.sh"
       - ".github/workflows/release.yml"
```

Also added the generator script itself — if its bundling logic ever changes, the archive must be regenerated to reflect that.

### Defense-in-depth design

After this fix, **two independent triggers** keep the release fresh:
- **Direct path match** (push) — fires immediately for relevant edits, no waiting on docker build
- **workflow_run after Build Docker Images** — catches anything that triggered the docker rebuild (e.g. workflow file edits, schedule, repository_dispatch)

Either one is sufficient; both running concurrently is harmless because release.yml's `concurrency.cancel-in-progress: false` lets them complete sequentially.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('release.yml'))"` → OK
- [x] `grep "^name:" docker-images.yml` ≡ `grep "workflows:" release.yml` (verified by hand)
- [ ] CI green on this PR
- [ ] Post-merge: this PR itself touches `.github/workflows/release.yml` so it should trigger release.yml via the existing path filter — that's the behavioral test
- [ ] Manual: a future docs-only commit on `.devcontainer/images/.claude/**` should produce a fresh `latest` GitHub Release without manual dispatch

## Refs

- Discovered while completing PR #332 (propagate learned patterns)
- Fixes the underlying mechanism that PR #332's manual workflow_dispatch worked around

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
What  
Fix CI release workflow triggers and make release-job idempotent: ensure releases (and claude-assets.tar.gz) are regenerated when relevant Claude-related files change and prevent tag-creation failures on duplicate runs.

Why  
Two issues prevented release.yml from running when image assets changed: the `workflow_run` trigger referenced the wrong workflow name ("Build Docker Image" vs "Build Docker Images"), and `push` path filters omitted `.devcontainer/images/.claude/**` and the asset generator script. Additionally, the dual-trigger setup could run the release job twice for the same SHA and fail creating an already-existing dated tag.

How  
- Corrected `workflow_run` to require "Build Docker Images" to match docker-images.yml.  
- Extended `push` path filters to include `.devcontainer/images/.claude/**` and `.devcontainer/scripts/generate-assets-archive.sh`, so changes to agents, commands, scripts, docs, settings, or the generator trigger the release.  
- Added idempotency in the release job: if the dated release/tag for the computed `$TAG` already exists (second run for same SHA/day), delete it (with --cleanup-tag) before re-creating, so replayed runs succeed.  
- Kept two independent triggers (direct push and workflow_run) and left `concurrency.cancel-in-progress: false` so runs serialize rather than cancel.

Risk  
Low-risk CI/workflow-only changes with no public API or dependency additions. Notable risk zones: release/tag manipulation is security-sensitive — the job now explicitly deletes and re-creates dated releases/tags (supply-chain / release integrity consideration). No changes to secrets/authentication, but reviewers should confirm GH token permissions and that deleting/recreating releases fits project policy. Concurrency remains serialized; no DB migrations or caching invalidations. Tests: YAML parsing and workflow-name match validated locally; full CI/post-merge behavior still pending verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->