### PR TITLE
fix(nodejs): harden npm install against ETIMEDOUT with retries

### DIFF
--- a/.devcontainer/features/languages/nodejs/devcontainer-feature.json
+++ b/.devcontainer/features/languages/nodejs/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "nodejs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "name": "Node.js Development Environment",
   "description": "Installs Node.js via NVM, npm, yarn, pnpm and common development tools",
   "options": {

--- a/.devcontainer/features/languages/nodejs/install.sh
+++ b/.devcontainer/features/languages/nodejs/install.sh
@@ -203,13 +203,45 @@ log_success "npm ${NPM_INSTALLED} installed"
 # Create cache directory
 mkdir_safe "$npm_config_cache"
 
+# Harden npm against transient registry timeouts (issue: ETIMEDOUT on registry.npmjs.org).
+# npm defaults retry only 2x with 10s mintimeout — too tight for flaky CI/proxy setups.
+npm config set fetch-retries 5
+npm config set fetch-retry-mintimeout 20000
+npm config set fetch-retry-maxtimeout 120000
+npm config set fetch-timeout 600000
+
+# npm install with retry — retries the whole batch on ETIMEDOUT/ECONNRESET.
+npm_install_global() {
+    retry 3 15 npm install -g --fetch-retries=5 --fetch-timeout=600000 "$@"
+}
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Install Node.js Development Tools — batched for speed
 # ─────────────────────────────────────────────────────────────────────────────
 log_info "Installing Node.js development tools..."
 
-npm install -g pnpm@latest typescript@latest eslint@latest prettier@latest tsx@latest
-log_success "Core tools installed (pnpm, typescript, eslint, prettier, tsx)"
+if npm_install_global pnpm@latest typescript@latest eslint@latest prettier@latest tsx@latest; then
+    log_success "Core tools installed (pnpm, typescript, eslint, prettier, tsx)"
+else
+    # Batch failed after retries — fall back to per-package install so a single
+    # flaky package does not block the others. Critical core: pnpm + typescript.
+    log_warning "Batch install failed; falling back to per-package install"
+    CORE_FAILED=0
+    for core_pkg in pnpm@latest typescript@latest eslint@latest prettier@latest tsx@latest; do
+        if npm_install_global "$core_pkg"; then
+            log_success "Installed $core_pkg"
+        else
+            log_error "Failed to install $core_pkg after retries"
+            case "$core_pkg" in
+                pnpm@latest|typescript@latest) CORE_FAILED=1 ;;
+            esac
+        fi
+    done
+    if [ "$CORE_FAILED" -eq 1 ]; then
+        log_error "Critical core tool (pnpm or typescript) failed to install — aborting"
+        exit 1
+    fi
+fi
 
 # Install additional global packages from devcontainer-feature.json option
 GLOBAL_PACKAGES="${GLOBALPACKAGES:-}"
@@ -219,7 +251,7 @@ if [ -n "$GLOBAL_PACKAGES" ]; then
     for pkg in "${PKGS[@]}"; do
         pkg=$(echo "$pkg" | xargs)  # trim whitespace
         if [ -n "$pkg" ] && ! command -v "$pkg" &>/dev/null; then
-            npm install -g "$pkg" 2>/dev/null && log_success "Installed $pkg" || log_warning "Failed to install $pkg"
+            npm_install_global "$pkg" && log_success "Installed $pkg" || log_warning "Failed to install $pkg (non-critical)"
         fi
     done
 fi
@@ -230,27 +262,28 @@ fi
 log_info "Installing Desktop & WASM tools..."
 
 (
-    if npm install -g electron@latest && command -v electron &> /dev/null; then
+    if npm_install_global electron@latest && command -v electron &> /dev/null; then
         ELECTRON_VERSION=$(electron --version 2>/dev/null || echo "installed")
         log_success "Electron ${ELECTRON_VERSION} installed"
     else
-        log_warning "Electron installation failed or not in PATH"
+        log_warning "Electron installation failed or not in PATH (non-critical)"
     fi
 ) &
 ELECTRON_PID=$!
 
 (
-    if npm install -g assemblyscript@latest && command -v asc &> /dev/null; then
+    if npm_install_global assemblyscript@latest && command -v asc &> /dev/null; then
         ASC_VERSION=$(asc --version 2>/dev/null | head -n 1 || echo "installed")
         log_success "AssemblyScript ${ASC_VERSION} installed"
     else
-        log_warning "AssemblyScript installation failed or not in PATH"
+        log_warning "AssemblyScript installation failed or not in PATH (non-critical)"
     fi
 ) &
 ASC_PID=$!
 
