### PR TITLE
feat(ktn-linter): inject per-hook `phases` into HTTP request body (#338)

### DIFF
--- a/.devcontainer/images/.claude/scripts/on-stop.sh
+++ b/.devcontainer/images/.claude/scripts/on-stop.sh
@@ -73,6 +73,38 @@ printf '\a'
 # Project directory used by ktn-linter and session summary
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-/workspace}"
 
+# === ktn-linter HTTP /hooks/stop: session-end validation report ===
+# Forwards the full hook input JSON (with session_id) to the server, with an
+# explicit per-request phase scope. Phases 1..8 — includes 'tests' since the
+# agent has finished writing, but excludes 'health' (project-wide check that
+# is too noisy for an interactive stop).
+# Servers pre-#190 ignore 'phases' and use YAML config — back-compat safe.
+KTN_PORT="${KTN_LINTER_PORT:-7717}"
+if command -v curl &>/dev/null; then
+    KTN_PHASES_CSV="${KTN_STOP_PHASES:-structural,signatures,logic,performance,modern,style,comment,tests}"
+    KTN_PHASES_CSV="${KTN_PHASES_CSV// /}"
+    KTN_BODY="${INPUT:-}"
+    [ -z "$KTN_BODY" ] && KTN_BODY="{}"
+    if command -v jq &>/dev/null; then
+        KTN_TRY=$(printf '%s' "$KTN_BODY" | jq -c --arg p "$KTN_PHASES_CSV" \
+            '. + {phases: ($p | split(","))}' 2>/dev/null) \
+            && KTN_BODY="$KTN_TRY"
+    fi
+    KTN_RESP=$(curl -sf --max-time 28 \
+        -H "Content-Type: application/json" \
+        -d "$KTN_BODY" \
+        "http://localhost:${KTN_PORT}/hooks/stop" 2>/dev/null) || true
+    if [ -n "$KTN_RESP" ] && [ "$KTN_RESP" != "{}" ] && [ "$KTN_RESP" != "null" ] && command -v jq &>/dev/null; then
+        if printf '%s' "$KTN_RESP" | jq -e '.hookSpecificOutput' &>/dev/null; then
+            printf '%s' "$KTN_RESP"
+        else
+            jq -n -c --arg ctx "$(printf '%s' "$KTN_RESP" | head -c 1000)" \
+                '{"hookSpecificOutput":{"hookEventName":"Stop","additionalContext":$ctx}}' \
+                2>/dev/null || true
+        fi
+    fi
+fi
+
 # === ktn-linter: scoped to THIS SESSION's edits only ===
 # Uses the per-session tracker populated by post-edit.sh (Write/Edit hooks).
 # If this session did no edits (e.g., /search), skip entirely.

--- a/.devcontainer/images/.claude/scripts/post-edit.sh
+++ b/.devcontainer/images/.claude/scripts/post-edit.sh
@@ -42,13 +42,25 @@ FMT_OUT=$("$SCRIPT_DIR/format.sh" "$FILE" 2>&1) || true
 # === ktn-linter: focused scan after edit ===
 # Calls ktn-linter HTTP endpoint to lint the modified file.
 # Can block via permissionDecision:"deny" if critical violation found.
