### PR TITLE
fix(claude): raise skillListingBudgetFraction to 5% to stop dropping descriptions

### DIFF
--- a/.devcontainer/images/.claude/settings.json
+++ b/.devcontainer/images/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "cleanupPeriodDays": 30,
+  "skillListingBudgetFraction": 0.05,
   "env": {
     "BASH_DEFAULT_TIMEOUT_MS": "60000",
     "MAX_THINKING_TOKENS": "10000",


### PR DESCRIPTION
## Summary

- The 2.1.129 runtime emitted: `Skill listing will be truncated — 45 descriptions dropped (1.2%/1% of context)`.
- Default `skillListingBudgetFraction = 0.01` no longer fits the full skill catalog (28 first-party skills + bundled `/simplify` `/batch` `/debug` `/loop` `/claude-api` + plugin skills like `/vpn`, `/search:generate`, `/security-review`).
- Bumps the fraction to `0.05` in both the live user-level `~/.claude/settings.json` (effective at next session start) **and** the template `.devcontainer/images/.claude/settings.json` so future image rebuilds carry the fix.
- The fraction is a **cap, not a reservation** — sessions only consume what's actually needed (≈2k tokens at full inclusion per the diagnostic), so this is free headroom until the skill set grows past the new cap.

Why dropped descriptions matter (per [the official docs](https://code.claude.com/docs/en/skills#skill-descriptions-are-cut-short)):

> All skill names are always included, but if you have many skills, descriptions are shortened to fit the character budget, **which can strip the keywords Claude needs to match your request**.

So while names always survive, dropped descriptions break model-invocation matching — the assistant can't auto-trigger a skill it can't recognize.

## Test plan

- [x] `jq -e '.skillListingBudgetFraction' ~/.claude/settings.json` → `0.05`
- [x] `jq -e '.skillListingBudgetFraction' .devcontainer/images/.claude/settings.json` → `0.05`
- [x] JSON schema valid: both files parse via `jq`
- [ ] CI pipeline green
- [ ] On next session restart in this devcontainer, the diagnostic warning disappears (verified manually by user after merge + reload)
- [ ] Image rebuild on merge auto-triggers via existing `docker-images.yml` path filter on `.devcontainer/images/**`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**What**
Increases the Claude runtime's `skillListingBudgetFraction` setting from the default 1% to 5% in the devcontainer configuration file (`.devcontainer/images/.claude/settings.json`).

**Why**
The Claude 2.1.129 runtime has begun truncating skill descriptions with warnings like "Skill listing will be truncated — 45 descriptions dropped" because the default 1% budget no longer accommodates the expanded skill catalog (28 first-party skills plus bundled and plugin skills). Truncated skill descriptions prevent the assistant from matching skills and auto-invoking them reliably.

**How**
Adds a single configuration parameter `"skillListingBudgetFraction": 0.05` to the JSON settings file, positioned after the `cleanupPeriodDays` property. The 5% value functions as a cap rather than a reservation; diagnostics indicate full skill listing requires approximately 2,000 tokens, so sessions only consume tokens up to the configured limit.

**Risk**
Minimal. This is a configuration increase that expands available token budget for skill descriptions rather than a breaking change. Sessions will only use tokens if needed to accommodate the full skill listing. No migration, rollback steps, or dependency changes required. Verification via CI pipeline and runtime behavior on next session restart or image rebuild is included in the test plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->