-wait "$ELECTRON_PID" 2>/dev/null || true
-wait "$ASC_PID" 2>/dev/null || true
+# Per-PID wait so we surface real failures (bare `wait` returns 0 unconditionally).
+wait "$ELECTRON_PID" || log_warning "Electron subshell exited non-zero (non-critical)"
+wait "$ASC_PID" || log_warning "AssemblyScript subshell exited non-zero (non-critical)"
 log_success "Desktop & WASM tools installed"
 
 # Create global symlinks for node, npm, and npx

--- a/.devcontainer/features/languages/nodejs/install.sh
+++ b/.devcontainer/features/languages/nodejs/install.sh
@@ -251,7 +251,11 @@ if [ -n "$GLOBAL_PACKAGES" ]; then
     for pkg in "${PKGS[@]}"; do
         pkg=$(echo "$pkg" | xargs)  # trim whitespace
         if [ -n "$pkg" ] && ! command -v "$pkg" &>/dev/null; then
-            npm_install_global "$pkg" && log_success "Installed $pkg" || log_warning "Failed to install $pkg (non-critical)"
+            if npm_install_global "$pkg"; then
+                log_success "Installed $pkg"
+            else
+                log_warning "Failed to install $pkg (non-critical)"
+            fi
         fi
     done
 fi

--- a/.devcontainer/features/languages/nodejs/install.sh
+++ b/.devcontainer/features/languages/nodejs/install.sh
@@ -286,9 +286,14 @@ ELECTRON_PID=$!
 ASC_PID=$!
 
 # Per-PID wait so we surface real failures (bare `wait` returns 0 unconditionally).
-wait "$ELECTRON_PID" || log_warning "Electron subshell exited non-zero (non-critical)"
-wait "$ASC_PID" || log_warning "AssemblyScript subshell exited non-zero (non-critical)"
-log_success "Desktop & WASM tools installed"
+electron_rc=0; asc_rc=0
+wait "$ELECTRON_PID" || { electron_rc=$?; log_warning "Electron subshell exited non-zero (non-critical)"; }
+wait "$ASC_PID" || { asc_rc=$?; log_warning "AssemblyScript subshell exited non-zero (non-critical)"; }
+if [ "$electron_rc" -eq 0 ] && [ "$asc_rc" -eq 0 ]; then
+    log_success "Desktop & WASM tools installed"
+else
+    log_warning "Desktop & WASM tools installed with non-critical failures"
+fi
 
 # Create global symlinks for node, npm, and npx
 # This ensures they're available for subsequent devcontainer features


### PR DESCRIPTION
## Summary

- Add npm fetch retry config (5 retries, 20s–120s backoff, 600s timeout) to absorb transient `ETIMEDOUT` on `registry.npmjs.org`
- Wrap global installs in `retry 3 15` helper so a flaky network blip no longer aborts the whole feature install
- On batch failure, fall back to per-package install; abort only if `pnpm` or `typescript` (critical core) fail
- Replace bare `wait` with per-PID `wait` so Electron/AssemblyScript subshell failures are surfaced instead of swallowed
- Bump feature version `1.0.1` → `1.0.2`

## Test plan

- [ ] Rebuild devcontainer with simulated network jitter, verify install completes
- [ ] Force a single non-core package failure, verify batch fallback still installs core tools
- [ ] Force pnpm failure, verify install aborts with clear error
- [ ] Confirm Electron/AssemblyScript subshell failures now produce `log_warning` lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**What**  
Hardens the Node.js devcontainer feature's npm installation: adds npm fetch retry/timeouts, wraps global installs in a retry helper with backoff, falls back to per-package installs on batch failure, surfaces subshell failures, and bumps feature version 1.0.1 → 1.0.2.

**Why**  
Transient ETIMEDOUT and network blips when contacting registry.npmjs.org caused feature installs to fail; retries, extended timeouts, and a batch→per-package fallback increase robustness while preserving core-tool guarantees.

**How**  
- Sets npm fetch config: fetch-retries=5, fetch-retry-mintimeout=20s, fetch-retry-maxtimeout=120s, fetch-timeout=600s.  
- Adds npm_install_global() that retries `npm install -g` (3 attempts, 15s backoff) and preserves the command exit code.  
- Core tool install: try a batched install with retries; on persistent batch failure, install packages individually and only abort if critical packages (pnpm or typescript) fail.  
- Optional globals (including Electron and AssemblyScript) use the same retry wrapper and are treated as non-fatal.  
- Replace suppressed wait (e.g., `wait ... || true`) with per-PID waits that capture exit codes and log warnings for subshell failures.

**Risk**  
Impacts container setup/install path: may increase total install time under failure, changes behavior from fast-fail to retry-and-fallback, and surface previously-suppressed subshell errors in logs. No new external dependencies, no auth/crypto/secrets changes, no DB/state-machine migrations, and no supply-chain package additions beyond existing npm packages. Rollback is trivial by reverting the install script and the version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->