### PR TITLE
fix(features/go): ktn-linter release asset URL + tar.gz extract + go install fallback (#371)

### DIFF
--- a/.devcontainer/features/languages/go/devcontainer-feature.json
+++ b/.devcontainer/features/languages/go/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "go",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "name": "Go Development Environment",
   "description": "Installs Go with common development tools and multi-architecture support",
   "options": {

--- a/.devcontainer/features/languages/go/install.sh
+++ b/.devcontainer/features/languages/go/install.sh
@@ -312,10 +312,15 @@ set +e
 TOOL_PIDS[goimports]=$!
 set -e
 
+# Release asset is goreleaser-style `ktn-linter_linux_<arch>.tar.gz` containing
+# the binary at the tarball root. The legacy hyphenated raw-binary URL never
+# existed as a published asset — that 404 broke every container build because
+# no go-install fallback was wired (issue #324 follow-up). The `cmd/ktn-linter`
+# fallback covers a Releases-CDN blip or future asset-naming skew.
 spawn_tool "ktn-linter" \
-    "https://github.com/kodflow/ktn-linter/releases/latest/download/ktn-linter-linux-${GO_ARCH}" \
-    "" \
-    "binary"
+    "https://github.com/kodflow/ktn-linter/releases/latest/download/ktn-linter_linux_${GO_ARCH}.tar.gz" \
+    "github.com/kodflow/ktn-linter/cmd/ktn-linter" \
+    "tar.gz"
 
 # Bazel tooling — same release ships both binaries.
 if [[ -n "$BUILDTOOLS_VERSION" ]]; then

--- a/.devcontainer/images/hooks/lifecycle/sync-toolchains.sh
+++ b/.devcontainer/images/hooks/lifecycle/sync-toolchains.sh
@@ -201,21 +201,30 @@ sync_go() {
     # short-circuit and skip Go sync entirely.
     local failed=0
     local tool installed upstream major_pin
-    # Atomic binary install for ktn-linter (release asset, not a Go module).
+    # Atomic install for ktn-linter (goreleaser tarball, not a Go module path).
     # Writes to a sibling .download path then renames — protects against a
-    # half-fetched binary if curl is interrupted mid-stream. Returns non-zero
-    # on any failure so the caller can flag the sync as incomplete.
+    # half-fetched payload if curl is interrupted mid-stream. Falls back to
+    # `go install …/cmd/ktn-linter` if the release CDN 404s (asset-naming
+    # drift) or times out. Returns non-zero only when both paths fail.
     install_ktn_linter() {
         local target="${GOPATH}/bin/ktn-linter"
-        local tmp="${target}.download"
+        local tmp_tgz="${target}.download.tgz"
+        local tmp_bin="${target}.download"
         if curl -fsSL --connect-timeout 10 --max-time 60 \
-                "https://github.com/kodflow/ktn-linter/releases/latest/download/ktn-linter-linux-${GO_ARCH}" \
-                -o "$tmp" 2>/dev/null \
-            && chmod +x "$tmp" \
-            && mv -f "$tmp" "$target"; then
+                "https://github.com/kodflow/ktn-linter/releases/latest/download/ktn-linter_linux_${GO_ARCH}.tar.gz" \
+                -o "$tmp_tgz" 2>/dev/null \
+            && tar -xzf "$tmp_tgz" -C "$(dirname "$tmp_bin")" ktn-linter 2>/dev/null \
+            && mv -f "$(dirname "$tmp_bin")/ktn-linter" "$tmp_bin" \
+            && chmod +x "$tmp_bin" \
+            && mv -f "$tmp_bin" "$target"; then
+            rm -f "$tmp_tgz"
             return 0
         fi
-        rm -f "$tmp"
+        rm -f "$tmp_tgz" "$tmp_bin"
+        if command -v go >/dev/null 2>&1 \
+            && go install "github.com/kodflow/ktn-linter/cmd/ktn-linter@latest" 2>/dev/null; then
+            return 0
+        fi
         return 1
     }
 


### PR DESCRIPTION
## Summary

- Switch ktn-linter download from non-existent `ktn-linter-linux-<arch>` (404) to the actual goreleaser asset `ktn-linter_linux_<arch>.tar.gz`.
- Wire `go install github.com/kodflow/ktn-linter/cmd/ktn-linter@latest` as fallback so a CDN blip or future asset-naming skew no longer aborts the whole Go feature.
- Apply the same fix on the runtime resync path (`sync-toolchains.sh`) — otherwise a built container re-breaks on the next `postStart`.
- Bump feature version `1.2.1 → 1.2.2` so GHCR republishes (`devcontainers/cli` skips identical versions).

Root cause: the published asset name is goreleaser-style (`ktn-linter_linux_<arch>.tar.gz`), not the hyphenated raw-binary URL the install script was building. With `set -Eeuo pipefail` and no fallback, the 404 took down every devcontainer build that enabled the Go feature. Issue #371 has the full repro log from a downstream ktn-linter rebuild.

## Test plan

- [ ] `bash -n` passes on `install.sh` and `sync-toolchains.sh`
- [ ] `shellcheck -x --severity=warning` passes on both scripts (verified: 0 findings)
- [ ] `curl -sSL ktn-linter_linux_arm64.tar.gz` → HTTP 200, tarball root contains `ktn-linter` (verified)
- [ ] `curl -sSL ktn-linter-linux-arm64` → HTTP 404 (legacy URL, confirms root cause)
- [ ] Devcontainer rebuild on a downstream project (e.g. ktn-linter repo itself) succeeds end-to-end
- [ ] `ktn-linter --version` resolves inside the built container
- [ ] Runtime resync (`sync-toolchains.sh`) updates the binary atomically on version drift

Closes #371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What
Fixed ktn-linter installation in the Go devcontainer feature by correcting the release asset URL from a non-existent hyphenated binary to the actual goreleaser-produced tarball, and added a `go install` fallback to ensure robustness against CDN failures or asset-naming skew. Feature version bumped from 1.2.1 → 1.2.2.

## Why
Issue `#371`: The previous download URL (`ktn-linter-linux-${GO_ARCH}`) was never published as a release asset; only the goreleaser-produced tarball (`ktn-linter_linux_${GO_ARCH}.tar.gz` with underscores and `.tar.gz` extension) exists. This caused consistent 404 failures. With strict error handling enabled (`set -Eeuo pipefail`), the build failed without a fallback mechanism. The go install fallback ensures transient CDN blips or future asset-naming changes do not abort container builds.

## How
**install.sh** (lines 315–323):
- Updated ktn-linter spawn call to download the correct goreleaser tarball URL: `https://github.com/kodflow/ktn-linter/releases/latest/download/ktn-linter_linux_${GO_ARCH}.tar.gz`
- Reused the existing `install_go_tool()` helper function which already handles tar.gz extraction with multiple fallback strategies (direct extraction, strip-components, temp-extraction)
- Configured go install fallback: `github.com/kodflow/ktn-linter/cmd/ktn-linter@latest`
- Added detailed inline comments explaining the legacy failure mode and fallback strategy

**sync-toolchains.sh** (lines 204–258):
- Created new atomic `install_ktn_linter()` function that:
  - Downloads tarball to temporary file with `.download.tgz` suffix to prevent half-fetched payloads
  - Extracts to temporary directory, moves to final `${GOPATH}/bin/ktn-linter` location with `chmod +x`
  - Cleans up temporary files on both success and failure paths
  - Falls back to `go install github.com/kodflow/ktn-linter/cmd/ktn-linter@latest` if tarball fails
  - Returns non-zero only if both paths fail, triggering sync_lang's marker-write suppression
- Integrated into main sync loop with version-aware refresh logic: probes upstream version on every postStart and reinstalls on drift (mirrors the GO_TOOL_REPOS pattern for other tools)

**devcontainer-feature.json**:
- Bumped `"version"` from `"1.2.1"` to `"1.2.2"` to force GHCR republish (devcontainers/cli skips identical versions and would not pick up the corrected install.sh)

## Risk
**Supply chain update**: Now explicitly depends on goreleaser asset naming convention (underscores + `.tar.gz`). The go install fallback mitigates single-point-of-failure risk but introduces a secondary build path (compilation vs. prebuilt binary).

**Complexity**: The atomic extraction pattern with temporary files and move operations is more involved than the previous single-curl approach, but provides better error recovery and protection against interrupted downloads.

**Runtime behavior change**: sync-toolchains.sh now probes upstream ktn-linter version on every postStart and reinstalls on drift (previously only installed if missing). This ensures stale cached binaries are refreshed but adds network I/O to every container start—mitigated by rate-limit fallback that keeps existing binaries in case of upstream probe failure.

**No breaking changes** for end users; this fix only corrects a previously non-functional installation path. Existing containers and builds using 1.2.1 will upgrade to 1.2.2 automatically on rebuild.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kodflow/devcontainer-template/pull/372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->