### PR TITLE
fix(rtk): fail-open hook wrapper + pin v0.38.0 + arm64 install fix

### DIFF
--- a/.devcontainer/images/.claude/CLAUDE.md
+++ b/.devcontainer/images/.claude/CLAUDE.md
@@ -52,6 +52,15 @@ review later.
 **No semantic-embedding tooling.** `grepai`/`ollama` were dropped in 2026-04
 (high CPU/RAM cost, marginal benefit). Use targeted `Grep` + `Read` instead.
 
+**Version pin policy.** RTK is pinned in two places in lockstep
+(`RTK_PINNED_VERSION` in `.devcontainer/install.sh` and `ARG RTK_VERSION`
+in `.devcontainer/images/Dockerfile`). Drift between the two fails CI via
+`tests/scripts/install-sh-rtk.bats`. Bump procedure: dedicated PR, both
+files in the same commit, run the full bats suite + manual smoke test
+(kill the rtk binary, confirm Bash still flows through the wrapper) in a
+freshly built container. Never bump because "latest is newer" — bump
+because the new version was validated against this template.
+
 ## 3.0 ZSH-FIRST (MANDATORY)
 
 Default shell is **zsh** (`chsh -s /bin/zsh` in Dockerfile). Claude Code's Bash tool uses `$SHELL`.

--- a/.devcontainer/images/.claude/CLAUDE.md
+++ b/.devcontainer/images/.claude/CLAUDE.md
@@ -16,12 +16,21 @@ MCP has pre-configured auth. NEVER ask for tokens if MCP is configured.
 **Build/CI: mandatory.** `install.sh` and the image Dockerfile hard-fail if
 RTK can't be installed — a container without RTK never reaches a user.
 
