### PR TITLE
fix(postStart): protect consumer-modified files from features/ force-sync (#334)

### DIFF
--- a/.devcontainer/images/.claude/commands/update/apply.md
+++ b/.devcontainer/images/.claude/commands/update/apply.md
@@ -99,9 +99,8 @@ apply_devcontainer_tarball() {
     # Image-embedded hooks (container only)
     if [ "$CONTEXT" = "container" ] && [ -d "$src/.devcontainer/images/hooks" ]; then
         mkdir -p ".devcontainer/images/hooks/shared" ".devcontainer/images/hooks/lifecycle"
-        [ -f "$src/.devcontainer/images/hooks/shared/utils.sh" ] && \
-            cp -f "$src/.devcontainer/images/hooks/shared/utils.sh" ".devcontainer/images/hooks/shared/utils.sh" && \
-            chmod +x ".devcontainer/images/hooks/shared/utils.sh"
+        # All shared helpers (utils.sh, sync-features.sh, …)
+        safe_glob_copy "$src/.devcontainer/images/hooks/shared/*.sh" ".devcontainer/images/hooks/shared" "+x"
         safe_glob_copy "$src/.devcontainer/images/hooks/lifecycle/*.sh" ".devcontainer/images/hooks/lifecycle" "+x"
         echo "  ✓ image-hooks"
     fi
@@ -138,19 +137,37 @@ apply_devcontainer_tarball() {
         echo "  ✓ mcp-fragments"
     fi
 
-    # DevContainer features (container only) — mirror from tarball.
+    # DevContainer features (container only) — mirror from tarball using the
+    # 3-way safe sync helper (same code path as postStart's step_sync_features).
     # postStart also force-syncs from the image's embedded copy; /update brings
     # them current immediately without waiting for the next image rebuild.
     # The updated .template-version written in §5.7 tells postStart to yield
     # when the repo is ahead of the image.
+    # Bug ref: kodflow/devcontainer-template#334 — silent overwrite of
+    # consumer-modified files. Phase 1 protection: per-file git-dirty guard.
     if [ "$CONTEXT" = "container" ] && [ -d "$src/.devcontainer/features" ]; then
-        mkdir -p ".devcontainer/features"
-        if command -v rsync &>/dev/null; then
-            rsync -a --delete "$src/.devcontainer/features/" ".devcontainer/features/"
-        else
-            rm -rf ".devcontainer/features"
+        local helper="$src/.devcontainer/images/hooks/shared/sync-features.sh"
+        local utils="$src/.devcontainer/images/hooks/shared/utils.sh"
+        if [ -f "$helper" ] && [ -f "$utils" ]; then
+            # shellcheck source=/dev/null
+            source "$utils"
+            # shellcheck source=/dev/null
+            source "$helper"
             mkdir -p ".devcontainer/features"
-            cp -rf "$src/.devcontainer/features/." ".devcontainer/features/"
+            sync_features_tree "$src/.devcontainer/features" \
+                "$(pwd)/.devcontainer/features" "$(pwd)"
+        else
+            # Fallback: tarball missing the helper (older template) — keep the
+            # legacy behaviour but warn the user to re-run /update afterwards.
+            echo "  ⚠ sync-features.sh missing in tarball; falling back to rsync (#334)"
+            mkdir -p ".devcontainer/features"
+            if command -v rsync &>/dev/null; then
+                rsync -a --delete "$src/.devcontainer/features/" ".devcontainer/features/"
+            else
+                rm -rf ".devcontainer/features"
+                mkdir -p ".devcontainer/features"
+                cp -rf "$src/.devcontainer/features/." ".devcontainer/features/"
+            fi
         fi
         echo "  ✓ features"
     fi

--- a/.devcontainer/images/CLAUDE.md
+++ b/.devcontainer/images/CLAUDE.md
@@ -43,13 +43,14 @@ Claude Code and MCP servers are included; languages added via features.
 | `.claude/docs/` | `~/.claude/docs/` | `/etc/claude-defaults/docs/` |
 | `mcp.json.tpl` | `/etc/mcp/mcp.json.tpl` | - |
 | `hooks/` | `/etc/devcontainer-hooks/` | - |
-| `features/` (CI-staged) | `/etc/devcontainer-template/features/` | Force-synced to `.devcontainer/features/` |
+| `features/` (CI-staged) | `/etc/devcontainer-template/features/` | 3-way safe-synced to `.devcontainer/features/` |
 
 **Note:** Claude files restored from `/etc/claude-defaults/` at each start via `postStart.sh`.
 Lifecycle hooks called directly from `devcontainer.json` → `/etc/devcontainer-hooks/` (no stubs).
-`.devcontainer/features/` is rsync-mirrored from `/etc/devcontainer-template/features/` at every
-`postStart` in consumer projects (step `step_sync_features`). Template repo self-skips via
-`.devcontainer/.template-version` commit match.
+`.devcontainer/features/` is **3-way merged** from `/etc/devcontainer-template/features/` at every
+`postStart` (step `step_sync_features`, helper `shared/sync-features.sh`). Per-file protection:
+files with uncommitted consumer edits are **preserved** with a `[WARNING]` log (issue #334).
+Template repo self-skips via `.devcontainer/.template-version` commit match.
 
 ## Design Patterns Knowledge Base
 

--- a/.devcontainer/images/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/images/hooks/lifecycle/postStart.sh
@@ -1354,22 +1354,34 @@ init_vpn() {
     return 0
 }
 
-# Force-sync .devcontainer/features/ from image-embedded copy (always overwrites).
-# Consumer projects get upstream template features at every container start.
-# Auto-skips when running inside the template repo itself (detected via
-# .devcontainer/.template-version matching git HEAD).
+# Sync .devcontainer/features/ from image-embedded copy with consumer-edit
+# protection (3-way safe). Consumer projects get upstream template features at
+# every container start without clobbering their own edits.
+#
+# Skip layers (in order):
+#   1. Self-exclusion when running inside the template repo itself.
+#   2. /update harmony when consumer ran /update on a fresher template.
+#   3. Per-file: see shared/sync-features.sh (_sync_file_safely):
+#      - byte-identical → noop
+#      - tracked + git-dirty → preserve consumer WIP, log warning
+#      - manifest-known + dst==prev_hash → safe overwrite (Phase 2)
+#      - otherwise → overwrite (narrowed by Phase 2 manifest)
+#
+# Bug ref: kodflow/devcontainer-template#334 (silent overwrite of edited
+# CLAUDE.md / consumer files when global .template-version lagged image).
 step_sync_features() {
     local src="/etc/devcontainer-template/features"
     local dst="${WORKSPACE_FOLDER:-/workspace}/.devcontainer/features"
-    local marker="${WORKSPACE_FOLDER:-/workspace}/.devcontainer/.template-version"
+    local ws="${WORKSPACE_FOLDER:-/workspace}"
+    local marker="$ws/.devcontainer/.template-version"
 
     if [ ! -d "$src" ]; then
         log_info "No embedded features dir in image, skipping sync"
         return 0
     fi
 
-    if [ ! -d "${WORKSPACE_FOLDER:-/workspace}/.devcontainer" ]; then
-        log_warn "No .devcontainer/ in workspace, skipping features sync"
+    if [ ! -d "$ws/.devcontainer" ]; then
+        log_warning "No .devcontainer/ in workspace, skipping features sync"
         return 0
     fi
 
@@ -1377,7 +1389,7 @@ step_sync_features() {
     if [ -f "$marker" ] && command -v jq &>/dev/null; then
         local marker_commit current_commit
         marker_commit=$(jq -r '.commit // empty' "$marker" 2>/dev/null || true)
-        current_commit=$(git -C "${WORKSPACE_FOLDER:-/workspace}" rev-parse --short HEAD 2>/dev/null || true)
+        current_commit=$(git -C "$ws" rev-parse --short HEAD 2>/dev/null || true)
         if [ -n "$marker_commit" ] && [ -n "$current_commit" ] && \
            { [[ "$current_commit" == "$marker_commit"* ]] || [[ "$marker_commit" == "$current_commit"* ]]; }; then
             log_info "Template repo detected (template-version matches HEAD), skipping features sync"
@@ -1400,24 +1412,17 @@ step_sync_features() {
         fi
     fi
 
-    log_info "Force-syncing .devcontainer/features/ from template image..."
-    if command -v rsync &>/dev/null; then
-        if rsync -a --delete --checksum "$src/" "$dst/"; then
-            log_success ".devcontainer/features/ synced ($(find "$dst" -type f 2>/dev/null | wc -l) files)"
-        else
-            log_error "rsync failed; features dir may be in inconsistent state"
-            return 1
-        fi
-    else
-        rm -rf "$dst"
-        mkdir -p "$dst"
-        if cp -a "$src/." "$dst/"; then
-            log_success ".devcontainer/features/ synced via cp ($(find "$dst" -type f 2>/dev/null | wc -l) files)"
-        else
-            log_error "cp fallback failed"
-            return 1
-        fi
+    # Per-file 3-way safe sync (replaces previous rsync -a --delete --checksum).
+    local helper="$SCRIPT_DIR/../shared/sync-features.sh"
+    if [ ! -f "$helper" ]; then
+        log_error "sync-features.sh helper missing at $helper; cannot sync safely"
+        return 1
     fi
+    # shellcheck source=../shared/sync-features.sh
+    source "$helper"
+
+    log_info "Syncing .devcontainer/features/ from template image (3-way safe)…"
+    sync_features_tree "$src" "$dst" "$ws"
 }
 
 # Clean up legacy workspace hook stubs (replaced by direct /etc/devcontainer-hooks/ calls)

--- a/.devcontainer/images/hooks/shared/sync-features.sh
+++ b/.devcontainer/images/hooks/shared/sync-features.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# shellcheck disable=SC1090,SC1091
+# ============================================================================
+# sync-features.sh - 3-way safe sync for .devcontainer/features/
+# ============================================================================
+# Sourced by postStart.sh (step_sync_features) and by /update apply.md
+# to mirror the template's features/ tree into a consumer repo without
+# clobbering consumer-modified files.
+#
+# Phase 1 (this file): per-file git-dirty + byte-identical guard.
+# Phase 2 (manifest):  hash manifest 3-way merge — see _sync_via_manifest stub.
+#
+# See plan: .claude/plans/2026-04-28-fix-poststart-features-sync-overwrite.md
+# Tracking issue: kodflow/devcontainer-template#334
+# ============================================================================
+
+# Counter exported so callers can report skips after the loop.
+export FEATURES_SYNC_SKIPPED=0
+
+# Phase 2 hook — replaced when the shipped-content hash manifest lands.
+# Contract: succeed (return 0) only when the manifest can prove the dst
+# file is untouched since the last image build, then perform the copy.
+# Phase 1 always returns 1 so callers fall through to the safe default.
+_sync_via_manifest() {
+    return 1
+}
+
+# 3-way file copy with consumer-edit protection.
+# Args: $1 = src absolute path, $2 = dst absolute path, $3 = workspace root
+# Return codes (caller drives counters; never fatal):
+#   0 = wrote (new file or safe overwrite)
+#   1 = noop (byte-identical, no I/O)
+#   2 = preserved (consumer-modified, skipped on purpose)
+_sync_file_safely() {
+    local src="$1"
+    local dst="$2"
+    local ws="$3"
+    local rel="${dst#"${ws}"/.devcontainer/features/}"
+
+    # Case 1: dst missing → copy (new file from upstream).
+    if [ ! -e "$dst" ]; then
+        mkdir -p "$(dirname "$dst")"
+        cp -a "$src" "$dst"
+        return 0
+    fi
+
+    # Case 2: byte-identical → noop.
+    if cmp -s "$src" "$dst"; then
+        return 1
+    fi
+
+    # Case 3: tracked + dirty in consumer git → preserve consumer WIP.
+    # Without git, we cannot tell WIP from a committed divergence; the
+    # manifest path (Phase 2) closes that gap. Until then, fall through.
+    if [ -d "$ws/.git" ] && command -v git >/dev/null 2>&1; then
+        if git -C "$ws" ls-files --error-unmatch -- ".devcontainer/features/${rel}" >/dev/null 2>&1; then
+            if ! git -C "$ws" diff --quiet --exit-code -- ".devcontainer/features/${rel}" >/dev/null 2>&1; then
+                log_warning "Skipping features/${rel}: consumer has uncommitted changes (commit or run /update first)"
+                return 2
+            fi
+        fi
+    fi
+
+    # Case 4: manifest-aware copy (Phase 2). Phase 1 stub returns 1 → fall through.
+    if _sync_via_manifest "$src" "$dst" "$rel"; then
+        return 0
+    fi
+
+    # Case 5: fallback — overwrite. Phase 1 keeps current behaviour for
+    # committed consumer edits (the manifest in Phase 2 narrows this gap).
+    cp -a "$src" "$dst"
+    return 0
+}
+
+# Per-file walk over the embedded features tree. Replaces the previous
+# `rsync -a --delete --checksum` call. `--delete` is intentionally dropped
+# in Phase 1 (no manifest yet → cannot tell consumer-added from upstream-
+# removed files). Phase 2 restores deletion via the hash manifest.
+sync_features_tree() {
+    local src="$1"
+    local dst="$2"
+    local ws="$3"
+
+    if [ ! -d "$src" ]; then
+        log_warning "sync_features_tree: source dir missing ($src)"
+        return 1
+    fi
+    mkdir -p "$dst"
+
+    FEATURES_SYNC_SKIPPED=0
+    local copied=0 noop=0
+    local rc
+    while IFS= read -r -d '' src_file; do
+        local rel="${src_file#"$src"/}"
+        local dst_file="$dst/$rel"
+        _sync_file_safely "$src_file" "$dst_file" "$ws"
+        rc=$?
+        case "$rc" in
+            0) copied=$((copied + 1)) ;;
+            1) noop=$((noop + 1)) ;;
+            2) FEATURES_SYNC_SKIPPED=$((FEATURES_SYNC_SKIPPED + 1)) ;;
+        esac
+    done < <(find "$src" -type f -print0)
+
+    log_success ".devcontainer/features/ synced ($copied copied, $noop unchanged, $FEATURES_SYNC_SKIPPED preserved)"
+    if [ "$FEATURES_SYNC_SKIPPED" -gt 0 ]; then
+        log_info "Tip: \`git status -- .devcontainer/features/\` shows preserved consumer edits"
+    fi
+    return 0
+}


### PR DESCRIPTION
## Summary

Closes the silent-overwrite half of #334. `step_sync_features` no longer clobbers consumer-modified files in `.devcontainer/features/`. Same protection mirrored in `/update apply.md`.

## Root cause

`postStart.sh`'s `step_sync_features` did `rsync -a --delete --checksum` from `/etc/devcontainer-template/features/` into the consumer's `.devcontainer/features/`. The only skip guards were:

1. Self-exclusion when `git rev-parse --short HEAD` matched the marker commit (template repo only).
2. Global `repo_updated > image_updated` comparison.

Neither caught a per-file edit when the consumer hadn't run `/update` since the latest image build. The reproducer in #334 (`languages/CLAUDE.md` edited in the consumer, then silently reverted on rebuild) exercises exactly this gap.

## What changed

| File | Change |
|---|---|
| `images/hooks/shared/sync-features.sh` (new) | `_sync_file_safely` + `sync_features_tree` — per-file 3-way logic |
| `images/hooks/lifecycle/postStart.sh` | `step_sync_features` now sources the helper instead of calling `rsync` |
| `images/.claude/commands/update/apply.md` | `/update` features block uses the same helper from the tarball |
| `images/CLAUDE.md` | Doc updated to reflect 3-way merge semantics |

### Decision matrix per file

| Case | Action |
|---|---|
| `dst` missing | copy |
| byte-identical | noop |
| tracked + git-dirty | **preserve** + `[WARNING]` log |
| `_sync_via_manifest` (Phase 2 stub) returns 0 | safe overwrite |
| otherwise | overwrite (narrowed by Phase 2 manifest) |

## What this PR does NOT do (Phase 2)

- Does not protect **committed** consumer edits (still overwritten in Phase 1). The hash manifest (`/etc/devcontainer-template/.template-files.json`) closes that gap and is the subject of the follow-up PR.
- Drops `--delete` temporarily — without the manifest, we cannot tell consumer-added from upstream-removed files. Phase 2 restores deletion safely.

Plan: [`.claude/plans/2026-04-28-fix-poststart-features-sync-overwrite.md`](#) (local).

## Manual verification

Smoke-tested against the helper in isolation (5 scenarios):

```
A: PASS new copy
B: PASS noop
C: PASS dirty preserved (#334 fix)
D: PASS untracked preserved + new copied
E: EXPECTED Phase 1 overwrites committed edits (Phase 2 will narrow this)
```

`shellcheck` clean on `sync-features.sh`. `bash -n` clean on both files.

## Test plan

- [ ] Rebuild a fresh devcontainer in `kodflow/ktn-linter` on `fix/cli-version-and-golangci-v2-guard` and confirm `git diff -- .devcontainer/features/languages/CLAUDE.md` is empty after `postStart`.
- [ ] Confirm postStart log shows `synced (N copied, M unchanged, K preserved)` with `K=0` on a clean consumer and `K>0` after touching a tracked feature file.
- [ ] Run `/update` with the same setup and confirm the `/update` flow logs the same skip line.
- [ ] CI green on linux/amd64 + linux/arm64.

Refs: #334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What
Replaces unsafe `rsync`-based feature synchronization with a per-file "3-way safe" sync that preserves consumer-modified files instead of silently overwriting them.

## Why
Fixes issue #334 (silent-overwrite vulnerability). The previous `rsync -a --delete` approach in `postStart.sh` could clobber consumer edits to files in `.devcontainer/features/`, with no warning or recovery path.

## How
- Introduces new helper script `images/hooks/shared/sync-features.sh` with per-file sync logic:
  - `_sync_file_safely()`: Copies missing files, performs byte-level comparison to skip identical files, detects uncommitted changes via `git diff`/`git ls-files` and preserves consumer-modified tracked files with `[WARNING]` logs, defers to manifest-aware path (Phase 2 stub), and overwrites as final fallback.
  - `sync_features_tree()`: Walks source directory and syncs each file via the per-file helper, aggregating counts and emitting usage hints when edits are preserved.
- Updates `postStart.sh`'s `step_sync_features()` to source and call `sync_features_tree()` instead of running rsync.
- Updates `images/.claude/commands/update/apply.md` to use the same helper from tarball context; falls back to prior rsync/copy behavior if helpers unavailable.
- Adds documentation in `images/CLAUDE.md` describing the 3-way safe process and warning behavior for issue #334.

## Risk
**Phase 1 Limitations (Phase 2 planned with manifest)**:
- Does not protect committed (already-merged) consumer edits—only uncommitted changes are preserved; Phase 2 will add hash-based manifest validation for safer overwrite decisions.
- Temporarily removes `--delete` flag behavior until manifest-driven shipping content is available, delaying full force-sync semantics.
- **Breaking behavior change**: Force-sync workflows that relied on unconditional overwrite will now preserve consumer git-dirty files; consumers must manually merge or discard if needed.
- **Git state dependency**: Sync behavior depends on local git status (`git diff`, `git ls-files`). If git is unavailable or repository state is ambiguous, fallback to overwrite occurs.
- **New exported entity**: `FEATURES_SYNC_SKIPPED` variable and `sync_features_tree()` function are now part of the shared hook API.
- **No new dependencies or security-sensitive crypto/auth changes**, but state-machine-like logic (per-file decision tree) increases code complexity and test surface.

Smoke tests and shellcheck/bash -n validation passed; manual verification steps provided in PR description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->