### PR TITLE
fix(post-edit): drop duplicate ktn-linter HTTP hook (closes #344)

### DIFF
--- a/.devcontainer/images/.claude/scripts/post-edit.sh
+++ b/.devcontainer/images/.claude/scripts/post-edit.sh
@@ -37,41 +37,13 @@ if [[ "$FILE" == *".claude/contexts/"* ]] || \
 fi
 
 # === Format only (fast: goimports ~100ms, ruff ~50ms, prettier ~200ms) ===
+# ktn-linter integration is intentionally NOT called from this script —
+# Claude Code keeps only the LAST JSON written by a PostToolUse chain, so a
+# script-level curl here would race with the project-level HTTP hook and
+# silently drop `decision: "block"` payloads (issue #344). Consumers wire
+# ktn-linter via a native HTTP hook in `.claude/settings.json` instead; see
+# `.devcontainer/images/CLAUDE.md` for the recipe.
 FMT_OUT=$("$SCRIPT_DIR/format.sh" "$FILE" 2>&1) || true
-
-# === ktn-linter: focused scan after edit ===
-# Calls ktn-linter HTTP endpoint to lint the modified file.
-# Can block via permissionDecision:"deny" if critical violation found.
-# Phase scope = phases 1..7 (excludes 'tests' and 'health' by default — same
-# semantics as the legacy YAML default, just made explicit at request time).
-KTN_PORT="${KTN_LINTER_PORT:-7717}"
-if command -v curl &>/dev/null && [[ "$FILE" != *.md ]] && [[ "$FILE" != *.json ]] && \
-   [[ "$FILE" != *.yaml ]] && [[ "$FILE" != *.yml ]] && [[ "$FILE" != *.toml ]] && \
-   [[ "$FILE" != /tmp/* ]] && [[ "$FILE" != *".claude/"* ]]; then
-    # Override via KTN_POST_PHASES env var, comma-separated.
-    KTN_PHASES_CSV="${KTN_POST_PHASES:-structural,signatures,logic,performance,modern,style,comment}"
-    KTN_PHASES_CSV="${KTN_PHASES_CSV// /}"
-    KTN_BODY="${INPUT:-}"
-    [ -z "$KTN_BODY" ] && KTN_BODY="{}"
-    if command -v jq &>/dev/null; then
-        KTN_TRY=$(printf '%s' "$KTN_BODY" | jq -c --arg p "$KTN_PHASES_CSV" \
-            '. + {phases: ($p | split(","))}' 2>/dev/null) \
-            && KTN_BODY="$KTN_TRY"
-    fi
-    KTN_RESP=$(curl -sf --max-time 14 \
-        -H "Content-Type: application/json" \
-        -d "$KTN_BODY" \
-        "http://localhost:${KTN_PORT}/hooks/post-tool-use" 2>/dev/null) || true
-    if [ -n "$KTN_RESP" ] && [ "$KTN_RESP" != "{}" ] && [ "$KTN_RESP" != "null" ] && command -v jq &>/dev/null; then
-        if printf '%s' "$KTN_RESP" | jq -e '.hookSpecificOutput' &>/dev/null; then
-            printf '%s' "$KTN_RESP"
-        else
-            jq -n -c --arg ctx "$(printf '%s' "$KTN_RESP" | head -c 1000)" \
-                '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":$ctx}}' \
-                2>/dev/null || true
-        fi
-    fi
-fi
 
 # Track edited file for on-stop-quality.sh batch processing (session-scoped)
 SESSION_ID="${CLAUDE_SESSION_ID:-default}"

--- a/.devcontainer/images/CLAUDE.md
+++ b/.devcontainer/images/CLAUDE.md
@@ -193,10 +193,32 @@ Full inventory: See `.devcontainer/hooks/CLAUDE.md` and `CLAUDE.md` (root).
 | Script | Endpoint | Timeout | Phase scope (default) | Env override | Purpose |
 |--------|----------|---------|-----------------------|--------------|---------|
 | `pre-validate.sh` | `/hooks/pre-tool-use` | 4s | `structural,signatures` (1–2) | `KTN_PRE_PHASES` | Pre-edit fast check — only naming/signature breaks block before the edit |
-| `post-edit.sh` | `/hooks/post-tool-use` | 14s | `structural,signatures,logic,performance,modern,style,comment` (1–7) | `KTN_POST_PHASES` | Post-edit full check — can block on critical |
 | `on-stop.sh` | `/hooks/stop` | 28s | `structural,…,comment,tests` (1–8) | `KTN_STOP_PHASES` | Session-end report — includes test-quality phase |
 
 The `phases` field is injected into the JSON request body via `jq` (per-request override; server YAML config is preserved for any consumer that doesn't pass `phases`). Servers pre-ktn-linter-#190 ignore the unknown field and fall back to YAML — back-compat safe. Override per-project via the `KTN_*_PHASES` env vars (comma-separated, no spaces). Graceful degradation: calls exit silently if ktn-linter is not running or `jq` is missing (raw `${INPUT:-{}}` is sent unchanged). See [docs/ktn-linter-integration.md](/workspace/docs/ktn-linter-integration.md).
+
+**Per-edit lint (PostToolUse) — project-level recipe.** `post-edit.sh` deliberately does NOT curl `/hooks/post-tool-use`: Claude Code keeps only the *last* JSON emitted by a hook chain, so a script-level call would race with the native HTTP hook and silently drop `decision: "block"` payloads (issue #344). Consumers needing per-edit lint wire the HTTP hook directly in their project's `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:7717/hooks/post-tool-use",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The native hook speaks the Claude Code hook payload protocol directly (decision + hookSpecificOutput) — no re-parse, no re-wrap, no payload mangling.
 
 **Makefile-first pattern:** Scripts check `make fmt/lint/typecheck/test FILE=<path>` first, then fall back to direct tool invocation.
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,7 @@
     "*.tsx": "${capture}.ts, ${capture}.js, ${capture}.jsx, ${capture}.test.tsx, ${capture}.spec.tsx, ${capture}.stories.tsx, ${capture}.module.css, ${capture}.module.scss, ${capture}.styles.ts",
     "*.jsx": "${capture}.js, ${capture}.test.jsx, ${capture}.spec.jsx, ${capture}.stories.jsx",
     "*.js": "${capture}.js.map, ${capture}.min.js, ${capture}.test.js, ${capture}.spec.js, ${capture}.d.ts",
-    "*.go": "${capture}_test.go, ${capture}_internal_test.go, ${capture}_external_test.go, ${capture}_bench_test.go, ${capture}_mock.go, ${capture}_generated.go, ${capture}.pb.go, ${capture}_grpc.pb.go",
+    "*.go": "${capture}_test.go, ${capture}_internal_test.go, ${capture}_external_test.go, ${capture}_bench_test.go, ${capture}_compliance.go, ${capture}_mock.go, ${capture}_generated.go, ${capture}.pb.go, ${capture}_grpc.pb.go",
     "*.rs": "${capture}.test.rs, ${capture}_test.rs",
     "*.py": "${capture}_test.py, test_${capture}.py, ${capture}.pyi, ${capture}.pyc",
     "*.rb": "${capture}_test.rb, ${capture}_spec.rb",

--- a/docs/ktn-linter-integration.md
+++ b/docs/ktn-linter-integration.md
@@ -50,7 +50,8 @@ This document defines the integration between `devcontainer-template` and `ktn-l
 
 | Responsibility | Details |
 |---------------|---------|
-| **Nothing** | Zero manual configuration — hooks are in the template |
+| **PostToolUse hook** | Wire the native HTTP hook in `.claude/settings.json` (matcher `Edit\|Write\|MultiEdit`, `type: "http"`, `url: http://localhost:${KTN_LINTER_PORT:-7717}/hooks/post-tool-use`, `timeout: 15`). See PostToolUse section below. |
+| **PreToolUse / Stop** | Zero manual configuration — embedded in `pre-validate.sh` / `on-stop.sh`. |
 | **Optional** | Override via `settings.local.json` or `KTN_LINTER_PORT` env var |
 
 ## Hook Integration Points
@@ -214,8 +215,10 @@ jq '.mcpServers["ktn-linter"]' /workspace/mcp.json
 
 # 3. Hook scripts have ktn-linter integration?
 grep -l "ktn-linter" ~/.claude/scripts/{pre-validate,on-stop}.sh
-# 3b. PostToolUse wired at project level?
-jq '.hooks.PostToolUse[].hooks[]? | select(.url | test("ktn|7717"))' .claude/settings.json
+# 3b. PostToolUse wired at project level? (guard on hook type and optional .url
+# so a sibling type:"command" hook in the same array doesn't error the filter)
+jq '.hooks.PostToolUse[]?.hooks[]?
+    | select(.type == "http" and (.url? | test("ktn|7717")))' .claude/settings.json
 
 # 4. Server responding?
 curl -sf http://localhost:7717/health && echo "OK" || echo "Not running"

--- a/docs/ktn-linter-integration.md
+++ b/docs/ktn-linter-integration.md
@@ -156,9 +156,9 @@ Agent wants to edit file.go
 
 | Hook | Timeout | Curl | Rationale |
 |------|---------|------|-----------|
-| PreToolUse | 5s | 4s | Must be fast — quick HTTP call to cached package state |
-| PostToolUse | 15s | 14s | Single file scan with 148 rules, must complete before agent proceeds |
-| Stop | 30s | 28s | Full project scan of all modified packages, runs once at session end |
+| PreToolUse | 5s | 4s (`pre-validate.sh`) | Must be fast — quick HTTP call to cached package state |
+| PostToolUse | 15s | N/A — project-level native HTTP hook | Single file scan with 148 rules, must complete before agent proceeds |
+| Stop | 30s | 28s (`on-stop.sh`) | Full project scan of all modified packages, runs once at session end |
 
 ## Canonical Hooks Doctrine (Future)
 
@@ -228,7 +228,7 @@ curl -sf http://localhost:7717/health && echo "OK" || echo "Not running"
 
 ### Change port
 
-Set `KTN_LINTER_PORT` environment variable (default: 7717). All 3 hook scripts read this.
+Set `KTN_LINTER_PORT` environment variable (default: 7717). Read by the template scripts that still call ktn-linter directly (`pre-validate.sh`, `on-stop.sh`). PostToolUse runs through the project-level native HTTP hook, where the URL is hard-coded in `.claude/settings.json` — adjust the URL there if you change the port.
 
 ### Disable ktn-linter hooks only
 

--- a/docs/ktn-linter-integration.md
+++ b/docs/ktn-linter-integration.md
@@ -50,7 +50,7 @@ This document defines the integration between `devcontainer-template` and `ktn-l
 
 | Responsibility | Details |
 |---------------|---------|
-| **PostToolUse hook** | Wire the native HTTP hook in `.claude/settings.json` (matcher `Edit\|Write\|MultiEdit`, `type: "http"`, `url: http://localhost:7717/hooks/post-tool-use`, `timeout: 15`). See PostToolUse section below for the full snippet. |
+| **PostToolUse hook** | Wire the native HTTP hook in `.claude/settings.json` (matcher `Edit|Write|MultiEdit`, `type: "http"`, `url: http://localhost:7717/hooks/post-tool-use`, `timeout: 15`). See PostToolUse section below for the full snippet. |
 | **PreToolUse / Stop** | Zero manual configuration — embedded in `pre-validate.sh` / `on-stop.sh`. |
 | **Port override** | If you change the port: edit the literal URL in your `.claude/settings.json` AND set `KTN_LINTER_PORT` so the template scripts (`pre-validate.sh`, `on-stop.sh`) match. JSON settings do not perform shell expansion. |
 
@@ -106,7 +106,9 @@ Before session summary, calls `/hooks/stop` for session-level validation.
 
 ### Phase scope (per-request override, ktn-linter ≥ #190)
 
-Each hook injects an explicit `phases` field into the JSON request body, scoped to what the event-type actually needs to surface. The server's YAML config (`.ktn-linter.yaml`) is **not** consulted when `phases` is present — it acts as a per-request override. Empty/absent `phases` → YAML default (back-compat for servers pre-#190, which ignore the unknown field).
+Each script-backed hook (`pre-validate.sh`, `on-stop.sh`) injects an explicit `phases` field into the JSON request body, scoped to what the event-type actually needs to surface. The server's YAML config (`.ktn-linter.yaml`) is **not** consulted when `phases` is present — it acts as a per-request override. Empty/absent `phases` → YAML default (back-compat for servers pre-#190, which ignore the unknown field).
+
+> **Note:** PostToolUse runs through a project-level native HTTP hook (no script wrapper) and therefore **does not** inject `phases` — it forwards the request body unchanged to ktn-linter, which falls back to its YAML config.
 
 Override per-project via env vars (comma-separated, no spaces):
 

--- a/docs/ktn-linter-integration.md
+++ b/docs/ktn-linter-integration.md
@@ -10,7 +10,8 @@ This document defines the integration between `devcontainer-template` and `ktn-l
 ┌───────────────────────────────────────────────────────────────┐
 │                    TEMPLATE (devcontainer)                      │
 │  - ktn-linter calls embedded in existing hook scripts          │
-│  - pre-validate.sh, post-edit.sh, on-stop.sh                  │
+│  - pre-validate.sh, on-stop.sh                                 │
+│  - PostToolUse wired via project-level native HTTP hook        │
 │  - Graceful degradation if ktn-linter not running              │
 │  - MCP fragment system (requires_binary gate)                  │
 └──────────────────────────┬────────────────────────────────────┘
@@ -31,7 +32,7 @@ This document defines the integration between `devcontainer-template` and `ktn-l
 |---------------|---------|
 | **Binary** | Installs ktn-linter (Go feature) |
 | **MCP registration** | Fragment at `/etc/mcp/features/go.mcp.json` with `requires_binary` gate |
-| **Hook integration** | ktn-linter calls embedded in `pre-validate.sh`, `post-edit.sh`, `on-stop.sh` |
+| **Hook integration** | ktn-linter calls embedded in `pre-validate.sh`, `on-stop.sh` (PostToolUse moved to project-level native HTTP hook — see images/CLAUDE.md, issue #344) |
 | **Graceful degradation** | Calls exit silently if ktn-linter is not running (curl fails → continue) |
 | **Permissions** | `Bash(ktn-linter:*)` pre-authorized in settings.json |
 
@@ -65,15 +66,32 @@ After protected file validation, calls `/hooks/pre-tool-use` to surface existing
 - Phase scope: `structural,signatures` (override: `KTN_PRE_PHASES`)
 - Fail-open: continues silently if ktn-linter unreachable
 
-### `post-edit.sh` — PostToolUse (Write|Edit)
+### PostToolUse (Write|Edit|MultiEdit) — project-level native HTTP hook
 
-After formatting, calls `/hooks/post-tool-use` to lint the modified file.
+`post-edit.sh` deliberately does NOT call `/hooks/post-tool-use`. A script-level
+curl would race with the project's native HTTP hook (Claude Code keeps only the
+*last* JSON of a hook chain, silently dropping `decision: "block"` payloads —
+issue #344). Consumers wire ktn-linter directly in their `.claude/settings.json`:
 
-- Skips non-code files
-- Curl timeout: 14s (within 15s hook timeout)
-- Phase scope: `structural,signatures,logic,performance,modern,style,comment` (override: `KTN_POST_PHASES`)
-- Can block edits via `permissionDecision: "deny"` in response
-- Fail-open: continues silently if ktn-linter unreachable
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          { "type": "http", "url": "http://localhost:7717/hooks/post-tool-use", "timeout": 15 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The native hook speaks the Claude Code hook payload protocol directly (decision
++ hookSpecificOutput) — no re-parse, no re-wrap. Phase scope falls through to
+ktn-linter's YAML config (`.ktn-linter.yaml`); per-request override via the
+project-level body is consumer-managed.
 
 ### `on-stop.sh` — Stop (*)
 
@@ -93,9 +111,11 @@ Override per-project via env vars (comma-separated, no spaces):
 
 ```bash
 export KTN_PRE_PHASES=structural,signatures,modern
-export KTN_POST_PHASES=structural,signatures,logic,performance
 export KTN_STOP_PHASES=structural,signatures,logic,performance,modern,style,comment,tests,health
 ```
+
+(`KTN_POST_PHASES` is no longer applicable — PostToolUse uses the project-level
+native HTTP hook, which forwards the body unchanged to ktn-linter's YAML config.)
 
 Defensive: if `jq` is missing, the scripts fall through to the raw `${INPUT:-{}}` body — server uses YAML default, no failure.
 
@@ -116,7 +136,7 @@ Agent wants to edit file.go
         ▼
 ┌─ PostToolUse ─────────────────────────────┐
 │  post-edit.sh        → format file        │
-│  ktn-post-tool-use.sh → lint scan         │  ← "ERROR: unused variable line 42"
+│  (project-level HTTP hook → lint scan)    │  ← "ERROR: unused variable line 42"
 │  log.sh (async)      → action logging     │
 └───────────────────────────────────────────┘
         │
@@ -193,7 +213,9 @@ which ktn-linter && ktn-linter --version
 jq '.mcpServers["ktn-linter"]' /workspace/mcp.json
 
 # 3. Hook scripts have ktn-linter integration?
-grep -l "ktn-linter" ~/.claude/scripts/{pre-validate,post-edit,on-stop}.sh
+grep -l "ktn-linter" ~/.claude/scripts/{pre-validate,on-stop}.sh
+# 3b. PostToolUse wired at project level?
+jq '.hooks.PostToolUse[].hooks[]? | select(.url | test("ktn|7717"))' .claude/settings.json
 
 # 4. Server responding?
 curl -sf http://localhost:7717/health && echo "OK" || echo "Not running"

--- a/docs/ktn-linter-integration.md
+++ b/docs/ktn-linter-integration.md
@@ -50,9 +50,9 @@ This document defines the integration between `devcontainer-template` and `ktn-l
 
 | Responsibility | Details |
 |---------------|---------|
-| **PostToolUse hook** | Wire the native HTTP hook in `.claude/settings.json` (matcher `Edit\|Write\|MultiEdit`, `type: "http"`, `url: http://localhost:${KTN_LINTER_PORT:-7717}/hooks/post-tool-use`, `timeout: 15`). See PostToolUse section below. |
+| **PostToolUse hook** | Wire the native HTTP hook in `.claude/settings.json` (matcher `Edit\|Write\|MultiEdit`, `type: "http"`, `url: http://localhost:7717/hooks/post-tool-use`, `timeout: 15`). See PostToolUse section below for the full snippet. |
 | **PreToolUse / Stop** | Zero manual configuration — embedded in `pre-validate.sh` / `on-stop.sh`. |
-| **Optional** | Override via `settings.local.json` or `KTN_LINTER_PORT` env var |
+| **Port override** | If you change the port: edit the literal URL in your `.claude/settings.json` AND set `KTN_LINTER_PORT` so the template scripts (`pre-validate.sh`, `on-stop.sh`) match. JSON settings do not perform shell expansion. |
 
 ## Hook Integration Points
 


### PR DESCRIPTION
## Problem (issue #344)

`post-edit.sh` curls `http://localhost:7717/hooks/post-tool-use` and prints the response on stdout. When a consumer ALSO wires the recommended project-level HTTP hook to the same endpoint in their `.claude/settings.json`, both hooks fire on every `Write/Edit` and the hook runtime keeps only the **last** JSON emitted — silently overwriting the first response.

Result: ktn-linter `decision: "block"` payloads (critical-rule violations) get dropped. The agent believes the edit is clean while the linter actually said "block".

The two paths are not fungible:
- The native HTTP-hook path speaks the Claude Code hook payload protocol directly (decision + hookSpecificOutput).
- The script-level curl re-parses the response and re-wraps it as `additionalContext`, mangling block payloads in the process.

## Fix

### `fix(post-edit): drop duplicate ktn-linter HTTP hook`

- **`.devcontainer/images/.claude/scripts/post-edit.sh`** — removes the curl block (formerly lines 41–74). Format-only behavior is preserved (~100–500 ms). A short comment now documents *why* the script intentionally does NOT call the endpoint.
- **`.devcontainer/images/CLAUDE.md`** — updates the ktn-linter integration table (drops the `post-edit.sh` row) and adds a "Per-edit lint (PostToolUse) — project-level recipe" subsection with the exact `.claude/settings.json` JSON snippet consumers should add.
- **`docs/ktn-linter-integration.md`** — replaces the `post-edit.sh — PostToolUse` section with the project-level recipe, removes the now-irrelevant `KTN_POST_PHASES` from the env-var override list, updates the architecture diagram, and updates the health-check grep list.

### `chore(vscode): add _compliance.go to Go file nesting`

Bundled per request: extends `.vscode/settings.json` `explorer.fileNesting.patterns` for `*.go` to also nest `${capture}_compliance.go` (matches the existing `_test`/`_mock`/`_generated` siblings).

## Verification

- `bash -n .devcontainer/images/.claude/scripts/post-edit.sh` → syntax OK.
- `grep -rn "KTN_POST_PHASES\|hooks/post-tool-use" --include="*.sh" --include="*.bats"` → no active code refs left (only explanatory mentions in the two docs).
- Behavior on a consumer container without the project-level hook: lint feedback no longer surfaces on edits — but `on-stop.sh` still runs the full session-end report (`/hooks/stop`, phases 1–8). This is the documented trade-off; `post-edit.sh` was never the right place for the protocol-sensitive call.
- Behavior on a consumer container WITH the project-level hook: native HTTP hook returns `decision: "block"` payloads cleanly, no JSON race.

## Scope

- **Touches**: `.devcontainer/images/.claude/scripts/post-edit.sh`, `.devcontainer/images/CLAUDE.md`, `docs/ktn-linter-integration.md`, `.vscode/settings.json`
- **No test changes** — no existing test exercised the curl block (`grep` came back empty in `tests/hooks/`, `tests/scripts/`).
- **No behavior change** for consumers without ktn-linter (post-edit.sh stays a pure format hook).
- **No env-var migration** required — `KTN_POST_PHASES` was script-only; the project-level body is consumer-managed.

Closes the third hook-protocol gap from the same audit pass that produced #341 (rtk wrapper) and #342 (golangci config gating), both closed in #343 on 2026-05-05.

## Test plan

- [ ] CI green (lint + bats).
- [ ] CodeRabbit + Qodo + Codacy review pass.
- [ ] Manual: consumer container with ktn-linter MCP serve + the project-level HTTP hook → introduce a critical-phase violation → block payload reaches the chat.
- [ ] Manual: consumer container WITHOUT the project-level hook → format still runs; on-stop session report still surfaces lint at session end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**What**  
Remove the duplicate ktn-linter PostToolUse HTTP call from .devcontainer/images/.claude/scripts/post-edit.sh and require per-edit linting to be wired via a project-level PostToolUse HTTP hook in the consumer's .claude/settings.json.

**Why**  
The image-shipped curl duplicated a project-level PostToolUse hook and could race with the native hook chain (Claude Code keeps only the last JSON), causing legitimate `decision: "block"` payloads to be silently overwritten (issue #344); script-level re-parsing also risked mangling block payloads.

**How**  
- Deleted the curl-based PostToolUse invocation from post-edit.sh, retained fast format-on-edit behavior (~100–500 ms), and added an inline comment pointing consumers to the project-level hook recipe.  
- Updated .devcontainer/images/CLAUDE.md to remove the post-edit.sh integration row and add a “Per-edit lint (PostToolUse) — project-level recipe” with an exact .claude/settings.json snippet (type: "http", url: "http://localhost:7717/hooks/post-tool-use", timeout: 15).  
- Updated docs/ktn-linter-integration.md: replaced the script-level PostToolUse section with the canonical project-level recipe, removed KTN_POST_PHASES from env-var override lists, hardened jq filters to match http-type hooks by URL, revised the architecture diagram and health-check to validate project-level HTTP wiring, and clarified timeout/phase semantics.  
- Extended .vscode/settings.json file-nesting to include ${capture}_compliance.go.  
- Verification: shell syntax check of post-edit.sh; repo grep shows no active code refs to KTN_POST_PHASES or hooks/post-tool-use outside docs; manual checks confirm post-edit is format-only without a project hook and that project-level native HTTP hook preserves `decision: "block"` payloads.

**Risk**  
- Migration: Consumers who relied on the embedded post-edit curl must add the provided PostToolUse hook snippet to their .claude/settings.json to restore per-edit linting; otherwise post-edit remains format-only (on-stop linting still runs).  
- Concurrency/state-machine: risk is reduced (removes duplicate-writer race that could overwrite hook JSON).  
- No auth/crypto/secrets changes, no database migrations, no new runtime dependencies, no public API changes, and no supply-chain or caching impacts.  
- Security note: projects wiring the project-level HTTP hook should validate hook auth/timeouts appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->