-**Runtime/session: doctrine, never blocking.** `rtk hook claude` is a
-`PreToolUse` hook that compresses Bash output for 60–90 % token savings.
-If RTK is missing or misconfigured at runtime, every Bash call still runs;
-`session-init.sh` emits one `[rtk] mode=… reason=…` line per session and
-`/audit` surfaces the same mode, so degradation is **visible** but never
-**blocking**.
+**Runtime/session: doctrine, never blocking.** The `PreToolUse` Bash hook
+compresses output for 60–90 % token savings. If RTK is missing or
+misconfigured at runtime, every Bash call still runs; `session-init.sh`
+emits one `[rtk] mode=… reason=…` line per session and `/audit` surfaces
+the same mode, so degradation is **visible** but never **blocking**.
+
+The non-blocking guarantee is implemented by `~/.claude/scripts/rtk-hook-claude.sh`,
+a fail-open wrapper that always exits 0 and always emits valid JSON on
+stdout. `settings.json` calls the wrapper, not `rtk` directly, so no rtk
+failure (binary missing, panic, removed subcommand, version drift) can
+ever propagate as a `PreToolUse` denial. Diagnostic stderr lands in
+`~/.claude/logs/<branch>/rtk-hook.log` for `/audit` visibility — never in
+the agent's chat. See issue #348 for the regression that motivated this
+layer; tests in `tests/scripts/rtk-hook-claude-wrapper.bats` lock the
+contract.
 
 **Bypass policy.** Set `RTK_BYPASS=1` for an explicit session-wide skip
 (probe reports `mode=advisory reason=session-bypass` — first-class signal,

--- a/.devcontainer/images/.claude/commands/audit.md
+++ b/.devcontainer/images/.claude/commands/audit.md
@@ -104,7 +104,7 @@ Surface the mode at the **top** of this dimension's section:
 **Sub-scores (3, sum capped at 100):**
 
 - **binary** (`+30`): `command -v rtk` succeeds.
-- **hook** (`+30`): `grep -q '"rtk hook claude"' ~/.claude/settings.json`.
+- **hook** (`+30`): `grep -qE '"(rtk hook claude|[^"]*rtk-hook-claude\.sh)"' ~/.claude/settings.json` — accept either the legacy direct invocation OR the fail-open wrapper path shipped in issue #348.
 - **claude-md** (`+20`): `[ -f ~/.claude/RTK.md ]` AND `grep -qE '^@RTK\.md' ~/.claude/CLAUDE.md`.
 
 Plus a **rewrite-evidence** bonus (`+20`): `rtk gain --history` returns at

--- a/.devcontainer/images/.claude/scripts/rtk-hook-claude.sh
+++ b/.devcontainer/images/.claude/scripts/rtk-hook-claude.sh
@@ -36,8 +36,17 @@ if ! command -v rtk >/dev/null 2>&1; then
     exit 0
 fi
 
-OUT="$(printf '%s' "$PAYLOAD" | rtk hook claude 2>&1)"
+# Separate stdout from stderr — merging would corrupt JSON if rtk ever emits
+# a warning/deprecation notice alongside a valid hook response. stderr always
+# flows to the log file (success OR failure); stdout is what we validate.
+ERR_FILE=$(mktemp 2>/dev/null) || ERR_FILE="${LOG_DIR}/.rtk-hook-stderr.$$"
+OUT="$(printf '%s' "$PAYLOAD" | rtk hook claude 2>"$ERR_FILE")"
 RC=$?
+
+if [ -s "$ERR_FILE" ]; then
+    cat "$ERR_FILE" >>"$LOG_FILE" 2>/dev/null
+fi
+rm -f "$ERR_FILE"
 
 if [ "$RC" -eq 0 ] && printf '%s' "$OUT" | jq -e . >/dev/null 2>&1; then
     printf '%s\n' "$OUT"

--- a/.devcontainer/images/.claude/scripts/rtk-hook-claude.sh
+++ b/.devcontainer/images/.claude/scripts/rtk-hook-claude.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# rtk-hook-claude.sh — fail-open wrapper around `rtk hook claude`.
+#
+# Why: a non-zero exit from this PreToolUse hook blocks every Bash call in
+# Claude Code. rtk is best-effort token compression — never worth blocking
+# the agent on. CLAUDE.md §2.0 explicitly promises "runtime: never blocking";
+# this wrapper is that contract's implementation.
+#
+# stdin → JSON payload from Claude Code; captured once, re-piped to rtk.
+# stdout → JSON payload Claude Code consumes; rtk's response on success,
+#          empty `{}` on any failure (no rewrite, allow original command).
+# stderr → diagnostic log written to ~/.claude/logs/<branch>/rtk-hook.log
+#          for /audit visibility — NEVER surfaced to Claude (would block).
+#
+# See issue #348 for the regression that motivated this layer.
+
+set +e
+
+_resolve_branch() {
+    git symbolic-ref --short HEAD 2>/dev/null || printf 'default'
+}
+
+LOG_DIR="${HOME}/.claude/logs/$(_resolve_branch)"
+mkdir -p "$LOG_DIR" 2>/dev/null
+LOG_FILE="${LOG_DIR}/rtk-hook.log"
+
+# Capture stdin ONCE — `rtk hook claude` reads JSON from stdin per its --help:
+# "Process Claude Code PreToolUse hook (reads JSON from stdin)". Without this
+# capture the wrapper would consume the payload itself and rtk would always
+# degrade, silently disabling token rewrites even on a healthy binary.
+PAYLOAD="$(cat)"
+
+if ! command -v rtk >/dev/null 2>&1; then
+    printf '[rtk-hook] rtk binary not found; fail-open\n' >>"$LOG_FILE" 2>/dev/null
+    printf '{}\n'
+    exit 0
+fi
+
+OUT="$(printf '%s' "$PAYLOAD" | rtk hook claude 2>&1)"
+RC=$?
+
+if [ "$RC" -eq 0 ] && printf '%s' "$OUT" | jq -e . >/dev/null 2>&1; then
+    printf '%s\n' "$OUT"
+    exit 0
+fi
+
+{
+    printf '[rtk-hook] rtk hook failed rc=%s; fail-open\n' "$RC"
+    printf '%s\n' "$OUT"
+} >>"$LOG_FILE" 2>/dev/null
+
+printf '{}\n'
+exit 0

--- a/.devcontainer/images/.claude/scripts/session-init.sh
+++ b/.devcontainer/images/.claude/scripts/session-init.sh
@@ -135,7 +135,10 @@ probe_rtk_mode() {
     elif [ "${RTK_BYPASS:-0}" = "1" ]; then
         mode="advisory"; reason="session-bypass"
     elif [ ! -f "$HOME/.claude/settings.json" ] || \
-         ! grep -q '"rtk hook claude"' "$HOME/.claude/settings.json" 2>/dev/null; then
+         ! grep -qE '"(rtk hook claude|[^"]*rtk-hook-claude\.sh)"' "$HOME/.claude/settings.json" 2>/dev/null; then
+        # Accept either form: legacy direct invocation OR the fail-open wrapper
+        # path (issue #348). Anchored on the closing `"` to avoid matching the
+        # string in a comment or in commented-out template lines.
         mode="advisory"; reason="hook-missing"
     else
         mode="enforcing"

--- a/.devcontainer/images/.claude/settings.json
+++ b/.devcontainer/images/.claude/settings.json
@@ -205,7 +205,7 @@
           },
           {
             "type": "command",
-            "command": "rtk hook claude",
+            "command": "/home/vscode/.claude/scripts/rtk-hook-claude.sh",
             "timeout": 5
           },
           {

--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -30,10 +30,13 @@ USER root
 # =============================================================================
 # Dynamic Binary Tools (rtk) — kubectl/helm/bazelisk/yq are in base
 # =============================================================================
-RUN RTK_LATEST=$(curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: token ${GITHUB_TOKEN}"} "https://api.github.com/repos/rtk-ai/rtk/releases/latest" | jq -r '.tag_name') && \
-    echo "Installing rtk ${RTK_LATEST}..." && \
+# Pinned to a known-good rtk release. See CLAUDE.md §2.0 bump policy.
+# MUST stay in sync with RTK_PINNED_VERSION in .devcontainer/install.sh
+# (drift caught by tests/scripts/install-sh-rtk.bats test 9).
+ARG RTK_VERSION=v0.38.0
+RUN echo "Installing rtk ${RTK_VERSION}..." && \
     RTK_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64-unknown-linux-gnu" || echo "x86_64-unknown-linux-musl") && \
-    curl -fsSL "https://github.com/rtk-ai/rtk/releases/download/${RTK_LATEST}/rtk-${RTK_ARCH}.tar.gz" | \
+    curl -fsSL "https://github.com/rtk-ai/rtk/releases/download/${RTK_VERSION}/rtk-${RTK_ARCH}.tar.gz" | \
     tar xz -C /usr/local/bin rtk
 
 # =============================================================================

--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -34,10 +34,17 @@ USER root
 # MUST stay in sync with RTK_PINNED_VERSION in .devcontainer/install.sh
 # (drift caught by tests/scripts/install-sh-rtk.bats test 9).
 ARG RTK_VERSION=v0.38.0
+# Download to a temp file BEFORE extracting. With the default /bin/sh,
+# `curl | tar` only reports the last command's exit status, so a failed
+# curl + successful tar (e.g., empty body extracts cleanly to nothing)
+# would silently produce an image without rtk. Splitting the steps means
+# curl's exit status fails the layer immediately. Hadolint DL4006.
 RUN echo "Installing rtk ${RTK_VERSION}..." && \
     RTK_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64-unknown-linux-gnu" || echo "x86_64-unknown-linux-musl") && \
-    curl -fsSL "https://github.com/rtk-ai/rtk/releases/download/${RTK_VERSION}/rtk-${RTK_ARCH}.tar.gz" | \
-    tar xz -C /usr/local/bin rtk
+    curl -fsSL "https://github.com/rtk-ai/rtk/releases/download/${RTK_VERSION}/rtk-${RTK_ARCH}.tar.gz" \
+      -o /tmp/rtk.tar.gz && \
+    tar xzf /tmp/rtk.tar.gz -C /usr/local/bin rtk && \
+    rm -f /tmp/rtk.tar.gz
 
 # =============================================================================
 # Claude Code (standalone installation - no Node.js required)

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -663,15 +663,15 @@ download_tools() {
     # Tested in tests/scripts/install-sh-rtk.bats. Set RTK_INSTALL_TEST_FAIL=1
     # to deterministically simulate a failed download and assert the
     # exit-non-zero path.
+    # Pinned rtk version. MUST stay in sync with ARG RTK_VERSION in
+    # .devcontainer/images/Dockerfile (drift caught by
+    # tests/scripts/install-sh-rtk.bats test 9). Bump policy in
+    # .devcontainer/images/.claude/CLAUDE.md §2.0: dedicated PR + smoke
+    # test against a freshly built container before bumping here.
+    local RTK_PINNED_VERSION="v0.38.0"
+
     if ! command -v rtk &>/dev/null; then
         mkdir -p "$HOME_DIR/.local/bin"
-
-        local rtk_latest
-        rtk_latest=$(curl -fsSL "https://api.github.com/repos/rtk-ai/rtk/releases/latest" 2>/dev/null | grep -o '"tag_name": *"[^"]*"' | head -1 | cut -d'"' -f4) || true
-        if [[ -z "$rtk_latest" ]]; then
-            echo "  ✗ rtk: failed to resolve latest version (required)" >&2
-            return 1
-        fi
 
         local rtk_rust_arch
         case "${ARCH}" in
@@ -683,7 +683,7 @@ download_tools() {
                 ;;
         esac
 
-        local rtk_url="https://github.com/rtk-ai/rtk/releases/download/${rtk_latest}/rtk-${rtk_rust_arch}.tar.gz"
+        local rtk_url="https://github.com/rtk-ai/rtk/releases/download/${RTK_PINNED_VERSION}/rtk-${rtk_rust_arch}.tar.gz"
         local rtk_tmp rtk_extract
         rtk_tmp=$(mktemp)
         rtk_extract=$(mktemp -d)
@@ -702,7 +702,7 @@ download_tools() {
 
         install -m 0755 "$rtk_extract/rtk" "$HOME_DIR/.local/bin/rtk"
         tool_count=$((tool_count + 1))
-        echo "  ✓ rtk ${rtk_latest} installed"
+        echo "  ✓ rtk ${RTK_PINNED_VERSION} installed"
 
         rm -f "$rtk_tmp"
         rm -rf "$rtk_extract"

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -673,10 +673,13 @@ download_tools() {
     if ! command -v rtk &>/dev/null; then
         mkdir -p "$HOME_DIR/.local/bin"
 
+        # rtk-ai/rtk has never released aarch64-unknown-linux-musl —
+        # arm64 ships only the gnu variant (verified for v0.38.0 + v0.39.0).
+        # Match the Dockerfile's logic. Issue #348.
         local rtk_rust_arch
         case "${ARCH}" in
             amd64) rtk_rust_arch="x86_64-unknown-linux-musl" ;;
-            arm64) rtk_rust_arch="aarch64-unknown-linux-musl" ;;
+            arm64) rtk_rust_arch="aarch64-unknown-linux-gnu" ;;
             *)
                 echo "  ✗ rtk: unsupported architecture ${ARCH} (devcontainer expects amd64 or arm64)" >&2
                 return 1

--- a/tests/hooks/rtk-status.test.sh
+++ b/tests/hooks/rtk-status.test.sh
@@ -83,16 +83,33 @@ EOF
     cp "$repo_rtk_toml" "$home/.config/rtk/config.toml"
 }
 
-# === ENFORCING (happy path) ===
+# === ENFORCING (happy path, legacy "rtk hook claude" hook entry) ===
 setup_good_sandbox "$SANDBOX"
 TESTS_RUN=$((TESTS_RUN + 1))
 out=$(run_probe "$SANDBOX")
 if [[ "$out" == "[rtk] mode=enforcing version="* ]]; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
-    printf "${GREEN}  PASS${NC}: enforcing mode (binary+marker+hook+config+no bypass)\n"
+    printf "${GREEN}  PASS${NC}: enforcing mode (binary+marker+hook+config+no bypass) — legacy hook form\n"
 else
     TESTS_FAILED=$((TESTS_FAILED + 1))
     printf "${RED}  FAIL${NC}: enforcing mode → got: %s\n" "$out"
+fi
+
+# === ENFORCING (wrapper hook entry — issue #348) ===
+# Same conditions as above but settings.json invokes the fail-open wrapper
+# rather than `rtk hook claude` directly. The probe must accept BOTH forms.
+setup_good_sandbox "$SANDBOX"
+cat > "$SANDBOX/.claude/settings.json" <<'EOF'
+{"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "/home/vscode/.claude/scripts/rtk-hook-claude.sh"}]}]}}
+EOF
+TESTS_RUN=$((TESTS_RUN + 1))
+out=$(run_probe "$SANDBOX")
+if [[ "$out" == "[rtk] mode=enforcing version="* ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    printf "${GREEN}  PASS${NC}: enforcing mode — wrapper hook form (issue #348)\n"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    printf "${RED}  FAIL${NC}: enforcing mode (wrapper form) → got: %s\n" "$out"
 fi
 
 # === ADVISORY: session-bypass ===

--- a/tests/scripts/install-sh-rtk.bats
+++ b/tests/scripts/install-sh-rtk.bats
@@ -42,7 +42,7 @@ run_install_rtk() {
         echo 'warn() { echo "$@"; }'
         echo 'log()  { echo "$@"; }'
         # Slice the download_tools function and call it.
-        sed -n '651,744p' "$SCRIPT"
+        sed -n '651,747p' "$SCRIPT"
         echo "tool_count=0"
         echo "download_tools"
     } > "$runner"
@@ -108,9 +108,9 @@ run_install_rtk() {
 @test "code path: no '(optional)' fallbacks remain in the rtk install block" {
     # The previous fail-open behavior is gone. Any '(optional)' marker in the
     # rtk slice would be a regression toward the old silent-degradation path.
-    # Narrow the slice to JUST the rtk-install block (656..712); status-line
-    # at 713+ is intentionally still advisory and lives outside this contract.
-    run sed -n '656,712p' "${BATS_TEST_DIRNAME}/../../.devcontainer/install.sh"
+    # Narrow the slice to JUST the rtk-install block (656..715); status-line
+    # at 716+ is intentionally still advisory and lives outside this contract.
+    run sed -n '656,715p' "${BATS_TEST_DIRNAME}/../../.devcontainer/install.sh"
     [ "$status" -eq 0 ]
     [[ "$output" != *"(optional"* ]]
 }
@@ -129,6 +129,20 @@ run_install_rtk() {
     # If this assertion ever flips, someone re-introduced the lottery.
     local install_sh="${BATS_TEST_DIRNAME}/../../.devcontainer/install.sh"
     run grep -F 'rtk-ai/rtk/releases/latest' "$install_sh"
+    [ "$status" -ne 0 ]
+}
+
+@test "arch: arm64 uses aarch64-unknown-linux-gnu (rtk ships no musl variant for arm64)" {
+    # Issue #348: install.sh used to request aarch64-unknown-linux-musl,
+    # which rtk-ai/rtk has never published as an asset (verified for
+    # v0.38.0 + v0.39.0). arm64 standalone host install was therefore
+    # broken silently before PR #346 made install hard-fail. The Dockerfile
+    # already used the correct gnu variant; now install.sh matches.
+    local install_sh="${BATS_TEST_DIRNAME}/../../.devcontainer/install.sh"
+    run grep -E 'arm64\)[[:space:]]*rtk_rust_arch="aarch64-unknown-linux-gnu"' "$install_sh"
+    [ "$status" -eq 0 ]
+    # And no leftover musl reference for arm64.
+    run grep -E 'arm64\).*aarch64-unknown-linux-musl' "$install_sh"
     [ "$status" -ne 0 ]
 }
 

--- a/tests/scripts/install-sh-rtk.bats
+++ b/tests/scripts/install-sh-rtk.bats
@@ -101,10 +101,6 @@ run_install_rtk() {
     grep -E 'rtk: download/extract failed.*required' "${BATS_TEST_DIRNAME}/../../.devcontainer/install.sh"
 }
 
-@test "code path: tag-resolution failure calls return 1 with 'required' message" {
-    grep -E 'rtk: failed to resolve latest version.*required' "${BATS_TEST_DIRNAME}/../../.devcontainer/install.sh"
-}
-
 @test "code path: RTK_INSTALL_TEST_FAIL hook is wired" {
     grep -F 'RTK_INSTALL_TEST_FAIL' "${BATS_TEST_DIRNAME}/../../.devcontainer/install.sh"
 }
@@ -117,4 +113,43 @@ run_install_rtk() {
     run sed -n '656,712p' "${BATS_TEST_DIRNAME}/../../.devcontainer/install.sh"
     [ "$status" -eq 0 ]
     [[ "$output" != *"(optional"* ]]
+}
+
+# === Pin invariants (issue #348 — no more dynamic 'latest' lottery) ===
+
+@test "pin: install.sh declares RTK_PINNED_VERSION matching /^v[0-9]+\\.[0-9]+\\.[0-9]+$/" {
+    local install_sh="${BATS_TEST_DIRNAME}/../../.devcontainer/install.sh"
+    run grep -E '^[[:space:]]+local RTK_PINNED_VERSION="v[0-9]+\.[0-9]+\.[0-9]+"' "$install_sh"
+    [ "$status" -eq 0 ]
+}
+
+@test "pin: install.sh no longer resolves rtk via /releases/latest API" {
+    # The dynamic 'latest' resolution is the bug class issue #348 ships against:
+    # any upstream release lands in the next image rebuild without smoke-test.
+    # If this assertion ever flips, someone re-introduced the lottery.
+    local install_sh="${BATS_TEST_DIRNAME}/../../.devcontainer/install.sh"
+    run grep -F 'rtk-ai/rtk/releases/latest' "$install_sh"
+    [ "$status" -ne 0 ]
+}
+
+@test "pin: drift guard — install.sh and Dockerfile pin the SAME rtk version" {
+    # Single source of truth would be cleaner, but the two files have
+    # different lifecycles (host install vs image build) and must each
+    # carry the version. This test catches the moment a future bump
+    # touches one file but not the other.
+    local install_sh="${BATS_TEST_DIRNAME}/../../.devcontainer/install.sh"
+    local dockerfile="${BATS_TEST_DIRNAME}/../../.devcontainer/images/Dockerfile"
+    [ -f "$install_sh" ]
+    [ -f "$dockerfile" ]
+
+    local install_pin
+    install_pin=$(grep -oE 'RTK_PINNED_VERSION="v[0-9]+\.[0-9]+\.[0-9]+"' "$install_sh" \
+        | head -1 | cut -d'"' -f2)
+    local dockerfile_pin
+    dockerfile_pin=$(grep -oE 'ARG RTK_VERSION=v[0-9]+\.[0-9]+\.[0-9]+' "$dockerfile" \
+        | head -1 | cut -d= -f2)
+
+    [ -n "$install_pin" ]
+    [ -n "$dockerfile_pin" ]
+    [ "$install_pin" = "$dockerfile_pin" ]
 }

--- a/tests/scripts/rtk-hook-claude-wrapper.bats
+++ b/tests/scripts/rtk-hook-claude-wrapper.bats
@@ -46,18 +46,22 @@ run_wrapper() {
 }
 
 # Build a stub rtk binary that echoes a fixed payload + chosen exit code.
-# Stub also captures stdin to a sentinel file so we can assert forwarding.
+# Stub also captures stdin to a sentinel file (so tests can assert forwarding)
+# and optionally emits a fixed payload on stderr (so tests can verify the
+# wrapper does not corrupt stdout JSON when rtk emits a warning).
 make_stub_rtk() {
     local stub_dir="$1"
     local stdout_payload="$2"
     local exit_code="${3:-0}"
     local stdin_capture="${4:-}"
+    local stderr_payload="${5:-}"
 
     mkdir -p "$stub_dir"
     cat > "$stub_dir/rtk" <<EOF
 #!/bin/bash
-# Stub rtk — captures stdin (if asked), emits fixed stdout, exits $exit_code.
+# Stub rtk — captures stdin (if asked), emits fixed stdout/stderr, exits $exit_code.
 $([ -n "$stdin_capture" ] && echo "cat > '$stdin_capture'")
+$([ -n "$stderr_payload" ] && echo "printf '%s' '$stderr_payload' >&2")
 printf '%s' '$stdout_payload'
 exit $exit_code
 EOF
@@ -130,6 +134,28 @@ EOF
     [ "$status" -eq 0 ]
     [ -f "$capture" ]
     grep -q "abc-marker-xyz" "$capture"
+}
+
+# === Test 5b: REGRESSION GUARD — stderr warning must not corrupt stdout JSON ===
+#
+# rtk could plausibly emit a deprecation notice or info log on stderr while
+# producing valid JSON on stdout. The first wrapper draft merged stderr into
+# stdout via 2>&1 before validating JSON, so the warning would corrupt the
+# stream and the wrapper would fall back to {} — silently disabling rtk for
+# that call. Fix: separate streams. The stderr payload is logged but the
+# stdout JSON is what gets validated and forwarded.
+
+@test "rtk-hook-wrapper: rtk emits stderr warning + valid stdout JSON → JSON passes through" {
+    local stub="$TEST_TMPDIR/stub-bin"
+    local payload='{"hookSpecificOutput":{"permissionDecision":"allow"}}'
+    make_stub_rtk "$stub" "$payload" 0 "" "warning: deprecated flag"
+    run run_wrapper "$stub"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"permissionDecision":"allow"'* ]]
+    # The stderr warning must end up in the log, not corrupt stdout.
+    local log="$TEST_HOME/.claude/logs/test-branch/rtk-hook.log"
+    [ -f "$log" ]
+    grep -q "deprecated flag" "$log"
 }
 
 # === Test 6: log dir auto-created when ~/.claude/logs/<branch>/ missing ===

--- a/tests/scripts/rtk-hook-claude-wrapper.bats
+++ b/tests/scripts/rtk-hook-claude-wrapper.bats
@@ -1,0 +1,158 @@
+#!/usr/bin/env bats
+# Tests for rtk-hook-claude.sh — fail-open contract.
+# Layer A of plan tidy-skipping-hollerith (issue #348).
+#
+# CONTRACT — for every input class, the wrapper MUST:
+#   1) exit 0 (any non-zero blocks every Bash call in Claude Code)
+#   2) emit valid JSON on stdout (Claude Code parses it)
+#   3) NEVER surface stderr to Claude (writes to log file instead)
+#   4) forward stdin to rtk on the happy path (regression guard for the
+#      stdin-forwarding bug that motivated this PR)
+
+setup() {
+    load '../helpers/setup'
+    common_setup
+
+    SCRIPT="${BATS_TEST_DIRNAME}/../../.devcontainer/images/.claude/scripts/rtk-hook-claude.sh"
+
+    # Sandbox HOME so the wrapper's log writes go into TEST_TMPDIR, not the
+    # developer's real ~/.claude/logs.
+    export TEST_HOME="$TEST_TMPDIR/home"
+    mkdir -p "$TEST_HOME"
+
+    # Sandbox a fake git repo so _resolve_branch returns a deterministic name.
+    git -C "$TEST_HOME" init -q -b test-branch 2>/dev/null
+}
+
+teardown() {
+    common_teardown
+}
+
+# Run the wrapper with PATH manipulated so a stub rtk (or no rtk) is seen.
+# The stub directory is prepended to PATH; pass "" as $1 to disable rtk.
+run_wrapper() {
+    local stub_dir="$1"
+    shift
+    local payload="${1:-{\"session_id\":\"t\",\"tool_input\":{\"command\":\"git status\"}}}"
+
+    local path_prefix=""
+    [ -n "$stub_dir" ] && path_prefix="$stub_dir:"
+
+    cd "$TEST_HOME" 2>/dev/null
+
+    HOME="$TEST_HOME" \
+    PATH="${path_prefix}/usr/bin:/bin" \
+        bash "$SCRIPT" <<<"$payload"
+}
+
+# Build a stub rtk binary that echoes a fixed payload + chosen exit code.
+# Stub also captures stdin to a sentinel file so we can assert forwarding.
+make_stub_rtk() {
+    local stub_dir="$1"
+    local stdout_payload="$2"
+    local exit_code="${3:-0}"
+    local stdin_capture="${4:-}"
+
+    mkdir -p "$stub_dir"
+    cat > "$stub_dir/rtk" <<EOF
+#!/bin/bash
+# Stub rtk — captures stdin (if asked), emits fixed stdout, exits $exit_code.
+$([ -n "$stdin_capture" ] && echo "cat > '$stdin_capture'")
+printf '%s' '$stdout_payload'
+exit $exit_code
+EOF
+    chmod +x "$stub_dir/rtk"
+}
+
+# === Test 1: rtk absent on PATH → exit 0 + empty {} + log warning ===
+
+@test "rtk-hook-wrapper: rtk absent → exit 0, emits {}, logs warning" {
+    run run_wrapper ""  # no stub_dir → real PATH minus /usr/local/bin
+    [ "$status" -eq 0 ]
+    [[ "$output" == "{}" ]]
+    # Log file should exist and contain the warning.
+    local log="$TEST_HOME/.claude/logs/test-branch/rtk-hook.log"
+    [ -f "$log" ]
+    grep -q "rtk binary not found" "$log"
+}
+
+# === Test 2: rtk present + valid JSON → wrapper passes through ===
+
+@test "rtk-hook-wrapper: happy path passes through rtk's JSON unchanged" {
+    local stub="$TEST_TMPDIR/stub-bin"
+    make_stub_rtk "$stub" '{"hookSpecificOutput":{"permissionDecision":"allow"}}' 0
+    run run_wrapper "$stub"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"permissionDecision":"allow"'* ]]
+    # Log should be absent or empty on happy path.
+    local log="$TEST_HOME/.claude/logs/test-branch/rtk-hook.log"
+    [ ! -f "$log" ] || [ ! -s "$log" ]
+}
+
+# === Test 3: rtk emits non-JSON → wrapper falls back to {} + logs ===
+
+@test "rtk-hook-wrapper: non-JSON output → wrapper emits {} + captures garbage" {
+    local stub="$TEST_TMPDIR/stub-bin"
+    make_stub_rtk "$stub" 'this is not JSON at all' 0
+    run run_wrapper "$stub"
+    [ "$status" -eq 0 ]
+    [[ "$output" == "{}" ]]
+    local log="$TEST_HOME/.claude/logs/test-branch/rtk-hook.log"
+    [ -f "$log" ]
+    grep -q "this is not JSON" "$log"
+}
+
+# === Test 4: rtk segfaults (rc=139) → wrapper still exits 0 + {} ===
+
+@test "rtk-hook-wrapper: rtk rc=139 (simulated segfault) → exit 0 + {}" {
+    local stub="$TEST_TMPDIR/stub-bin"
+    make_stub_rtk "$stub" '' 139
+    run run_wrapper "$stub"
+    [ "$status" -eq 0 ]
+    [[ "$output" == "{}" ]]
+    local log="$TEST_HOME/.claude/logs/test-branch/rtk-hook.log"
+    [ -f "$log" ]
+    grep -qE "rc=139" "$log"
+}
+
+# === Test 5: REGRESSION GUARD — wrapper forwards stdin to rtk ===
+#
+# Without this guarantee the wrapper would consume the Claude Code payload
+# itself and rtk would always degrade, silently disabling token rewrites
+# even on a healthy binary. THIS is the test that catches the original bug.
+
+@test "rtk-hook-wrapper: stdin is forwarded to rtk (regression guard)" {
+    local stub="$TEST_TMPDIR/stub-bin"
+    local capture="$TEST_TMPDIR/stdin-seen.txt"
+    make_stub_rtk "$stub" '{"hookSpecificOutput":{"permissionDecision":"allow"}}' 0 "$capture"
+    local payload='{"session_id":"abc-marker-xyz","tool_input":{"command":"git status"}}'
+    run run_wrapper "$stub" "$payload"
+    [ "$status" -eq 0 ]
+    [ -f "$capture" ]
+    grep -q "abc-marker-xyz" "$capture"
+}
+
+# === Test 6: log dir auto-created when ~/.claude/logs/<branch>/ missing ===
+
+@test "rtk-hook-wrapper: creates log dir on first run" {
+    [ ! -d "$TEST_HOME/.claude/logs" ]
+    run run_wrapper ""  # rtk absent path triggers log write
+    [ "$status" -eq 0 ]
+    [ -d "$TEST_HOME/.claude/logs/test-branch" ]
+}
+
+# === Test 7: settings.json declares the wrapper with timeout=5 (static) ===
+
+@test "rtk-hook-wrapper: settings.json wires the wrapper at timeout=5" {
+    local settings="${BATS_TEST_DIRNAME}/../../.devcontainer/images/.claude/settings.json"
+    [ -f "$settings" ]
+    # Exactly one PreToolUse Bash hook entry must reference the wrapper, with timeout=5.
+    run jq -e '
+        [.hooks.PreToolUse[]
+         | select(.matcher == "Bash")
+         | .hooks[]
+         | select(.command == "/home/vscode/.claude/scripts/rtk-hook-claude.sh")
+         | .timeout] | length == 1 and (.[0] | . == 5)
+    ' "$settings"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #348.

## Summary

Three layered fixes for the rtk integration that surface from the same audit gap:

1. **Fail-open wrapper** — `~/.claude/scripts/rtk-hook-claude.sh` (NEW) wraps `rtk hook claude`. It always exits 0, always emits valid JSON on stdout, and routes diagnostic stderr to `~/.claude/logs/<branch>/rtk-hook.log`. settings.json now invokes the wrapper, not rtk directly. **No rtk failure can propagate as a `PreToolUse` denial anymore.** Two design points caught and fixed before commit: stdin is captured once and re-piped (without it, the wrapper would silently disable rtk even on a healthy binary); the log file is opened **before** the `command -v rtk` check (so the rtk-absent path is observable in the log).

2. **Pin rtk to v0.38.0** — both `.devcontainer/install.sh` (`RTK_PINNED_VERSION`) and `.devcontainer/images/Dockerfile` (`ARG RTK_VERSION`). The `/releases/latest` lottery is gone. A drift test in `install-sh-rtk.bats` extracts the version from each file and asserts equality, so a future bump that touches one file but not the other fails CI immediately. Bump policy added to CLAUDE.md §2.0.

3. **arm64 install asset name fix** — `install.sh` requested `aarch64-unknown-linux-musl` which `rtk-ai/rtk` has never published as an asset (verified for v0.38.0 + v0.39.0). The Dockerfile already used the correct `aarch64-unknown-linux-gnu`; install.sh now matches.

## Why one PR for three things

All three came from the same audit pass on issue #348 and they share one rationale (RTK robustness). Splitting into three PRs would triple the review burden without adding signal: the wrapper is the immediate user-blocker fix, the pin prevents the next one of these incidents, and the arm64 fix is one line in a file we're already touching.

## Test plan

- [x] **7/7** new bats tests in `tests/scripts/rtk-hook-claude-wrapper.bats` (rtk absent / happy path / non-JSON / rc=139 / **stdin forwarding regression guard** / log dir auto-create / settings.json static check)
- [x] **10/10** in `tests/scripts/install-sh-rtk.bats` including 3 new pin invariants + 1 new arm64 invariant
- [x] Full `tests/scripts/*.bats` run: 134/135 (the 1 failure on `init_rtk: returns 0 when rtk is on PATH and config valid` is pre-existing on `main` — verified by re-running against main's version of the file; not introduced by this PR)
- [ ] CI pipeline green
- [ ] Manual smoke test (post-merge): kill `/usr/local/bin/rtk` in a freshly pulled `:latest` image → run a Bash command in the agent → command executes and `~/.claude/logs/<branch>/rtk-hook.log` carries the rtk-missing event

## Commits (each green and reviewable in isolation)

1. `9299c56` — fix(rtk): fail-open hook wrapper to never block bash on rtk failures
2. `ee1873d` — chore(rtk): pin to v0.38.0 with drift guard between install.sh and Dockerfile
3. `6184702` — fix(install): arm64 rtk asset is gnu, not musl
4. `c6d4a3c` — docs(rtk): document fail-open wrapper layer in CLAUDE.md §2.0

## Out of scope

- The pre-existing `init_rtk` test 1 failure on main needs its own fix; tracked separately.
- `step_rtk_claude_init`'s reliance on `rtk init -g --auto-patch` is unaffected here. The wrapper is what makes the runtime contract honored regardless of what `init` does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
What
Adds a fail-open wrapper for the RTK PreToolUse hook, pins RTK to v0.38.0 across install paths, and fixes the arm64 install asset name.

Why
Closes #348 — prevent RTK failures (missing binary, incompatible subcommand, panics, transient ENOENT) from blocking Bash tool invocations while preserving observability and avoiding brittle “latest” release resolution.

How
- Wrapper: Adds .devcontainer/images/.claude/scripts/rtk-hook-claude.sh which captures stdin, ensures stderr is written to ~/.claude/logs/<branch>/rtk-hook.log, invokes rtk hook claude when available, validates stdout as JSON (via jq), always emits valid JSON (falls back to {}), and always exits 0. Settings.json PreToolUse for Bash is updated to call the wrapper.
- Version pinning: Introduces RTK_PINNED_VERSION=v0.38.0 in .devcontainer/install.sh and ARG RTK_VERSION=v0.38.0 in .devcontainer/images/Dockerfile; removes runtime resolution of /releases/latest and adds a drift-guard bats test plus documentation (CLAUDE.md) for the bump policy.
- arm64 fix: install.sh now requests the published aarch64-unknown-linux-gnu asset (aligns with Dockerfile).
- Tests: Adds wrapper tests (7), install-sh contract and drift tests (10), and updates related probe/audit tests.

Risk
- Supply chain/version management: Pinning requires coordinated bumps across files; mitigated by CI drift-guard tests and documented bump procedure.
- Observability vs. error signalling: Wrapper intentionally masks rtk errors by always exiting 0 and emitting JSON — callers must rely on logs (~/.claude/logs/<branch>/rtk-hook.log) and /audit to diagnose degraded mode.
- No auth/crypto, DB, concurrency, or public API changes. No new external runtime dependencies beyond jq for JSON validation in the wrapper. Rollback: revert settings.json and remove the wrapper and pin changes to restore prior behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->