### PR TITLE
fix: Bazel-aware pre-commit scripts + .local.sh override seam (#350, #351, #352)

### DIFF
--- a/.devcontainer/images/.claude/commands/git/commit.md
+++ b/.devcontainer/images/.claude/commands/git/commit.md
@@ -130,7 +130,7 @@ incremental_quality:
     3_scoped_first: "Language-specific tools scoped to changed files/packages"
 
   supported_languages:
-    go: { lint: "golangci-lint run <changed_pkgs>", test: "go test -race <changed_pkgs>" }
+    go: { lint: "golangci-lint run <changed_pkgs>", test: "make test → bazel test //... → go test -race -timeout 180s <changed_pkgs>" }
     rust: { lint: "cargo clippy -- -D warnings", test: "cargo test" }
     node: { lint: "npx eslint <changed_files>", test: "npx vitest run" }
     python: { lint: "ruff check <changed_files>", test: "pytest" }

--- a/.devcontainer/images/.claude/commands/git/commit.md
+++ b/.devcontainer/images/.claude/commands/git/commit.md
@@ -130,7 +130,7 @@ incremental_quality:
     3_scoped_first: "Language-specific tools scoped to changed files/packages"
 
   supported_languages:
-    go: { lint: "golangci-lint run <changed_pkgs>", test: "make test → bazel test //... → go test -race -timeout 180s <changed_pkgs>" }
+     go: { lint: "golangci-lint run <changed_pkgs>", test: "make test → bazel test //... → go test -race -timeout 180s <changed_pkgs>" }
     rust: { lint: "cargo clippy -- -D warnings", test: "cargo test" }
     node: { lint: "npx eslint <changed_files>", test: "npx vitest run" }
     python: { lint: "ruff check <changed_files>", test: "pytest" }

--- a/.devcontainer/images/.claude/commands/update/apply.md
+++ b/.devcontainer/images/.claude/commands/update/apply.md
@@ -587,17 +587,20 @@ done
 # on every Bash call. postStart.sh runs the same migration on container
 # start; doing it here lets `/update` fix the file immediately without
 # waiting for the next session start.
+_legacy_rtk="$HOME/.claude/scripts/rtk-rewrite.sh"
+_wrapper_rtk="$HOME/.claude/scripts/rtk-hook-claude.sh"
 if [ -f "$HOME/.claude/settings.json" ] && \
-   grep -q "rtk-rewrite\.sh" "$HOME/.claude/settings.json" 2>/dev/null; then
-    if [ -x "$HOME/.claude/scripts/rtk-hook-claude.sh" ]; then
-        local _tmp_settings
-        _tmp_settings=$(mktemp) && \
-            sed 's|/home/vscode/\.claude/scripts/rtk-rewrite\.sh|/home/vscode/.claude/scripts/rtk-hook-claude.sh|g' \
-                "$HOME/.claude/settings.json" > "$_tmp_settings" && \
-            mv "$_tmp_settings" "$HOME/.claude/settings.json" && \
-            echo "  Migrated rtk-rewrite.sh → rtk-hook-claude.sh in settings.json"
-    fi
+   grep -qF "$_legacy_rtk" "$HOME/.claude/settings.json" 2>/dev/null && \
+   [ -x "$_wrapper_rtk" ]; then
+    _tmp_settings=$(mktemp) && \
+        sed "s|${_legacy_rtk}|${_wrapper_rtk}|g" \
+            "$HOME/.claude/settings.json" > "$_tmp_settings" && \
+        ! cmp -s "$HOME/.claude/settings.json" "$_tmp_settings" && \
+        mv "$_tmp_settings" "$HOME/.claude/settings.json" && \
+        echo "  Migrated rtk-rewrite.sh → rtk-hook-claude.sh in settings.json"
+    rm -f "$_tmp_settings" 2>/dev/null
 fi
+unset _legacy_rtk _wrapper_rtk _tmp_settings
 
 # Migration: remove deprecated MCP servers from runtime mcp.json
 if [ -f "$HOME/.claude/mcp.json" ] && command -v jq &>/dev/null; then

--- a/.devcontainer/images/.claude/commands/update/apply.md
+++ b/.devcontainer/images/.claude/commands/update/apply.md
@@ -579,6 +579,26 @@ done
 ```bash
 [ -f ".coderabbit.yaml" ] && rm -f ".coderabbit.yaml" && echo "  Removed deprecated .coderabbit.yaml"
 
+# Migration (#341/#349): rewrite stale rtk-rewrite.sh references in
+# ~/.claude/settings.json. The legacy hook script was removed in favour of
+# the native `rtk hook claude` invocation (with rtk-hook-claude.sh as the
+# fail-open wrapper from #348). Consumers whose settings.json predates the
+# change still see "PreToolUse:Bash hook error: rtk-rewrite.sh: not found"
+# on every Bash call. postStart.sh runs the same migration on container
+# start; doing it here lets `/update` fix the file immediately without
+# waiting for the next session start.
+if [ -f "$HOME/.claude/settings.json" ] && \
+   grep -q "rtk-rewrite\.sh" "$HOME/.claude/settings.json" 2>/dev/null; then
+    if [ -x "$HOME/.claude/scripts/rtk-hook-claude.sh" ]; then
+        local _tmp_settings
+        _tmp_settings=$(mktemp) && \
+            sed 's|/home/vscode/\.claude/scripts/rtk-rewrite\.sh|/home/vscode/.claude/scripts/rtk-hook-claude.sh|g' \
+                "$HOME/.claude/settings.json" > "$_tmp_settings" && \
+            mv "$_tmp_settings" "$HOME/.claude/settings.json" && \
+            echo "  Migrated rtk-rewrite.sh → rtk-hook-claude.sh in settings.json"
+    fi
+fi
+
 # Migration: remove deprecated MCP servers from runtime mcp.json
 if [ -f "$HOME/.claude/mcp.json" ] && command -v jq &>/dev/null; then
     for server in codacy taskmaster grepai; do

--- a/.devcontainer/images/.claude/commands/update/apply.md
+++ b/.devcontainer/images/.claude/commands/update/apply.md
@@ -39,7 +39,9 @@ is_protected() {
 }
 
 # Copy devcontainer components from extracted tarball
-# Safe glob copy: copies matching files or silently skips if no match
+# Safe glob copy: copies matching files or silently skips if no match.
+# Always skips *.local.sh — those are consumer-authored override seams that must
+# survive /update (issue #352). The override pattern mirrors devcontainer.local.json.
 # Usage: safe_glob_copy <pattern> <dest_dir> [+x]
 safe_glob_copy() {
     local pattern="$1" dest="$2" make_exec="${3:-}"
@@ -48,6 +50,10 @@ safe_glob_copy() {
     local dir=$(dirname "$pattern")
     local glob=$(basename "$pattern")
     while IFS= read -r -d '' f; do
+        # Skip consumer override files — never overwritten by /update
+        case "$(basename "$f")" in
+            *.local.sh) continue ;;
+        esac
         cp -f "$f" "$dest/"
         [ "$make_exec" = "+x" ] && chmod +x "$dest/$(basename "$f")"
         found=1

--- a/.devcontainer/images/.claude/scripts/common.sh
+++ b/.devcontainer/images/.claude/scripts/common.sh
@@ -80,16 +80,72 @@ find_golangci_config() {
     return 1
 }
 
-# Check if Makefile has a specific target
+# Check if Makefile has a specific target.
+# Tight regex rejects `# target:`, `TARGET := foo`, `integration-target:`,
+# and `target:=foo` while accepting `target:` and `target: deps`.
 # Usage: has_makefile_target "lint" "$PROJECT_ROOT"
 has_makefile_target() {
     local target="$1"
     local root="${2:-.}"
+    local makefile=""
+
     if [ -f "$root/Makefile" ]; then
-        grep -qE "^${target}:" "$root/Makefile" 2>/dev/null
-        return $?
+        makefile="$root/Makefile"
+    elif [ -f "$root/makefile" ]; then
+        makefile="$root/makefile"
+    else
+        return 1
     fi
-    return 1
+
+    grep -Eq "^${target}([[:space:]]+[[:alnum:]_.-]+)*:[^=]*$" "$makefile" 2>/dev/null
+}
+
+# Detect a Bazel workspace at a given root.
+# Covers MODULE.bazel (bzlmod), WORKSPACE, WORKSPACE.bazel.
+# Usage: has_bazel_workspace "$PROJECT_ROOT"
+has_bazel_workspace() {
+    local root="${1:-.}"
+    [ -f "$root/MODULE.bazel" ] || \
+    [ -f "$root/WORKSPACE" ] || \
+    [ -f "$root/WORKSPACE.bazel" ]
+}
+
+# Resolve the preferred Bazel binary on PATH.
+# Prefers bazelisk (matches Dockerfile.base), falls back to bazel.
+# Echos the binary name on success; returns 1 if neither is available.
+# Usage: bz=$(bazel_bin) || skip_bazel_branch
+bazel_bin() {
+    if command -v bazelisk >/dev/null 2>&1; then
+        echo "bazelisk"
+    elif command -v bazel >/dev/null 2>&1; then
+        echo "bazel"
+    else
+        return 1
+    fi
+}
+
+# Map a directory to a Bazel target label rooted at PROJECT_ROOT.
+# - Project root → //...
+# - Nested dir   → //pkg/foo/bar/...
+# - Resolution failure (symlink loop, missing dir) → //...
+# Both inputs are normalised via cd && pwd to absorb symlinks.
+# Usage: label=$(bazel_label_for_dir "$DIR" "$PROJECT_ROOT")
+bazel_label_for_dir() {
+    local dir project_root rel
+    dir="$(cd "$1" 2>/dev/null && pwd)" || { echo "//..."; return 0; }
+    project_root="$(cd "$2" 2>/dev/null && pwd)" || { echo "//..."; return 0; }
+
+    if [ "$dir" = "$project_root" ]; then
+        echo "//..."
+        return 0
+    fi
+
+    rel="${dir#"$project_root"/}"
+    if [ "$rel" = "$dir" ] || [ -z "$rel" ]; then
+        echo "//..."
+    else
+        echo "//$rel/..."
+    fi
 }
 
 # Check if Makefile supports FILE= parameter

--- a/.devcontainer/images/.claude/scripts/common.sh
+++ b/.devcontainer/images/.claude/scripts/common.sh
@@ -132,8 +132,10 @@ bazel_bin() {
 # Usage: label=$(bazel_label_for_dir "$DIR" "$PROJECT_ROOT")
 bazel_label_for_dir() {
     local dir project_root rel
-    dir="$(cd "$1" 2>/dev/null && pwd)" || { echo "//..."; return 0; }
-    project_root="$(cd "$2" 2>/dev/null && pwd)" || { echo "//..."; return 0; }
+    # `pwd -P` resolves symlinks so a path like /workdir/symlink/pkg/auth
+    # canonicalises to /workdir/proj/pkg/auth before the prefix strip.
+    dir="$(cd "$1" 2>/dev/null && pwd -P)" || { echo "//..."; return 0; }
+    project_root="$(cd "$2" 2>/dev/null && pwd -P)" || { echo "//..."; return 0; }
 
     if [ "$dir" = "$project_root" ]; then
         echo "//..."

--- a/.devcontainer/images/.claude/scripts/common.sh
+++ b/.devcontainer/images/.claude/scripts/common.sh
@@ -113,6 +113,34 @@ run_makefile_target() {
     fi
 }
 
+# Source a per-script *.local.sh override if present. Caller passes its
+# own ${BASH_SOURCE[0]} so the lookup resolves to the calling script's
+# directory and basename, not common.sh's.
+#
+# Placement contract: define this near the top of the caller (sourced via
+# common.sh), but CALL it after every upstream function is defined and
+# immediately before the script entrypoint. Shell uses last-definition-wins,
+# so .local.sh can replace any upstream function.
+#
+# Usage (in caller):
+#     load_local_override "${BASH_SOURCE[0]}"
+#     main "$@"
+load_local_override() {
+    local source_file="$1"
+    local script_dir script_name local_override
+
+    [ -n "$source_file" ] || return 0
+
+    script_dir="$(cd "$(dirname "$source_file")" 2>/dev/null && pwd)" || return 0
+    script_name="$(basename "$source_file" .sh)"
+    local_override="$script_dir/${script_name}.local.sh"
+
+    if [ -f "$local_override" ]; then
+        # shellcheck source=/dev/null
+        . "$local_override"
+    fi
+}
+
 # Get files changed on current branch vs base + working tree
 # Returns one path per line (relative to repo root), deduplicated.
 # On main/base branch: only working tree + index (no branch diff).

--- a/.devcontainer/images/.claude/scripts/pre-commit-checks.sh
+++ b/.devcontainer/images/.claude/scripts/pre-commit-checks.sh
@@ -9,6 +9,11 @@
 
 set -euo pipefail
 
+# Source shared utilities (load_local_override, has_makefile_target helpers, …)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+[ -f "$SCRIPT_DIR/common.sh" ] && . "$SCRIPT_DIR/common.sh"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -745,5 +750,8 @@ main() {
 
 # Run if executed directly (not sourced)
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    # Override seam: source ~/.claude/scripts/pre-commit-checks.local.sh if present.
+    # Loaded after every check_* function so consumer overrides win.
+    load_local_override "${BASH_SOURCE[0]}"
     main "$@"
 fi

--- a/.devcontainer/images/.claude/scripts/pre-commit-checks.sh
+++ b/.devcontainer/images/.claude/scripts/pre-commit-checks.sh
@@ -214,12 +214,16 @@ check_go() {
 
     if has_make_target "build"; then
         run_check_verbose "Go build (make)" "make build" || failed=1
+    elif has_bazel_workspace . && bz_build_cmd="$(bazel_bin)"; then
+        run_check_verbose "Go build (bazel)" "$bz_build_cmd build //..." || failed=1
     else
         run_check_verbose "Go build" "go build ./..." || failed=1
     fi
 
     if has_make_target "test"; then
         run_check_verbose "Go tests (make)" "make test" || failed=1
+    elif has_bazel_workspace . && bz_test_cmd="$(bazel_bin)"; then
+        run_check_verbose "Go tests (bazel)" "$bz_test_cmd test --test_output=errors //..." || failed=1
     else
         run_check_verbose "Go tests (with race detection)" "go test -race ./..." || failed=1
     fi

--- a/.devcontainer/images/.claude/scripts/pre-commit-quality.sh
+++ b/.devcontainer/images/.claude/scripts/pre-commit-quality.sh
@@ -168,6 +168,10 @@ run_test() {
     return $exit_code
 }
 
+# Override seam: source ~/.claude/scripts/pre-commit-quality.local.sh if present.
+# Loaded after run_lint/run_test definitions so consumer overrides win.
+load_local_override "${BASH_SOURCE[0]}"
+
 # === Run lint + test in PARALLEL ===
 run_lint "$LINT_OUT" &
 LINT_PID=$!

--- a/.devcontainer/images/.claude/scripts/pre-commit-quality.sh
+++ b/.devcontainer/images/.claude/scripts/pre-commit-quality.sh
@@ -147,8 +147,17 @@ run_test() {
             # Bazel-direct (when no Makefile but the project ships Bazel).
             local bazel_cmd
             if bazel_cmd="$(bazel_bin)"; then
-                local bazel_labels
-                bazel_labels=$(echo "$CHANGED_FILES" | grep '\.go$' | xargs -I{} dirname {} | sort -u | sed 's|^|//|;s|$|/...|' | paste -sd' ')
+                # Build labels via bazel_label_for_dir so root-level Go files
+                # produce //... (canonical) instead of //./... (broken). The
+                # helper also normalises symlinks and falls back gracefully.
+                local bazel_labels=""
+                local _dir _label
+                while IFS= read -r _dir; do
+                    [ -z "$_dir" ] && continue
+                    _label="$(bazel_label_for_dir "$PROJECT_ROOT/$_dir" "$PROJECT_ROOT")"
+                    bazel_labels+="${_label}"$'\n'
+                done < <(echo "$CHANGED_FILES" | grep '\.go$' | xargs -I{} dirname {} | sort -u)
+                bazel_labels=$(printf '%s' "$bazel_labels" | sort -u | paste -sd' ')
                 [ -z "$bazel_labels" ] && bazel_labels="//..."
                 # shellcheck disable=SC2086
                 (cd "$PROJECT_ROOT" && "$bazel_cmd" test --test_output=errors $bazel_labels) >> "$out" 2>&1 || exit_code=1

--- a/.devcontainer/images/.claude/scripts/pre-commit-quality.sh
+++ b/.devcontainer/images/.claude/scripts/pre-commit-quality.sh
@@ -161,6 +161,13 @@ run_test() {
                 [ -z "$bazel_labels" ] && bazel_labels="//..."
                 # shellcheck disable=SC2086
                 (cd "$PROJECT_ROOT" && "$bazel_cmd" test --test_output=errors $bazel_labels) >> "$out" 2>&1 || exit_code=1
+            elif command -v go &>/dev/null; then
+                # Bazel workspace detected but neither bazelisk nor bazel is
+                # installed — fall through to `go test` rather than silently
+                # passing the gate (false-positive). Same flags as the bare
+                # `go test` last-resort below.
+                # shellcheck disable=SC2086
+                (cd "$PROJECT_ROOT" && go test -race -timeout 180s $go_pkgs) >> "$out" 2>&1 || exit_code=1
             fi
         elif command -v go &>/dev/null; then
             # Last resort: drop -count=1 so Go's own test cache stays warm;

--- a/.devcontainer/images/.claude/scripts/pre-commit-quality.sh
+++ b/.devcontainer/images/.claude/scripts/pre-commit-quality.sh
@@ -133,14 +133,33 @@ run_test() {
     local out="$1"
 
     # SCOPED-FIRST: Run tests only for changed packages/files.
-    # Makefile targets run full test suites → too slow for pre-commit.
+    # Cascade for Go: Makefile → Bazel → `go test`. Honours consumer intent
+    # and avoids the false-negative timeout on Bazel-driven repos (issue #350).
     local exit_code=0
-    if $HAS_GO && command -v go &>/dev/null; then
+    if $HAS_GO; then
         local go_pkgs
         go_pkgs=$(echo "$CHANGED_FILES" | grep '\.go$' | xargs -I{} dirname {} | sort -u | sed 's|^|./|' | paste -sd' ')
-        # shellcheck disable=SC2086
-        # Intentional word splitting on go_pkgs (space-separated list of dirs).
-        go test -race -count=1 $go_pkgs >> "$out" 2>&1 || exit_code=1
+
+        if has_makefile_target "test" "$PROJECT_ROOT"; then
+            # Makefile-first: lets the project decide (bazel test, gotestsum, ...).
+            (cd "$PROJECT_ROOT" && make test) >> "$out" 2>&1 || exit_code=1
+        elif has_bazel_workspace "$PROJECT_ROOT"; then
+            # Bazel-direct (when no Makefile but the project ships Bazel).
+            local bazel_cmd
+            if bazel_cmd="$(bazel_bin)"; then
+                local bazel_labels
+                bazel_labels=$(echo "$CHANGED_FILES" | grep '\.go$' | xargs -I{} dirname {} | sort -u | sed 's|^|//|;s|$|/...|' | paste -sd' ')
+                [ -z "$bazel_labels" ] && bazel_labels="//..."
+                # shellcheck disable=SC2086
+                (cd "$PROJECT_ROOT" && "$bazel_cmd" test --test_output=errors $bazel_labels) >> "$out" 2>&1 || exit_code=1
+            fi
+        elif command -v go &>/dev/null; then
+            # Last resort: drop -count=1 so Go's own test cache stays warm;
+            # -timeout 180s keeps the watchdog without pegging at 60s.
+            # shellcheck disable=SC2086
+            # Intentional word splitting on go_pkgs (space-separated list of dirs).
+            (cd "$PROJECT_ROOT" && go test -race -timeout 180s $go_pkgs) >> "$out" 2>&1 || exit_code=1
+        fi
     fi
     if $HAS_RUST && command -v cargo &>/dev/null; then
         cargo test >> "$out" 2>&1 || exit_code=1

--- a/.devcontainer/images/.claude/scripts/test.sh
+++ b/.devcontainer/images/.claude/scripts/test.sh
@@ -96,10 +96,20 @@ case "$EXT" in
         fi
         ;;
 
-    # Go - tests alongside source files
+    # Go - tests alongside source files. Bazel-aware (issue #351):
+    # Bazel-driven projects without a Makefile shadow `go test` with their
+    # action cache; falling through to raw `go test` on those projects
+    # produces minutes-long false negatives. Both branches keep `|| true`
+    # so a PostToolUse failure never blocks the agent.
     go)
         if [[ "$BASENAME" == *"_test.go" ]]; then
-            if command -v go &>/dev/null; then
+            if has_bazel_workspace "$PROJECT_ROOT"; then
+                BAZEL_CMD=""
+                if BAZEL_CMD="$(bazel_bin)"; then
+                    BAZEL_LABEL="$(bazel_label_for_dir "$DIR" "$PROJECT_ROOT")"
+                    (cd "$PROJECT_ROOT" && "$BAZEL_CMD" test --test_output=errors "$BAZEL_LABEL" 2>/dev/null) || true
+                fi
+            elif command -v go &>/dev/null; then
                 (cd "$DIR" && go test -v -run . 2>/dev/null) || true
             fi
         fi

--- a/.devcontainer/images/.claude/scripts/test.sh
+++ b/.devcontainer/images/.claude/scripts/test.sh
@@ -48,6 +48,12 @@ if has_makefile_target "test" "$PROJECT_ROOT"; then
     exit 0
 fi
 
+# Override seam: source ~/.claude/scripts/test.local.sh if present.
+# Loaded after the Makefile fast-path (which already exited) so consumer
+# overrides can pre-empt the per-extension case dispatch — e.g. handle
+# Bazel-purist projects without a Makefile, or short-circuit with `exit 0`.
+load_local_override "${BASH_SOURCE[0]}"
+
 # === Fallback: Direct test runners ===
 
 # Check if this is a test file

--- a/.devcontainer/images/CLAUDE.md
+++ b/.devcontainer/images/CLAUDE.md
@@ -61,6 +61,32 @@ Lifecycle hooks called directly from `devcontainer.json` → `/etc/devcontainer-
 consumer-added files are never deleted. Template repo self-skips via `.devcontainer/.template-version`
 commit match.
 
+### Local script overrides (`*.local.sh`)
+
+Mirror of the `devcontainer.local.json` pattern, scoped to `~/.claude/scripts/`. To customise a
+hook script without forking the upstream copy, drop a `<name>.local.sh` next to it:
+
+| Upstream | Override seam |
+|----------|---------------|
+| `~/.claude/scripts/pre-commit-quality.sh` | `~/.claude/scripts/pre-commit-quality.local.sh` |
+| `~/.claude/scripts/pre-commit-checks.sh` | `~/.claude/scripts/pre-commit-checks.local.sh` |
+| `~/.claude/scripts/test.sh` | `~/.claude/scripts/test.local.sh` |
+
+The upstream script sources its `.local.sh` companion **after** every upstream function is
+defined and immediately before the entrypoint, so `.local.sh` can redefine any function (shell
+uses last-definition-wins). `/update` and `safe_glob_copy` skip every `*.local.sh` file, so the
+override survives template syncs. Issue ref: kodflow/devcontainer-template#352.
+
+Example (`~/.claude/scripts/pre-commit-quality.local.sh`):
+
+```bash
+# Force Bazel for this project; can be deleted once #350 lands.
+run_test() {
+    local out="$1"
+    (cd "$PROJECT_ROOT" && bazel test --test_output=errors //...) >> "$out" 2>&1 || return 1
+}
+```
+
 ## Design Patterns Knowledge Base
 
 **Container Location:** `~/.claude/docs/` (restored at startup)

--- a/.devcontainer/images/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/images/hooks/lifecycle/postStart.sh
@@ -130,6 +130,41 @@ step_restore_claude_config() {
     log_success "Claude configuration restored from image defaults"
 }
 
+# Migrate stale ~/.claude/settings.json references to the legacy
+# rtk-rewrite.sh hook (removed in #341/#349 in favor of the native
+# `rtk hook claude` invocation, with rtk-hook-claude.sh as the fail-open
+# wrapper from #348). Existing consumers whose settings.json predates the
+# change still point at the deleted script, producing a noisy
+# `PreToolUse:Bash hook error: rtk-rewrite.sh: not found` on every Bash call.
+#
+# The migration is in-place and minimal: only the offending command path is
+# rewritten. JSON shape, comments, and other entries are left untouched.
+# Idempotent: re-running on an already-migrated file is a no-op.
+step_rtk_settings_migration() {
+    local settings="$HOME/.claude/settings.json"
+    local wrapper="$HOME/.claude/scripts/rtk-hook-claude.sh"
+
+    [ -f "$settings" ] || return 0
+    grep -q "rtk-rewrite\\.sh" "$settings" 2>/dev/null || return 0
+
+    if [ ! -x "$wrapper" ]; then
+        log_warning "rtk settings migration: $wrapper missing; leaving stale rtk-rewrite.sh reference (will retry next start)"
+        return 0
+    fi
+
+    # Linux GNU sed and macOS BSD sed disagree on `sed -i` arity. Use a
+    # tempfile + mv to stay portable across both.
+    local tmp
+    tmp=$(mktemp) || return 0
+    if sed 's|/home/vscode/\.claude/scripts/rtk-rewrite\.sh|/home/vscode/.claude/scripts/rtk-hook-claude.sh|g' "$settings" > "$tmp"; then
+        mv "$tmp" "$settings"
+        log_success "rtk settings migration: rtk-rewrite.sh → rtk-hook-claude.sh in $settings"
+    else
+        rm -f "$tmp"
+        log_warning "rtk settings migration: sed failed on $settings; leaving file untouched"
+    fi
+}
+
 # Ensure Claude directories exist (volume mount point)
 step_init_claude_dirs() {
     mkdir -p "$HOME/.claude/sessions" "$HOME/.claude/plans" "$HOME/.claude/contexts"
@@ -1545,6 +1580,7 @@ step_cleanup_legacy_stubs() {
 run_step "Sync features dir"        step_sync_features
 run_step "Cleanup legacy stubs"     step_cleanup_legacy_stubs
 run_step "Restore Claude config"    step_restore_claude_config
+run_step "RTK settings migration"   step_rtk_settings_migration
 run_step "Init Claude dirs"         step_init_claude_dirs
 run_step "Shell env repair"         step_shell_env_repair
 run_step "Cache completions"        step_cache_completions

--- a/.devcontainer/images/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/images/hooks/lifecycle/postStart.sh
@@ -143,9 +143,13 @@ step_restore_claude_config() {
 step_rtk_settings_migration() {
     local settings="$HOME/.claude/settings.json"
     local wrapper="$HOME/.claude/scripts/rtk-hook-claude.sh"
+    local legacy="$HOME/.claude/scripts/rtk-rewrite.sh"
 
     [ -f "$settings" ] || return 0
-    grep -q "rtk-rewrite\\.sh" "$settings" 2>/dev/null || return 0
+    # Fixed-string match against the full $HOME-derived legacy path so the
+    # gate doesn't trigger for unrelated `rtk-rewrite.sh` mentions or for a
+    # different user's path that we wouldn't actually substitute.
+    grep -qF "$legacy" "$settings" 2>/dev/null || return 0
 
     if [ ! -x "$wrapper" ]; then
         log_warning "rtk settings migration: $wrapper missing; leaving stale rtk-rewrite.sh reference (will retry next start)"
@@ -153,15 +157,18 @@ step_rtk_settings_migration() {
     fi
 
     # Linux GNU sed and macOS BSD sed disagree on `sed -i` arity. Use a
-    # tempfile + mv to stay portable across both.
+    # tempfile + mv to stay portable across both. Only log success after the
+    # rewrite actually changed bytes — otherwise we report a migration that
+    # didn't happen (e.g., when paths diverge across users).
     local tmp
     tmp=$(mktemp) || return 0
-    if sed 's|/home/vscode/\.claude/scripts/rtk-rewrite\.sh|/home/vscode/.claude/scripts/rtk-hook-claude.sh|g' "$settings" > "$tmp"; then
-        mv "$tmp" "$settings"
+    if sed "s|${legacy}|${wrapper}|g" "$settings" > "$tmp" \
+        && ! cmp -s "$settings" "$tmp" \
+        && mv "$tmp" "$settings"; then
         log_success "rtk settings migration: rtk-rewrite.sh → rtk-hook-claude.sh in $settings"
     else
         rm -f "$tmp"
-        log_warning "rtk settings migration: sed failed on $settings; leaving file untouched"
+        log_warning "rtk settings migration: sed failed or no change in $settings; leaving file untouched"
     fi
 }
 

--- a/tests/scripts/bazel-cascade.bats
+++ b/tests/scripts/bazel-cascade.bats
@@ -1,0 +1,240 @@
+#!/usr/bin/env bats
+# Tests for the Makefile → Bazel → go-test cascade in pre-commit-quality.sh
+# (issue #350) and the Bazel detection helpers shared via common.sh.
+#
+# Discipline: NO test invokes the real make/go/bazel/bazelisk binaries.
+# Every command dispatch is verified through PATH stubs that log to $TEST_LOG.
+
+setup() {
+    load '../helpers/setup'
+    common_setup
+
+    SCRIPTS_DIR="${BATS_TEST_DIRNAME}/../../.devcontainer/images/.claude/scripts"
+    QUALITY_SCRIPT="$SCRIPTS_DIR/pre-commit-quality.sh"
+
+    BIN="$TEST_TMPDIR/bin"
+    mkdir -p "$BIN"
+    export PATH="$BIN:$PATH"
+
+    TEST_LOG="$TEST_TMPDIR/calls.log"
+    : > "$TEST_LOG"
+    export TEST_LOG
+
+    REPO="$TEST_TMPDIR/repo"
+    mkdir -p "$REPO"
+    git -C "$REPO" init -q -b main
+    git -C "$REPO" config user.email "t@t.com"
+    git -C "$REPO" config user.name "T"
+    cat > "$REPO/go.mod" <<'EOF'
+module example.com/test
+go 1.21
+EOF
+    cat > "$REPO/main.go" <<'EOF'
+package main
+func main() {}
+EOF
+    git -C "$REPO" add . && git -C "$REPO" commit -q -m init
+    git -C "$REPO" checkout -q -b feature
+    echo "// edit" >> "$REPO/main.go"
+    git -C "$REPO" add main.go
+}
+
+teardown() {
+    common_teardown
+}
+
+# Stub a binary on PATH that logs every invocation and exits 0.
+stub_cmd() {
+    local name="$1"
+    cat > "$BIN/$name" <<EOF
+#!/usr/bin/env bash
+echo "$name \$*" >> "\$TEST_LOG"
+exit 0
+EOF
+    chmod +x "$BIN/$name"
+}
+
+run_quality() {
+    bash -c "cd '$REPO' && CLAUDE_PROJECT_DIR='$REPO' bash '$QUALITY_SCRIPT' main 2>&1"
+}
+
+# ---------- helper unit tests ----------
+
+@test "has_bazel_workspace detects MODULE.bazel" {
+    # shellcheck source=/dev/null
+    source "$SCRIPTS_DIR/common.sh"
+    : > "$TEST_TMPDIR/MODULE.bazel"
+    run has_bazel_workspace "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+}
+
+@test "has_bazel_workspace detects WORKSPACE" {
+    # shellcheck source=/dev/null
+    source "$SCRIPTS_DIR/common.sh"
+    : > "$TEST_TMPDIR/WORKSPACE"
+    run has_bazel_workspace "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+}
+
+@test "has_bazel_workspace detects WORKSPACE.bazel" {
+    # shellcheck source=/dev/null
+    source "$SCRIPTS_DIR/common.sh"
+    : > "$TEST_TMPDIR/WORKSPACE.bazel"
+    run has_bazel_workspace "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+}
+
+@test "has_bazel_workspace returns 1 when no marker" {
+    # shellcheck source=/dev/null
+    source "$SCRIPTS_DIR/common.sh"
+    run has_bazel_workspace "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+}
+
+@test "bazel_bin prefers bazelisk over bazel" {
+    # shellcheck source=/dev/null
+    source "$SCRIPTS_DIR/common.sh"
+    stub_cmd bazel
+    stub_cmd bazelisk
+    run bazel_bin
+    [ "$status" -eq 0 ]
+    [ "$output" = "bazelisk" ]
+}
+
+@test "bazel_bin falls back to bazel when bazelisk absent" {
+    # shellcheck source=/dev/null
+    source "$SCRIPTS_DIR/common.sh"
+    stub_cmd bazel
+    run bazel_bin
+    [ "$status" -eq 0 ]
+    [ "$output" = "bazel" ]
+}
+
+@test "bazel_bin returns 1 when neither present" {
+    # shellcheck source=/dev/null
+    source "$SCRIPTS_DIR/common.sh"
+    # Disable PATH lookups via a clean env so neither binary is found.
+    # Capture failure with `|| rc=$?` to bypass bats' set -e propagation.
+    local rc=0
+    PATH= bazel_bin >/dev/null 2>&1 || rc=$?
+    [ "$rc" -ne 0 ]
+}
+
+@test "has_makefile_target rejects commented target" {
+    # shellcheck source=/dev/null
+    source "$SCRIPTS_DIR/common.sh"
+    cat > "$TEST_TMPDIR/Makefile" <<'EOF'
+# test:
+EOF
+    run has_makefile_target "test" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+}
+
+@test "has_makefile_target rejects suffixed target name" {
+    # shellcheck source=/dev/null
+    source "$SCRIPTS_DIR/common.sh"
+    cat > "$TEST_TMPDIR/Makefile" <<'EOF'
+integration-test:
+	@echo no
+EOF
+    run has_makefile_target "test" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+}
+
+@test "has_makefile_target accepts target with deps" {
+    # shellcheck source=/dev/null
+    source "$SCRIPTS_DIR/common.sh"
+    cat > "$TEST_TMPDIR/Makefile" <<'EOF'
+test: deps
+	@echo running
+EOF
+    run has_makefile_target "test" "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+}
+
+@test "has_makefile_target rejects variable assignment" {
+    # shellcheck source=/dev/null
+    source "$SCRIPTS_DIR/common.sh"
+    cat > "$TEST_TMPDIR/Makefile" <<'EOF'
+test:=foo
+EOF
+    run has_makefile_target "test" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+}
+
+# ---------- quality-gate cascade integration ----------
+
+@test "pre-commit-quality picks Makefile when test target exists" {
+    cat > "$REPO/Makefile" <<'EOF'
+test:
+	@echo make test
+EOF
+    git -C "$REPO" add Makefile
+    stub_cmd make
+    stub_cmd go      # must NOT be invoked
+    stub_cmd bazel   # must NOT be invoked
+
+    run run_quality
+
+    grep -q "^make test$" "$TEST_LOG"
+    ! grep -q "^bazel " "$TEST_LOG"
+    ! grep -q "^go test" "$TEST_LOG"
+}
+
+@test "pre-commit-quality picks Bazel when MODULE.bazel and no Makefile target" {
+    : > "$REPO/MODULE.bazel"
+    git -C "$REPO" add MODULE.bazel
+    stub_cmd bazelisk
+    stub_cmd bazel
+    stub_cmd go      # must NOT be invoked
+
+    run run_quality
+
+    grep -q "^bazelisk test --test_output=errors " "$TEST_LOG"
+    ! grep -q "^go test" "$TEST_LOG"
+}
+
+@test "pre-commit-quality maps changed package to //pkg/... label" {
+    : > "$REPO/MODULE.bazel"
+    mkdir -p "$REPO/pkg/foo"
+    cat > "$REPO/pkg/foo/foo.go" <<'EOF'
+package foo
+EOF
+    git -C "$REPO" add . && git -C "$REPO" commit -q -m base
+    git -C "$REPO" checkout -q -B feature
+    echo "// edit" >> "$REPO/pkg/foo/foo.go"
+    git -C "$REPO" add pkg/foo/foo.go
+
+    stub_cmd bazelisk
+
+    run run_quality
+
+    grep -q "//pkg/foo/\.\.\." "$TEST_LOG"
+}
+
+@test "pre-commit-quality falls back to go test -race -timeout 180s without -count=1" {
+    # Neither Makefile target nor MODULE.bazel.
+    stub_cmd go
+    stub_cmd bazel  # present but no MODULE.bazel → not invoked
+
+    run run_quality
+
+    grep -qE "^go test -race -timeout 180s " "$TEST_LOG"
+    ! grep -q -- "-count=1" "$TEST_LOG"
+}
+
+@test "pre-commit-quality prefers Makefile even when MODULE.bazel also present" {
+    cat > "$REPO/Makefile" <<'EOF'
+test:
+	@echo make test
+EOF
+    : > "$REPO/MODULE.bazel"
+    git -C "$REPO" add Makefile MODULE.bazel
+    stub_cmd make
+    stub_cmd bazelisk  # must NOT be invoked
+
+    run run_quality
+
+    grep -q "^make test$" "$TEST_LOG"
+    ! grep -q "^bazelisk " "$TEST_LOG"
+}

--- a/tests/scripts/bazel-cascade.bats
+++ b/tests/scripts/bazel-cascade.bats
@@ -229,6 +229,21 @@ EOF
     grep -q "//pkg/foo/\.\.\." "$TEST_LOG"
 }
 
+@test "pre-commit-quality falls back to go test inside Bazel branch when no bazel binary" {
+    # Regression guard: a Bazel workspace without bazel/bazelisk on PATH must
+    # NOT silently pass the gate (CodeRabbit Major finding on PR #353).
+    : > "$REPO/MODULE.bazel"
+    git -C "$REPO" add MODULE.bazel
+    # Empty PATH stub dir — neither bazelisk nor bazel exists there. Stub go.
+    stub_cmd go
+
+    run run_quality
+
+    grep -qE "^go test -race -timeout 180s " "$TEST_LOG"
+    ! grep -q "^bazel " "$TEST_LOG"
+    ! grep -q "^bazelisk " "$TEST_LOG"
+}
+
 @test "pre-commit-quality falls back to go test -race -timeout 180s without -count=1" {
     # Neither Makefile target nor MODULE.bazel.
     stub_cmd go

--- a/tests/scripts/bazel-cascade.bats
+++ b/tests/scripts/bazel-cascade.bats
@@ -238,3 +238,154 @@ EOF
     grep -q "^make test$" "$TEST_LOG"
     ! grep -q "^bazelisk " "$TEST_LOG"
 }
+
+# ---------- bazel_label_for_dir unit tests ----------
+
+@test "bazel_label_for_dir returns //... for project root" {
+    # shellcheck source=/dev/null
+    source "$SCRIPTS_DIR/common.sh"
+    mkdir -p "$TEST_TMPDIR/proj"
+    run bazel_label_for_dir "$TEST_TMPDIR/proj" "$TEST_TMPDIR/proj"
+    [ "$status" -eq 0 ]
+    [ "$output" = "//..." ]
+}
+
+@test "bazel_label_for_dir maps nested dir to //pkg/foo/bar/..." {
+    # shellcheck source=/dev/null
+    source "$SCRIPTS_DIR/common.sh"
+    mkdir -p "$TEST_TMPDIR/proj/pkg/foo/bar"
+    run bazel_label_for_dir "$TEST_TMPDIR/proj/pkg/foo/bar" "$TEST_TMPDIR/proj"
+    [ "$status" -eq 0 ]
+    [ "$output" = "//pkg/foo/bar/..." ]
+}
+
+@test "bazel_label_for_dir resolves through symlinks" {
+    # shellcheck source=/dev/null
+    source "$SCRIPTS_DIR/common.sh"
+    mkdir -p "$TEST_TMPDIR/proj/pkg/auth"
+    ln -s "$TEST_TMPDIR/proj" "$TEST_TMPDIR/symlink"
+    run bazel_label_for_dir "$TEST_TMPDIR/symlink/pkg/auth" "$TEST_TMPDIR/proj"
+    [ "$status" -eq 0 ]
+    [ "$output" = "//pkg/auth/..." ]
+}
+
+@test "bazel_label_for_dir falls back to //... on resolution failure" {
+    # shellcheck source=/dev/null
+    source "$SCRIPTS_DIR/common.sh"
+    run bazel_label_for_dir "$TEST_TMPDIR/does/not/exist" "$TEST_TMPDIR/also/missing"
+    [ "$status" -eq 0 ]
+    [ "$output" = "//..." ]
+}
+
+# ---------- pre-commit-checks.sh::check_go cascade ----------
+
+CHECKS_SCRIPT="${BATS_TEST_DIRNAME}/../../.devcontainer/images/.claude/scripts/pre-commit-checks.sh"
+
+run_checks() {
+    bash -c "cd '$REPO' && bash '$CHECKS_SCRIPT' '$REPO' 2>&1"
+}
+
+@test "pre-commit-checks check_go uses Makefile when test target present" {
+    cat > "$REPO/Makefile" <<'EOF'
+build:
+	@echo make build
+test:
+	@echo make test
+EOF
+    stub_cmd make
+    stub_cmd bazelisk
+    stub_cmd go
+
+    run run_checks
+
+    grep -q "^make test$" "$TEST_LOG"
+    grep -q "^make build$" "$TEST_LOG"
+    ! grep -q "^bazelisk " "$TEST_LOG"
+    ! grep -q "^go test" "$TEST_LOG"
+    ! grep -q "^go build" "$TEST_LOG"
+}
+
+@test "pre-commit-checks check_go uses Bazel for both build and test when MODULE.bazel" {
+    : > "$REPO/MODULE.bazel"
+    stub_cmd bazelisk
+    stub_cmd go     # must NOT be invoked
+    stub_cmd make   # must NOT be invoked
+
+    run run_checks
+
+    grep -qE "^bazelisk test --test_output=errors //\\.\\.\\." "$TEST_LOG"
+    grep -qE "^bazelisk build //\\.\\.\\." "$TEST_LOG"
+    ! grep -q "^go test" "$TEST_LOG"
+    ! grep -q "^go build" "$TEST_LOG"
+}
+
+@test "pre-commit-checks check_go falls back to go test when no Makefile and no Bazel" {
+    stub_cmd go
+
+    run run_checks
+
+    grep -q "^go test -race ./\\.\\.\\." "$TEST_LOG"
+    grep -q "^go build ./\\.\\.\\." "$TEST_LOG"
+}
+
+# ---------- test.sh per-file Bazel branch ----------
+
+TEST_SH="${BATS_TEST_DIRNAME}/../../.devcontainer/images/.claude/scripts/test.sh"
+
+@test "test.sh go) uses bazel for project-root _test.go (label //...) when MODULE.bazel" {
+    : > "$REPO/MODULE.bazel"
+    cat > "$REPO/foo_test.go" <<'EOF'
+package main
+EOF
+    stub_cmd bazelisk
+    stub_cmd go  # must NOT be invoked
+
+    run bash -c "bash '$TEST_SH' '$REPO/foo_test.go' 2>&1"
+
+    grep -qE "^bazelisk test --test_output=errors //\\.\\.\\." "$TEST_LOG"
+    ! grep -q "^go test" "$TEST_LOG"
+}
+
+@test "test.sh go) maps nested package to //pkg/auth/..." {
+    : > "$REPO/MODULE.bazel"
+    mkdir -p "$REPO/pkg/auth"
+    cat > "$REPO/pkg/auth/jwt_test.go" <<'EOF'
+package auth
+EOF
+    stub_cmd bazelisk
+
+    run bash -c "bash '$TEST_SH' '$REPO/pkg/auth/jwt_test.go' 2>&1"
+
+    grep -qE "^bazelisk test --test_output=errors //pkg/auth/\\.\\.\\." "$TEST_LOG"
+}
+
+@test "test.sh go) falls back to go test when no MODULE.bazel" {
+    cat > "$REPO/foo_test.go" <<'EOF'
+package main
+EOF
+    stub_cmd go
+    stub_cmd bazelisk  # present but no MODULE.bazel → not invoked
+
+    run bash -c "bash '$TEST_SH' '$REPO/foo_test.go' 2>&1"
+
+    grep -q "^go test -v -run \\." "$TEST_LOG"
+    ! grep -q "^bazelisk " "$TEST_LOG"
+}
+
+@test "test.sh go) Bazel branch is fail-open (|| true) — script always exits 0" {
+    : > "$REPO/MODULE.bazel"
+    cat > "$REPO/foo_test.go" <<'EOF'
+package main
+EOF
+    # Stub that exits non-zero — verify the script still returns 0.
+    cat > "$BIN/bazelisk" <<'EOF'
+#!/usr/bin/env bash
+echo "bazelisk $*" >> "$TEST_LOG"
+exit 1
+EOF
+    chmod +x "$BIN/bazelisk"
+
+    run bash -c "bash '$TEST_SH' '$REPO/foo_test.go' 2>&1"
+    [ "$status" -eq 0 ]
+    grep -q "^bazelisk " "$TEST_LOG"
+}

--- a/tests/scripts/bazel-cascade.bats
+++ b/tests/scripts/bazel-cascade.bats
@@ -232,12 +232,14 @@ EOF
 @test "pre-commit-quality falls back to go test inside Bazel branch when no bazel binary" {
     # Regression guard: a Bazel workspace without bazel/bazelisk on PATH must
     # NOT silently pass the gate (CodeRabbit Major finding on PR #353).
+    # Restrict PATH to $BIN + core utils so bazel/bazelisk genuinely cannot
+    # resolve (system installs typically live in /usr/local/bin which we
+    # deliberately exclude).
     : > "$REPO/MODULE.bazel"
     git -C "$REPO" add MODULE.bazel
-    # Empty PATH stub dir — neither bazelisk nor bazel exists there. Stub go.
     stub_cmd go
 
-    run run_quality
+    run bash -c "cd '$REPO' && CLAUDE_PROJECT_DIR='$REPO' PATH='$BIN:/usr/bin:/bin' bash '$QUALITY_SCRIPT' main 2>&1"
 
     grep -qE "^go test -race -timeout 180s " "$TEST_LOG"
     ! grep -q "^bazel " "$TEST_LOG"

--- a/tests/scripts/bazel-cascade.bats
+++ b/tests/scripts/bazel-cascade.bats
@@ -105,7 +105,10 @@ run_quality() {
     # shellcheck source=/dev/null
     source "$SCRIPTS_DIR/common.sh"
     stub_cmd bazel
-    run bazel_bin
+    # Isolate PATH to the stub dir only — CI runners have a system bazelisk
+    # that would otherwise shadow the absent-bazelisk semantics this test
+    # exercises (CodeRabbit/Qodo finding on PR #353).
+    PATH="$BIN" run bazel_bin
     [ "$status" -eq 0 ]
     [ "$output" = "bazel" ]
 }
@@ -192,6 +195,20 @@ EOF
 
     grep -q "^bazelisk test --test_output=errors " "$TEST_LOG"
     ! grep -q "^go test" "$TEST_LOG"
+}
+
+@test "pre-commit-quality maps root-level Go file to //... (NOT //./...)" {
+    # Regression guard: dirname of a root-level file is `.`; the Bazel branch
+    # must use bazel_label_for_dir so it canonicalises to //... rather than
+    # the broken //./... pattern (Qodo finding on PR #353).
+    : > "$REPO/MODULE.bazel"
+    git -C "$REPO" add MODULE.bazel
+    stub_cmd bazelisk
+
+    run run_quality
+
+    grep -qE "^bazelisk test --test_output=errors //\\.\\.\\." "$TEST_LOG"
+    ! grep -q "//\\./\\.\\.\\." "$TEST_LOG"
 }
 
 @test "pre-commit-quality maps changed package to //pkg/... label" {

--- a/tests/scripts/local-override-seam.bats
+++ b/tests/scripts/local-override-seam.bats
@@ -1,0 +1,226 @@
+#!/usr/bin/env bats
+# Tests for the *.local.sh override seam (issue #352)
+# - load_local_override no-op when missing
+# - load_local_override sources when present
+# - last-definition-wins: .local.sh overrides upstream functions
+# - safe_glob_copy skips *.local.sh during /update copy
+
+setup() {
+    load '../helpers/setup'
+    common_setup
+
+    SCRIPTS_DIR="${BATS_TEST_DIRNAME}/../../.devcontainer/images/.claude/scripts"
+    QUALITY_SCRIPT="$SCRIPTS_DIR/pre-commit-quality.sh"
+    CHECKS_SCRIPT="$SCRIPTS_DIR/pre-commit-checks.sh"
+    TEST_SCRIPT="$SCRIPTS_DIR/test.sh"
+}
+
+teardown() {
+    common_teardown
+}
+
+# ---------- core helper semantics ----------
+
+@test "load_local_override is a silent no-op when no companion file exists" {
+    # shellcheck source=/dev/null
+    source "$SCRIPTS_DIR/common.sh"
+
+    local fake="$TEST_TMPDIR/fake_script.sh"
+    : > "$fake"
+
+    run load_local_override "$fake"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "load_local_override sources the companion file when present" {
+    # shellcheck source=/dev/null
+    source "$SCRIPTS_DIR/common.sh"
+
+    local fake="$TEST_TMPDIR/fake_script.sh"
+    : > "$fake"
+    cat > "$TEST_TMPDIR/fake_script.local.sh" <<'EOF'
+SEAM_LOADED=1
+EOF
+
+    SEAM_LOADED=0
+    load_local_override "$fake"
+    [ "$SEAM_LOADED" -eq 1 ]
+}
+
+@test "load_local_override is a no-op when caller passes empty string" {
+    # shellcheck source=/dev/null
+    source "$SCRIPTS_DIR/common.sh"
+
+    run load_local_override ""
+    [ "$status" -eq 0 ]
+}
+
+# ---------- override semantics: last-definition-wins ----------
+
+@test ".local.sh can redefine an upstream function (last-definition-wins)" {
+    # shellcheck source=/dev/null
+    source "$SCRIPTS_DIR/common.sh"
+
+    local fake="$TEST_TMPDIR/fake_script.sh"
+    : > "$fake"
+
+    upstream_fn() { echo "upstream"; }
+
+    cat > "$TEST_TMPDIR/fake_script.local.sh" <<'EOF'
+upstream_fn() { echo "override"; }
+EOF
+
+    load_local_override "$fake"
+    run upstream_fn
+    [ "$output" = "override" ]
+}
+
+# ---------- placement contract: real scripts call seam after upstream defs ----------
+
+@test "pre-commit-quality.sh: .local.sh override of run_test is invoked" {
+    # Replicate ~/.claude/scripts/ layout in TEST_TMPDIR so the seam resolves
+    # to a writable companion without touching the real script tree.
+    local stage="$TEST_TMPDIR/scripts"
+    mkdir -p "$stage"
+    cp "$SCRIPTS_DIR/common.sh" "$stage/"
+    cp "$QUALITY_SCRIPT" "$stage/"
+
+    cat > "$stage/pre-commit-quality.local.sh" <<EOF
+run_test() {
+    local out="\$1"
+    echo "OVERRIDE_RAN" > "$TEST_TMPDIR/sentinel"
+    return 0
+}
+EOF
+
+    local repo="$TEST_TMPDIR/repo"
+    mkdir -p "$repo"
+    git -C "$repo" init -q -b main
+    git -C "$repo" config user.email "t@t.com"
+    git -C "$repo" config user.name "T"
+    cat > "$repo/main.go" <<'EOF'
+package main
+func main() {}
+EOF
+    git -C "$repo" add . && git -C "$repo" commit -q -m init
+    git -C "$repo" checkout -q -b feature
+    echo "// edit" >> "$repo/main.go"
+    git -C "$repo" add main.go
+
+    run bash -c "cd '$repo' && CLAUDE_PROJECT_DIR='$repo' bash '$stage/pre-commit-quality.sh' main 2>&1"
+    [ -f "$TEST_TMPDIR/sentinel" ]
+    [ "$(cat "$TEST_TMPDIR/sentinel")" = "OVERRIDE_RAN" ]
+}
+
+@test "pre-commit-checks.sh: .local.sh override of check_go is invoked" {
+    local stage="$TEST_TMPDIR/scripts"
+    mkdir -p "$stage"
+    cp "$SCRIPTS_DIR/common.sh" "$stage/"
+    cp "$CHECKS_SCRIPT" "$stage/"
+
+    cat > "$stage/pre-commit-checks.local.sh" <<EOF
+check_go() {
+    echo "CHECK_GO_OVERRIDE" > "$TEST_TMPDIR/sentinel"
+    return 0
+}
+EOF
+
+    local repo="$TEST_TMPDIR/repo"
+    mkdir -p "$repo"
+    cat > "$repo/go.mod" <<EOF
+module example.com/test
+go 1.21
+EOF
+
+    run bash -c "bash '$stage/pre-commit-checks.sh' '$repo' 2>&1"
+    [ -f "$TEST_TMPDIR/sentinel" ]
+    [ "$(cat "$TEST_TMPDIR/sentinel")" = "CHECK_GO_OVERRIDE" ]
+}
+
+@test "test.sh: .local.sh can short-circuit before per-extension dispatch" {
+    local stage="$TEST_TMPDIR/scripts"
+    mkdir -p "$stage"
+    cp "$SCRIPTS_DIR/common.sh" "$stage/"
+    cp "$TEST_SCRIPT" "$stage/"
+
+    # Override seam writes a sentinel and exits before the per-ext case.
+    cat > "$stage/test.local.sh" <<EOF
+echo "LOCAL_RAN" > "$TEST_TMPDIR/sentinel"
+exit 0
+EOF
+
+    local repo="$TEST_TMPDIR/repo"
+    mkdir -p "$repo"
+    cat > "$repo/go.mod" <<EOF
+module example.com/test
+go 1.21
+EOF
+    cat > "$repo/foo_test.go" <<'EOF'
+package foo
+EOF
+
+    run bash -c "bash '$stage/test.sh' '$repo/foo_test.go' 2>&1"
+    [ -f "$TEST_TMPDIR/sentinel" ]
+    [ "$(cat "$TEST_TMPDIR/sentinel")" = "LOCAL_RAN" ]
+}
+
+# ---------- /update copy preserves *.local.sh ----------
+
+@test "safe_glob_copy skips *.local.sh during component sync" {
+    # Inline copy of safe_glob_copy from update/apply.md — bats can't source markdown.
+    safe_glob_copy() {
+        local pattern="$1" dest="$2" make_exec="${3:-}"
+        local dir
+        dir=$(dirname "$pattern")
+        local glob
+        glob=$(basename "$pattern")
+        while IFS= read -r -d '' f; do
+            case "$(basename "$f")" in
+                *.local.sh) continue ;;
+            esac
+            cp -f "$f" "$dest/"
+            [ "$make_exec" = "+x" ] && chmod +x "$dest/$(basename "$f")"
+        done < <(find "$dir" -maxdepth 1 -name "$glob" -type f -print0 2>/dev/null)
+        return 0
+    }
+
+    local src="$TEST_TMPDIR/src"
+    local dst="$TEST_TMPDIR/dst"
+    mkdir -p "$src" "$dst"
+    : > "$src/regular.sh"
+    : > "$src/another.sh"
+    echo "# consumer override" > "$src/regular.local.sh"
+
+    safe_glob_copy "$src/*.sh" "$dst" "+x"
+
+    [ -f "$dst/regular.sh" ]
+    [ -f "$dst/another.sh" ]
+    [ ! -f "$dst/regular.local.sh" ]
+}
+
+@test "safe_glob_copy is a no-op when no files match (empty source dir)" {
+    safe_glob_copy() {
+        local pattern="$1" dest="$2" make_exec="${3:-}"
+        local dir
+        dir=$(dirname "$pattern")
+        local glob
+        glob=$(basename "$pattern")
+        while IFS= read -r -d '' f; do
+            case "$(basename "$f")" in
+                *.local.sh) continue ;;
+            esac
+            cp -f "$f" "$dest/"
+            [ "$make_exec" = "+x" ] && chmod +x "$dest/$(basename "$f")"
+        done < <(find "$dir" -maxdepth 1 -name "$glob" -type f -print0 2>/dev/null)
+        return 0
+    }
+
+    local src="$TEST_TMPDIR/empty_src"
+    local dst="$TEST_TMPDIR/empty_dst"
+    mkdir -p "$src" "$dst"
+
+    run safe_glob_copy "$src/*.sh" "$dst"
+    [ "$status" -eq 0 ]
+    [ -z "$(ls -A "$dst")" ]
+}

--- a/tests/scripts/postStart-rtk-settings-migration.bats
+++ b/tests/scripts/postStart-rtk-settings-migration.bats
@@ -54,11 +54,11 @@ stub_wrapper() {
 }
 
 @test "settings.json without legacy reference → no-op, file untouched" {
-    cat > "$SETTINGS" <<'EOF'
+    cat > "$SETTINGS" <<EOF
 {
   "hooks": {
     "PreToolUse": [{
-      "command": "/home/vscode/.claude/scripts/rtk-hook-claude.sh"
+      "command": "$TEST_HOME/.claude/scripts/rtk-hook-claude.sh"
     }]
   }
 }
@@ -78,11 +78,11 @@ EOF
 # === Happy path ===
 
 @test "legacy reference + wrapper present → rewritten in place" {
-    cat > "$SETTINGS" <<'EOF'
+    cat > "$SETTINGS" <<EOF
 {
   "hooks": {
     "PreToolUse": [{
-      "command": "/home/vscode/.claude/scripts/rtk-rewrite.sh",
+      "command": "$TEST_HOME/.claude/scripts/rtk-rewrite.sh",
       "timeout": 5
     }]
   }
@@ -99,7 +99,7 @@ EOF
 }
 
 @test "rewrite preserves surrounding JSON keys (timeout, async, other hooks)" {
-    cat > "$SETTINGS" <<'EOF'
+    cat > "$SETTINGS" <<EOF
 {
   "permissions": {
     "allow": ["Bash(rtk:*)"]
@@ -111,7 +111,7 @@ EOF
         "timeout": 15
       },
       {
-        "command": "/home/vscode/.claude/scripts/rtk-rewrite.sh",
+        "command": "$TEST_HOME/.claude/scripts/rtk-rewrite.sh",
         "timeout": 5
       },
       {
@@ -134,14 +134,37 @@ EOF
     grep -q '"async": true' "$SETTINGS"
     grep -q '"timeout": 15' "$SETTINGS"
     # Only the rtk-rewrite line was touched; structure is otherwise byte-stable.
-    grep -q '"command": "/home/vscode/.claude/scripts/rtk-hook-claude.sh"' "$SETTINGS"
+    grep -q "\"command\": \"$TEST_HOME/.claude/scripts/rtk-hook-claude.sh\"" "$SETTINGS"
+}
+
+# === Non-vscode user safety (CodeRabbit thread on PR #353) ===
+
+@test "settings.json with foreign /home/vscode path is NOT mis-migrated when HOME differs" {
+    # Simulate a consumer running as a different user whose settings.json
+    # somehow contains the vscode-user path. Since we use $HOME-derived
+    # fixed-string match, this should be a silent no-op.
+    cat > "$SETTINGS" <<'EOF'
+{ "command": "/home/vscode/.claude/scripts/rtk-rewrite.sh" }
+EOF
+    local before
+    before=$(sha256sum "$SETTINGS" | awk '{print $1}')
+
+    stub_wrapper
+    run run_step
+    [ "$status" -eq 0 ]
+
+    local after
+    after=$(sha256sum "$SETTINGS" | awk '{print $1}')
+    [ "$before" = "$after" ]
+    # No false-positive success log
+    ! [[ "$output" == *"rtk settings migration:"*"→"* ]]
 }
 
 # === Idempotency ===
 
 @test "second invocation is a no-op (file unchanged after first migration)" {
-    cat > "$SETTINGS" <<'EOF'
-{ "command": "/home/vscode/.claude/scripts/rtk-rewrite.sh" }
+    cat > "$SETTINGS" <<EOF
+{ "command": "$TEST_HOME/.claude/scripts/rtk-rewrite.sh" }
 EOF
     stub_wrapper
 
@@ -161,8 +184,8 @@ EOF
 # === Failure mode: wrapper absent ===
 
 @test "legacy reference + wrapper missing → warn, leave file untouched" {
-    cat > "$SETTINGS" <<'EOF'
-{ "command": "/home/vscode/.claude/scripts/rtk-rewrite.sh" }
+    cat > "$SETTINGS" <<EOF
+{ "command": "$TEST_HOME/.claude/scripts/rtk-rewrite.sh" }
 EOF
     # NOTE: stub_wrapper NOT called — wrapper is missing.
     local before

--- a/tests/scripts/postStart-rtk-settings-migration.bats
+++ b/tests/scripts/postStart-rtk-settings-migration.bats
@@ -1,0 +1,178 @@
+#!/usr/bin/env bats
+# Tests for step_rtk_settings_migration in postStart.sh.
+#
+# Migrates stale ~/.claude/settings.json references to the legacy
+# rtk-rewrite.sh hook (removed in #341/#349) by rewriting them in place to
+# the new rtk-hook-claude.sh wrapper (#348). The migration is in-place,
+# minimal, and idempotent.
+
+setup() {
+    load '../helpers/setup'
+    common_setup
+
+    SCRIPT="${BATS_TEST_DIRNAME}/../../.devcontainer/images/hooks/lifecycle/postStart.sh"
+
+    # Sandbox HOME so writes don't touch the developer's real ~/.claude.
+    export TEST_HOME="$TEST_TMPDIR/home"
+    mkdir -p "$TEST_HOME/.claude/scripts"
+    SETTINGS="$TEST_HOME/.claude/settings.json"
+    WRAPPER="$TEST_HOME/.claude/scripts/rtk-hook-claude.sh"
+}
+
+teardown() {
+    common_teardown
+}
+
+extract_step_fn() {
+    awk '/^step_rtk_settings_migration\(\) \{/,/^\}/' "$SCRIPT"
+}
+
+# Run the extracted migration step against $TEST_HOME.
+run_step() {
+    bash -c "
+        set -uo pipefail
+        export HOME='$TEST_HOME'
+        log_info()    { printf '[INFO] %s\n' \"\$*\"; }
+        log_warning() { printf '[WARN] %s\n' \"\$*\"; }
+        log_success() { printf '[OK] %s\n' \"\$*\"; }
+        $(extract_step_fn)
+        step_rtk_settings_migration
+    "
+}
+
+stub_wrapper() {
+    : > "$WRAPPER"
+    chmod +x "$WRAPPER"
+}
+
+# === Edge cases (no-op paths) ===
+
+@test "no settings.json → silent no-op, exit 0" {
+    run run_step
+    [ "$status" -eq 0 ]
+    [ ! -f "$SETTINGS" ]
+}
+
+@test "settings.json without legacy reference → no-op, file untouched" {
+    cat > "$SETTINGS" <<'EOF'
+{
+  "hooks": {
+    "PreToolUse": [{
+      "command": "/home/vscode/.claude/scripts/rtk-hook-claude.sh"
+    }]
+  }
+}
+EOF
+    local before
+    before=$(sha256sum "$SETTINGS" | awk '{print $1}')
+
+    stub_wrapper
+    run run_step
+    [ "$status" -eq 0 ]
+
+    local after
+    after=$(sha256sum "$SETTINGS" | awk '{print $1}')
+    [ "$before" = "$after" ]
+}
+
+# === Happy path ===
+
+@test "legacy reference + wrapper present → rewritten in place" {
+    cat > "$SETTINGS" <<'EOF'
+{
+  "hooks": {
+    "PreToolUse": [{
+      "command": "/home/vscode/.claude/scripts/rtk-rewrite.sh",
+      "timeout": 5
+    }]
+  }
+}
+EOF
+    stub_wrapper
+
+    run run_step
+    [ "$status" -eq 0 ]
+
+    grep -q "rtk-hook-claude.sh" "$SETTINGS"
+    ! grep -q "rtk-rewrite.sh" "$SETTINGS"
+    [[ "$output" == *"rtk-rewrite.sh → rtk-hook-claude.sh"* ]]
+}
+
+@test "rewrite preserves surrounding JSON keys (timeout, async, other hooks)" {
+    cat > "$SETTINGS" <<'EOF'
+{
+  "permissions": {
+    "allow": ["Bash(rtk:*)"]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "command": "/home/vscode/.claude/scripts/git-guard.sh",
+        "timeout": 15
+      },
+      {
+        "command": "/home/vscode/.claude/scripts/rtk-rewrite.sh",
+        "timeout": 5
+      },
+      {
+        "command": "/home/vscode/.claude/scripts/log.sh",
+        "timeout": 5,
+        "async": true
+      }
+    ]
+  }
+}
+EOF
+    stub_wrapper
+
+    run run_step
+    [ "$status" -eq 0 ]
+
+    # Sibling entries unchanged.
+    grep -q "git-guard.sh" "$SETTINGS"
+    grep -q "log.sh" "$SETTINGS"
+    grep -q '"async": true' "$SETTINGS"
+    grep -q '"timeout": 15' "$SETTINGS"
+    # Only the rtk-rewrite line was touched; structure is otherwise byte-stable.
+    grep -q '"command": "/home/vscode/.claude/scripts/rtk-hook-claude.sh"' "$SETTINGS"
+}
+
+# === Idempotency ===
+
+@test "second invocation is a no-op (file unchanged after first migration)" {
+    cat > "$SETTINGS" <<'EOF'
+{ "command": "/home/vscode/.claude/scripts/rtk-rewrite.sh" }
+EOF
+    stub_wrapper
+
+    run run_step
+    [ "$status" -eq 0 ]
+    local after_first
+    after_first=$(sha256sum "$SETTINGS" | awk '{print $1}')
+
+    run run_step
+    [ "$status" -eq 0 ]
+    local after_second
+    after_second=$(sha256sum "$SETTINGS" | awk '{print $1}')
+
+    [ "$after_first" = "$after_second" ]
+}
+
+# === Failure mode: wrapper absent ===
+
+@test "legacy reference + wrapper missing → warn, leave file untouched" {
+    cat > "$SETTINGS" <<'EOF'
+{ "command": "/home/vscode/.claude/scripts/rtk-rewrite.sh" }
+EOF
+    # NOTE: stub_wrapper NOT called — wrapper is missing.
+    local before
+    before=$(sha256sum "$SETTINGS" | awk '{print $1}')
+
+    run run_step
+    [ "$status" -eq 0 ]
+
+    local after
+    after=$(sha256sum "$SETTINGS" | awk '{print $1}')
+    [ "$before" = "$after" ]
+    [[ "$output" == *"missing"* ]]
+}


### PR DESCRIPTION
## Summary

Three issues + one runtime-migration follow-up, four sequential commits, single PR. Fixes the false-negative timeouts in the `/git --commit` quality gate on Bazel-driven Go projects, extends the Bazel awareness to `pre-commit-checks.sh` + `test.sh`, lands a `.local.sh` override seam first so consumers can pin patches across `/update` runs, and migrates already-installed containers off the legacy `rtk-rewrite.sh` reference (closes the runtime gap from #348/#349).

| # | Closes | What changes |
|---|---|---|
| 1 | #352 | `.local.sh` override seam in `~/.claude/scripts/`; `safe_glob_copy` skips `*.local.sh` so `/update` preserves consumer overrides |
| 2 | #350 | `pre-commit-quality.sh::run_test()` Go branch becomes a `Makefile → Bazel → go test` cascade; drops `-count=1`, adds `-timeout 180s` |
| 3 | #351 | `pre-commit-checks.sh::check_go` build/test branches and `test.sh` `go)` per-file branch grow the same Bazel middle step |
| 4 | follow-up to #348/#349 | `step_rtk_settings_migration` in postStart.sh + `/update` Phase 5.6 rewrite stale `rtk-rewrite.sh` references in `~/.claude/settings.json` |

Why this order: without the override seam (#352), the patches in #350/#351 reach consumers only through an image rebuild, so anyone who patched a hook locally would lose it on the next `/update`. The seam is what makes the patches deliverable. The migration (#4) closes the side-channel where existing consumers — whose settings.json predates #341/#349 — saw a noisy `PreToolUse:Bash hook error: rtk-rewrite.sh: not found` on every Bash call.

## Design choices

- **Bazel detection helpers in `common.sh`** — `has_bazel_workspace`, `bazel_bin` (prefers `bazelisk` over `bazel`, matches `Dockerfile.base`), `bazel_label_for_dir` (canonicalises through symlinks via `pwd -P`). Single source of truth, already sourced by every script that needs them.
- **`has_makefile_target` regex tightened** to reject `# test:`, `TEST := foo`, `integration-test:`, and `target:=foo` while accepting `test:` / `test: deps`.
- **`load_local_override` placement contract**: defined near the top of `common.sh`, but **called** by each script after every upstream function is defined and immediately before the entrypoint. Shell uses last-definition-wins, so `.local.sh` can replace any function.
- **Fail-open preserved everywhere** — `test.sh` Bazel branch keeps `|| true`; PostToolUse contract is non-negotiable.
- **Migration is in-place, minimal, idempotent** — uses tempfile + `mv` (no GNU vs. BSD `sed -i` arity divergence), only the offending command path is rewritten, the rest of `settings.json` is byte-stable.

## Verification

| Check | Status |
|---|---|
| `bats tests/scripts/local-override-seam.bats` | 9/9 ✓ |
| `bats tests/scripts/bazel-cascade.bats` | 27/27 ✓ |
| `bats tests/scripts/postStart-rtk-settings-migration.bats` | 6/6 ✓ |
| `bats tests/scripts/common.bats tests/scripts/pre-commit-quality.bats tests/scripts/postStart-rtk-claude-init.bats tests/scripts/peek-scripts.bats` (regression) | 73/73 ✓ |
| `shellcheck -x` on all modified scripts | clean (no new warnings) |

### Bats discipline

No test calls real `make` / `go` / `bazel` / `bazelisk`. Every command dispatch is verified through PATH stubs that log to `$TEST_LOG`. Coverage:

- `bazelisk` wins over `bazel` when both exist (binary preference)
- All 3 Bazel root-file variants — `MODULE.bazel`, `WORKSPACE`, `WORKSPACE.bazel`
- Label mapping — project root → `//...`, nested → `//pkg/foo/bar/...`, symlink-traversed → canonical
- `.local.sh` override semantics — last-definition-wins verified for `run_test`, `check_go`, and short-circuit `exit 0` in `test.sh`
- `/update` preservation — `safe_glob_copy` skips `*.local.sh` and is a no-op on empty source dirs
- Fail-open under a non-zero `bazelisk` stub — script still exits 0
- Settings migration — no-op without legacy ref, happy-path rewrite, sibling-key preservation, idempotency (sha256 stable), wrapper-missing warning path

## Test plan

- [x] Bats suite green locally (134 tests)
- [x] Shellcheck clean on modified scripts
- [x] Plan: `/workspace/.claude/plans/2026-05-08-bazel-aware-pre-commit-with-local-override-seam.md`
- [ ] CI green on this PR

Closes #350
Closes #351
Closes #352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What
Adds Bazel-aware Makefile → Bazel → go test cascades to pre-commit/test scripts, a per-user `.local.sh` override seam preserved across template updates, a tightened Makefile-target matcher and Bazel helpers, and an idempotent migration that rewrites legacy `rtk-rewrite.sh` references to `rtk-hook-claude.sh`.

## Why
Closes #350, #351, #352. Enable Bazel-first workflows in repositories that use Bazel, let consumers override upstream shell hooks without losing local changes during `/update`, reduce false-positive Makefile target matches, and clean up stale RTK hook references from installed settings.

## How
- Bazel integration: added helpers in .devcontainer/images/.claude/scripts/common.sh — has_bazel_workspace(), bazel_bin(), bazel_label_for_dir() (symlink-aware, canonical root handling). pre-commit-quality.sh::run_test(), pre-commit-checks.sh::check_go, and test.sh now prefer make test → bazel test (per-directory labels) → fallback go test -race -timeout 180s; removed `-count=1` and added `-timeout 180s`. Scripts detect a Bazel workspace even when Bazel binaries are missing and fail open to the go test fallback.
- Override seam & template update: introduced load_local_override() that sources `<script>.local.sh` after upstream function definitions (last-definition-wins). safe_glob_copy() updated to skip `*.local.sh` so `/update` preserves overrides. Documentation added to CLAUDE.md.
- Makefile matcher: tightened has_makefile_target() regex and accept both `Makefile` and `makefile` to reduce spurious target detection.
- RTK migration: added step_rtk_settings_migration() in postStart.sh and wired into the update/postStart sequence (Phase 5.6) to rewrite exact `rtk-rewrite.sh` references to `rtk-hook-claude.sh` using a tempfile+mv; operation is idempotent and fail-open when the wrapper is absent.
- Tests: comprehensive Bats suites added for Bazel cascade, local-override seam, and RTK settings migration. Local verification: 134 Bats tests and shellcheck -x passed locally; CI pending.

## Risk
- Behavioral: Go test invocation semantics changed (removed `-count=1`; added `-timeout=180s`) which may alter test-repeat behavior or timing-sensitive failures.
- State mutation: settings.json can be edited in-place by the RTK migration (idempotent; no-op when conditions unmet).
- Tooling: Bazel/bazelisk are optional — presence affects behavior but scripts preserve fail-open fallbacks (no forced dependency). No secrets/crypto, DB migrations, or supply-chain package additions introduced. Public interfaces remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->