### PR TITLE
fix(nodejs): 3-tier NVM version resolution to avoid build aborts (closes #354)

### DIFF
--- a/.devcontainer/features/languages/nodejs/devcontainer-feature.json
+++ b/.devcontainer/features/languages/nodejs/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "nodejs",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "name": "Node.js Development Environment",
   "description": "Installs Node.js via NVM, npm, yarn, pnpm and common development tools",
   "options": {

--- a/.devcontainer/features/languages/nodejs/install.sh
+++ b/.devcontainer/features/languages/nodejs/install.sh
@@ -158,22 +158,25 @@ apt_get_retry install -y curl git build-essential libssl-dev || {
 # Install NVM (Node Version Manager)
 log_info "Installing NVM..."
 mkdir_safe "$NVM_DIR"
-# Fetch latest NVM version from GitHub API
+# Resolve latest NVM tag with 3-tier fallback (issue #354):
+#   1. git ls-remote — not rate-limited, no auth
+#   2. GitHub REST API via shared helper — fallback for restricted networks
+#   3. Pinned NVM_FALLBACK_VERSION — guarantees the build never aborts here
+NVM_FALLBACK_VERSION="v0.40.4"
 NVM_LATEST=""
-_nvm_auth=()
-[[ -n "${GITHUB_TOKEN:-}" ]] && _nvm_auth=(-H "Authorization: token ${GITHUB_TOKEN}")
-for _attempt in 1 2 3; do
-    NVM_LATEST=$(curl -fsS --connect-timeout 5 --max-time 10 \
-        "${_nvm_auth[@]}" \
-        "https://api.github.com/repos/nvm-sh/nvm/releases/latest" 2>/dev/null \
-        | grep -o '"tag_name": *"[^"]*"' | head -1 | cut -d'"' -f4) || true
-    [[ -n "$NVM_LATEST" ]] && break
-    sleep $((_attempt * 2))
-done
+NVM_LATEST=$(git ls-remote --tags --refs --sort=-v:refname \
+    https://github.com/nvm-sh/nvm.git 'v[0-9]*' 2>/dev/null \
+    | head -n 1 | sed 's|.*refs/tags/||') || true
 if [ -z "$NVM_LATEST" ]; then
-    log_error "Failed to resolve latest NVM version after retries"
-    exit 1
+    log_warning "git ls-remote failed for nvm-sh/nvm; trying GitHub API"
+    NVM_LATEST=$(get_github_latest_version_or_empty "nvm-sh/nvm")
 fi
+if [ -z "$NVM_LATEST" ]; then
+    log_warning "GitHub API rate-limited; falling back to pinned ${NVM_FALLBACK_VERSION}"
+    NVM_LATEST="$NVM_FALLBACK_VERSION"
+fi
+# Helper strips the leading 'v'; NVM install URL expects it
+[[ "$NVM_LATEST" != v* ]] && NVM_LATEST="v${NVM_LATEST}"
 log_info "Using NVM ${NVM_LATEST}"
 download_and_pipe "https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_LATEST}/install.sh" bash || {
     log_error "Failed to install NVM"

--- a/tests/scripts/nodejs-install.bats
+++ b/tests/scripts/nodejs-install.bats
@@ -44,7 +44,9 @@ teardown() {
     # Lock-in: the old fatal branch ('Failed to resolve latest NVM version' + exit 1)
     # must never come back — tier 3 guarantees a usable fallback.
     ! grep -q 'Failed to resolve latest NVM version after retries' "$INSTALL_SH"
-    ! awk '/Failed to resolve latest NVM/{flag=1} flag && /exit 1/{print; exit 0} END{exit 1}' \
+    # awk: END unconditionally overrode previous exit() — set a flag instead so
+    # exit code reflects whether the forbidden pattern was actually found.
+    ! awk '/Failed to resolve latest NVM/{flag=1} flag && /exit 1/{found=1} END{exit(found?0:1)}' \
         "$INSTALL_SH"
 }
 

--- a/tests/scripts/nodejs-install.bats
+++ b/tests/scripts/nodejs-install.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+# Static regression guards for the Node.js feature install.sh — issue #354.
+# Mirrors tests/scripts/go-install.bats. Network and apt are NOT exercised
+# (impossible without root + connectivity). We assert the structural
+# invariants that prevent the rate-limit fatal regression from creeping back.
+
+setup() {
+    load '../helpers/setup'
+    common_setup
+    INSTALL_SH="${BATS_TEST_DIRNAME}/../../.devcontainer/features/languages/nodejs/install.sh"
+    META="${BATS_TEST_DIRNAME}/../../.devcontainer/features/languages/nodejs/devcontainer-feature.json"
+}
+
+teardown() {
+    common_teardown
+}
+
+# --- syntax & shell hygiene ---
+
+@test "install.sh syntax is valid" {
+    bash -n "$INSTALL_SH"
+}
+
+@test "install.sh enables set -e" {
+    grep -qE '^set -e' "$INSTALL_SH"
+}
+
+# --- 3-tier NVM resolution invariants (issue #354) ---
+
+@test "tier 1: git ls-remote against nvm-sh/nvm exists" {
+    grep -q 'git ls-remote --tags --refs --sort=-v:refname' "$INSTALL_SH"
+    grep -q 'github.com/nvm-sh/nvm.git' "$INSTALL_SH"
+}
+
+@test "tier 2: shared helper get_github_latest_version_or_empty is used for nvm-sh/nvm" {
+    grep -q 'get_github_latest_version_or_empty "nvm-sh/nvm"' "$INSTALL_SH"
+}
+
+@test "tier 3: pinned NVM_FALLBACK_VERSION constant is defined with a v-prefixed tag" {
+    grep -qE '^NVM_FALLBACK_VERSION="v[0-9]+\.[0-9]+\.[0-9]+"' "$INSTALL_SH"
+}
+
+@test "no fatal exit when latest NVM version cannot be resolved" {
+    # Lock-in: the old fatal branch ('Failed to resolve latest NVM version' + exit 1)
+    # must never come back — tier 3 guarantees a usable fallback.
+    ! grep -q 'Failed to resolve latest NVM version after retries' "$INSTALL_SH"
+    ! awk '/Failed to resolve latest NVM/{flag=1} flag && /exit 1/{print; exit 0} END{exit 1}' \
+        "$INSTALL_SH"
+}
+
+@test "NVM_LATEST is normalized to a v-prefixed tag before use" {
+    grep -qE '\[\[ "\$NVM_LATEST" != v\* \]\] && NVM_LATEST="v\$\{NVM_LATEST\}"' "$INSTALL_SH"
+}
+
+@test "duplicated _nvm_auth array is removed (shared helper handles GITHUB_TOKEN)" {
+    ! grep -q '_nvm_auth=' "$INSTALL_SH"
+}
+
+# --- devcontainer-feature.json: version gate ---
+
+@test "feature version is bumped to >= 1.0.3 (CI version-gate.yml)" {
+    local v
+    v=$(grep -oE '"version": *"[0-9]+\.[0-9]+\.[0-9]+"' "$META" | head -1 \
+        | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)"/\1/')
+    [ -n "$v" ]
+    # Sort-merged comparison: $v must be >= 1.0.3
+    local lowest
+    lowest=$(printf '%s\n%s\n' "1.0.3" "$v" | sort -V | head -n1)
+    [ "$lowest" = "1.0.3" ]
+}


### PR DESCRIPTION
## Summary

Fixes #354 — the only open issue on the repo at the time of this PR.

`features/languages/nodejs/install.sh` aborts the **entire devcontainer build** whenever `api.github.com` rate-limits the request that resolves the latest NVM release tag. The single API path has no fallback, so every Docker Desktop NAT, corporate egress, or CI runner that exhausts the 60 req/h unauthenticated quota is fatal.

This PR replaces the inline `curl` loop with a 3-tier resolution that mirrors the `#266` fix already applied to Go/Kotlin/Java/Lua/Ada/Fortran:

1. **`git ls-remote`** against `https://github.com/nvm-sh/nvm.git` — git Smart-HTTP, **not rate-limited**, no auth. `git` is already a hard dependency of the feature.
2. **`get_github_latest_version_or_empty "nvm-sh/nvm"`** — shared helper from `features/languages/shared/feature-utils.sh:90`, non-fatal, returns empty string on failure.
3. **Pinned `NVM_FALLBACK_VERSION="v0.40.4"`** — last-resort constant verified upstream via `git ls-remote` on 2026-05-08. Bump alongside future template syncs.

A final normalization step ensures `$NVM_LATEST` always carries the `v` prefix expected by the NVM install URL (the helper strips it).

## What changed

- `.devcontainer/features/languages/nodejs/install.sh` — replaces lines 161-177 with the 3-tier block; drops the duplicated `_nvm_auth` array (the shared helper handles `GITHUB_TOKEN`).
- `.devcontainer/features/languages/nodejs/devcontainer-feature.json` — `version: "1.0.2"` → `"1.0.3"` so GHCR republishes (rule #6 in `features/CLAUDE.md`, enforced by `.github/workflows/version-gate.yml`).
- `tests/scripts/nodejs-install.bats` *(new file)* — 9 static structural guards mirroring `tests/scripts/go-install.bats`. Locks in the 3-tier invariants and prevents the old fatal regression from creeping back.

## Test plan

- [x] `bash -n .devcontainer/features/languages/nodejs/install.sh` — passes
- [x] `npx bats tests/scripts/nodejs-install.bats` — **9/9 ok**
- [x] Tier 1 sanity: `git ls-remote --tags --refs --sort=-v:refname https://github.com/nvm-sh/nvm.git 'v[0-9]*' | head -3` → returns `v0.40.4 / v0.40.3 / v0.40.2`
- [x] Version-gate rule satisfied: diff of `devcontainer-feature.json` includes `+ "version"` line
- [ ] CI green on this PR (workflows: tests.yml + version-gate.yml)

## Out of scope (deliberate)

Extending the `git ls-remote` first-try strategy into `shared/feature-utils.sh::get_github_latest_version` so all languages benefit. The original issue explicitly defers this to keep the diff minimal — should land as a follow-up if desired.

Closes #354.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**What**: Implemented a 3-tier NVM version resolution in the Node.js devcontainer feature to avoid build aborts when resolving the latest nvm-sh/nvm tag (replaces a fatal REST-API-only lookup).

**Why**: Closes #354 — the previous GitHub REST API-only approach caused devcontainer build failures under API rate limits or transient network errors; the new strategy ensures builds complete reliably in constrained or offline environments.

**How**: 
- install.sh now resolves NVM in three tiers: (1) git ls-remote https://github.com/nvm-sh/nvm.git (Smart-HTTP), (2) fallback to shared helper get_github_latest_version_or_empty "nvm-sh/nvm" (non-fatal), (3) pinned NVM_FALLBACK_VERSION="v0.40.4".
- Normalizes resolved tags to ensure a leading "v".
- Removes duplicated _nvm_auth handling (relies on the shared helper).
- Bumps .devcontainer/features/languages/nodejs/devcontainer-feature.json version 1.0.2 → 1.0.3 to force GHCR republish.
- Adds tests/scripts/nodejs-install.bats (9 structural tests) and fixes an awk regression in the tests to ensure the forbidden fatal-exit path is detected.

**Risk**:
- Supply-chain/maintenance: the pinned fallback (v0.40.4) may become outdated — requires occasional updates.
- Operational: relies on availability of git (git ls-remote), but this is standard and preferred over REST API rate-limits.
- No breaking changes to public API or build outputs; change is backward compatible.
- No new external dependencies or secrets/crypto changes introduced.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kodflow/devcontainer-template/pull/355)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->