+# Phase scope = phases 1..7 (excludes 'tests' and 'health' by default — same
+# semantics as the legacy YAML default, just made explicit at request time).
 KTN_PORT="${KTN_LINTER_PORT:-7717}"
 if command -v curl &>/dev/null && [[ "$FILE" != *.md ]] && [[ "$FILE" != *.json ]] && \
    [[ "$FILE" != *.yaml ]] && [[ "$FILE" != *.yml ]] && [[ "$FILE" != *.toml ]] && \
    [[ "$FILE" != /tmp/* ]] && [[ "$FILE" != *".claude/"* ]]; then
+    # Override via KTN_POST_PHASES env var, comma-separated.
+    KTN_PHASES_CSV="${KTN_POST_PHASES:-structural,signatures,logic,performance,modern,style,comment}"
+    KTN_PHASES_CSV="${KTN_PHASES_CSV// /}"
+    KTN_BODY="${INPUT:-}"
+    [ -z "$KTN_BODY" ] && KTN_BODY="{}"
+    if command -v jq &>/dev/null; then
+        KTN_TRY=$(printf '%s' "$KTN_BODY" | jq -c --arg p "$KTN_PHASES_CSV" \
+            '. + {phases: ($p | split(","))}' 2>/dev/null) \
+            && KTN_BODY="$KTN_TRY"
+    fi
     KTN_RESP=$(curl -sf --max-time 14 \
         -H "Content-Type: application/json" \
-        -d "${INPUT:-{\}}" \
+        -d "$KTN_BODY" \
         "http://localhost:${KTN_PORT}/hooks/post-tool-use" 2>/dev/null) || true
     if [ -n "$KTN_RESP" ] && [ "$KTN_RESP" != "{}" ] && [ "$KTN_RESP" != "null" ] && command -v jq &>/dev/null; then
         if printf '%s' "$KTN_RESP" | jq -e '.hookSpecificOutput' &>/dev/null; then

--- a/.devcontainer/images/.claude/scripts/pre-validate.sh
+++ b/.devcontainer/images/.claude/scripts/pre-validate.sh
@@ -118,13 +118,26 @@ fi
 # === ktn-linter: package context before edit ===
 # Calls ktn-linter HTTP endpoint to surface existing issues in the package
 # being modified. Graceful degradation if ktn-linter is not running.
+# Pre-edit fast check: only structural/signature breaks block before the edit;
+# logic/perf/style/comment categories are deferred to post-edit.sh.
 KTN_PORT="${KTN_LINTER_PORT:-7717}"
 if command -v curl &>/dev/null && [[ "$FILE" != *.md ]] && [[ "$FILE" != *.json ]] && \
    [[ "$FILE" != *.yaml ]] && [[ "$FILE" != *.yml ]] && [[ "$FILE" != *.toml ]] && \
    [[ "$FILE" != /tmp/* ]] && [[ "$FILE" != *".claude/"* ]]; then
+    # Per-hook phase scope (override via KTN_PRE_PHASES env var, comma-separated).
+    # Servers pre-#190 ignore the unknown field and fall back to YAML config.
+    KTN_PHASES_CSV="${KTN_PRE_PHASES:-structural,signatures}"
+    KTN_PHASES_CSV="${KTN_PHASES_CSV// /}"
+    KTN_BODY="${INPUT:-}"
+    [ -z "$KTN_BODY" ] && KTN_BODY="{}"
+    if command -v jq &>/dev/null; then
+        KTN_TRY=$(printf '%s' "$KTN_BODY" | jq -c --arg p "$KTN_PHASES_CSV" \
+            '. + {phases: ($p | split(","))}' 2>/dev/null) \
+            && KTN_BODY="$KTN_TRY"
+    fi
     KTN_RESP=$(curl -sf --max-time 4 \
         -H "Content-Type: application/json" \
-        -d "${INPUT:-{\}}" \
+        -d "$KTN_BODY" \
         "http://localhost:${KTN_PORT}/hooks/pre-tool-use" 2>/dev/null) || true
     if [ -n "$KTN_RESP" ] && [ "$KTN_RESP" != "{}" ] && [ "$KTN_RESP" != "null" ]; then
         if printf '%s' "$KTN_RESP" | jq -e '.hookSpecificOutput' &>/dev/null; then

--- a/.devcontainer/images/CLAUDE.md
+++ b/.devcontainer/images/CLAUDE.md
@@ -190,13 +190,13 @@ Full inventory: See `.devcontainer/hooks/CLAUDE.md` and `CLAUDE.md` (root).
 
 **ktn-linter integration (embedded in existing hook scripts):**
 
-| Script | Endpoint called | Timeout | Purpose |
-|--------|----------------|---------|---------|
-| `pre-validate.sh` | `/hooks/pre-tool-use` | 4s | Package context before edit |
-| `post-edit.sh` | `/hooks/post-tool-use` | 14s | Lint scan, can block on critical |
-| `on-stop.sh` | `/hooks/stop` | 28s | Session validation report |
+| Script | Endpoint | Timeout | Phase scope (default) | Env override | Purpose |
+|--------|----------|---------|-----------------------|--------------|---------|
+| `pre-validate.sh` | `/hooks/pre-tool-use` | 4s | `structural,signatures` (1–2) | `KTN_PRE_PHASES` | Pre-edit fast check — only naming/signature breaks block before the edit |
+| `post-edit.sh` | `/hooks/post-tool-use` | 14s | `structural,signatures,logic,performance,modern,style,comment` (1–7) | `KTN_POST_PHASES` | Post-edit full check — can block on critical |
+| `on-stop.sh` | `/hooks/stop` | 28s | `structural,…,comment,tests` (1–8) | `KTN_STOP_PHASES` | Session-end report — includes test-quality phase |
 
-Graceful degradation: calls exit silently if ktn-linter is not running. See [docs/ktn-linter-integration.md](/workspace/docs/ktn-linter-integration.md).
+The `phases` field is injected into the JSON request body via `jq` (per-request override; server YAML config is preserved for any consumer that doesn't pass `phases`). Servers pre-ktn-linter-#190 ignore the unknown field and fall back to YAML — back-compat safe. Override per-project via the `KTN_*_PHASES` env vars (comma-separated, no spaces). Graceful degradation: calls exit silently if ktn-linter is not running or `jq` is missing (raw `${INPUT:-{}}` is sent unchanged). See [docs/ktn-linter-integration.md](/workspace/docs/ktn-linter-integration.md).
 
 **Makefile-first pattern:** Scripts check `make fmt/lint/typecheck/test FILE=<path>` first, then fall back to direct tool invocation.
 

--- a/docs/ktn-linter-integration.md
+++ b/docs/ktn-linter-integration.md
@@ -62,6 +62,7 @@ After protected file validation, calls `/hooks/pre-tool-use` to surface existing
 
 - Skips non-code files (*.md, *.json, *.yaml, /tmp/*, .claude/*)
 - Curl timeout: 4s (within 5s hook timeout)
+- Phase scope: `structural,signatures` (override: `KTN_PRE_PHASES`)
 - Fail-open: continues silently if ktn-linter unreachable
 
 ### `post-edit.sh` — PostToolUse (Write|Edit)
@@ -70,6 +71,7 @@ After formatting, calls `/hooks/post-tool-use` to lint the modified file.
 
 - Skips non-code files
 - Curl timeout: 14s (within 15s hook timeout)
+- Phase scope: `structural,signatures,logic,performance,modern,style,comment` (override: `KTN_POST_PHASES`)
 - Can block edits via `permissionDecision: "deny"` in response
 - Fail-open: continues silently if ktn-linter unreachable
 
@@ -79,8 +81,23 @@ Before session summary, calls `/hooks/stop` for session-level validation.
 
 - Adds `CLAUDE_SESSION_ID` to request payload
 - Curl timeout: 28s (within 30s hook timeout)
+- Phase scope: `structural,signatures,logic,performance,modern,style,comment,tests` (override: `KTN_STOP_PHASES`)
 - Outputs summary to stderr (visible to user)
 - Never blocks session stop
+
+### Phase scope (per-request override, ktn-linter ≥ #190)
+
+Each hook injects an explicit `phases` field into the JSON request body, scoped to what the event-type actually needs to surface. The server's YAML config (`.ktn-linter.yaml`) is **not** consulted when `phases` is present — it acts as a per-request override. Empty/absent `phases` → YAML default (back-compat for servers pre-#190, which ignore the unknown field).
+
+Override per-project via env vars (comma-separated, no spaces):
+
+```bash
+export KTN_PRE_PHASES=structural,signatures,modern
+export KTN_POST_PHASES=structural,signatures,logic,performance
+export KTN_STOP_PHASES=structural,signatures,logic,performance,modern,style,comment,tests,health
+```
+
+Defensive: if `jq` is missing, the scripts fall through to the raw `${INPUT:-{}}` body — server uses YAML default, no failure.
 
 ## Hook Flow
 


### PR DESCRIPTION
Closes #338.

## What

Forward an explicit `phases` field to ktn-linter on every hook call so the server scopes diagnostics per-request without consulting `.ktn-linter.yaml`. Implements the proposal in #338 against ktn-linter [PR #190](https://github.com/kodflow/ktn-linter/pull/190) (merged 2026-05-01).

| Script | Endpoint | Default phases | Env override |
|---|---|---|---|
| `pre-validate.sh` | `/hooks/pre-tool-use` | `structural,signatures` (1–2) | `KTN_PRE_PHASES` |
| `post-edit.sh` | `/hooks/post-tool-use` | `…,comment` (1–7) | `KTN_POST_PHASES` |
| `on-stop.sh` | `/hooks/stop` | `…,tests` (1–8) | `KTN_STOP_PHASES` |

`on-stop.sh` previously had no HTTP call at all (only the `ktn-linter lint` CLI invocation against session-tracked Go packages). The new `/hooks/stop` request runs **alongside** the CLI block — they target different inputs (server-side session state vs local file scan) and don't conflict.

## How

`jq` merges `{phases:[…]}` into `INPUT`. The CSV→array conversion happens inside `jq` itself (`split(",")`) so no awk/sed quoting. Whitespace in env-var values is stripped at shell level.

Defensive paths (acceptance criterion #4):
1. `jq` missing → raw `${INPUT:-{}}` is sent unchanged → server uses YAML default
2. `jq` succeeds but `INPUT` is malformed JSON → fallback to raw INPUT
3. Empty `INPUT` → defaults to `{}` then phases injected

Verified all 6 cases inline (default phases for all 3 hooks, env override w/ spaces, empty INPUT, malformed INPUT).

## Acceptance criteria (from #338)

- [x] `pre-validate.sh` POSTs `phases: ["structural","signatures"]` (or env override)
- [x] `post-edit.sh` POSTs `phases: ["structural",…,"comment"]`
- [x] `on-stop.sh` POSTs `phases: ["structural",…,"tests"]`
- [x] All 3 fall through to `${INPUT:-{}}` default when `jq` is unavailable
- [x] `.devcontainer/images/CLAUDE.md` table documents per-hook phase scope + env override
- [x] No exit-code / stdout contract change — only the request body changes
- [ ] Live test against ktn-linter HEAD post-#190 — out of scope for this PR (no running server in CI for this template repo); change is logically a no-op for servers that ignore unknown JSON fields

## Files

- `.devcontainer/images/.claude/scripts/pre-validate.sh`
- `.devcontainer/images/.claude/scripts/post-edit.sh`
- `.devcontainer/images/.claude/scripts/on-stop.sh` (+ new HTTP block)
- `.devcontainer/images/CLAUDE.md` (table)
- `docs/ktn-linter-integration.md` (per-hook contract + env override section)

## Back-compat

Servers running ktn-linter < #190 ignore the unknown `phases` field (Go struct decoder is permissive on extra JSON keys) and fall back to YAML config. Zero impact on consumer projects that haven't upgraded their ktn-linter binary.