### PR TITLE
fix(tests): sync-toolchains bats regression after #372 ktn-linter URL fix

### DIFF
--- a/tests/scripts/sync-toolchains.bats
+++ b/tests/scripts/sync-toolchains.bats
@@ -85,8 +85,16 @@ teardown() {
     ! grep -qE 'go install "\$\{?tool\}?@latest"' "$SYNC_SH"
 }
 
-@test "sync_go keeps ktn-linter on the binary-download path (not a Go module)" {
-    grep -qF 'github.com/kodflow/ktn-linter/releases/latest/download/ktn-linter-linux-' "$SYNC_SH"
+@test "sync_go installs ktn-linter from the goreleaser release tarball (with go install fallback)" {
+    # The hyphenated raw-binary URL never existed as a published asset and
+    # 404'd every container build (#371). Asset is goreleaser-style:
+    # `ktn-linter_linux_<arch>.tar.gz` with the binary at the tarball root.
+    # A `go install …/cmd/ktn-linter` fallback covers CDN blips / asset
+    # rename drift so a single 404 cannot abort the entire Go feature.
+    grep -qF 'github.com/kodflow/ktn-linter/releases/latest/download/ktn-linter_linux_' "$SYNC_SH"
+    grep -qF '.tar.gz' "$SYNC_SH"
+    grep -qF 'github.com/kodflow/ktn-linter/cmd/ktn-linter@latest' "$SYNC_SH"
+    ! grep -qF 'ktn-linter-linux-' "$SYNC_SH"
 }
 
 @test "sync_go auto-refreshes ktn-linter against upstream (no skip-if-installed)" {
@@ -111,11 +119,15 @@ teardown() {
         | grep -qE 'if \[ -z "\$installed" \]'
 }
 
-@test "sync_go writes ktn-linter binary atomically (sibling .download + mv)" {
-    # Without a temp+rename, a curl killed mid-stream leaves a half-written
-    # executable that subsequent runs treat as "installed" — permanent drift.
-    grep -qE 'tmp="\$\{?target\}?\.download"' "$SYNC_SH"
-    grep -qE 'mv -f "\$tmp" "\$target"' "$SYNC_SH"
+@test "sync_go writes ktn-linter binary atomically (tarball + extract + sibling rename)" {
+    # Without a temp+extract+rename, a curl killed mid-stream leaves a
+    # half-written executable that subsequent runs treat as "installed" —
+    # permanent drift. New shape: download tarball to .download.tgz, extract
+    # to .download, chmod +x, then `mv -f` onto the final target.
+    grep -qE 'tmp_tgz="\$\{?target\}?\.download\.tgz"' "$SYNC_SH"
+    grep -qE 'tmp_bin="\$\{?target\}?\.download"' "$SYNC_SH"
+    grep -qF 'tar -xzf "$tmp_tgz"' "$SYNC_SH"
+    grep -qE 'mv -f "\$tmp_bin" "\$target"' "$SYNC_SH"
 }
 
 @test "sync_go preserves the existing tarball/binary-cache layout" {


### PR DESCRIPTION
## Summary

- Update two stale regression-guard tests in `tests/scripts/sync-toolchains.bats` that asserted the pre-#372 broken URL pattern (`ktn-linter-linux-<arch>`) and the single-file atomic-install shape (`tmp="$target.download"`).
- New assertions cover the post-#372 reality: goreleaser tarball URL (`ktn-linter_linux_<arch>.tar.gz`), `cmd/ktn-linter@latest` fallback, tarball-aware atomic flow (`.download.tgz` → extract → `.download` → mv).
- Add a regression guard so the legacy hyphenated URL cannot accidentally be reintroduced.

Main was red on `test` after #372 merged because the tests were guarding the broken implementation. Production code is unchanged — only test assertions move forward to match what landed in #372.

## Test plan

- [ ] `bats tests/scripts/sync-toolchains.bats` → the 2 previously-failing tests pass
- [ ] Manual `grep` verification confirms all new patterns match the current `sync-toolchains.sh` (verified locally)
- [ ] Legacy URL `ktn-linter-linux-` is absent from `sync-toolchains.sh` (regression guard)
- [ ] No production-code changes outside `tests/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What
Updates test assertions in `tests/scripts/sync-toolchains.bats` to validate the post-#372 `sync_go` behavior for `ktn-linter`, which now downloads a goreleaser-style tarball (`ktn-linter_linux_<arch>.tar.gz`) with a `cmd/ktn-linter@latest` go-install fallback, and implements a two-step atomic install flow (extract tarball to temporary location, then move to target).

## Why
PR `#372` updated the `sync-toolchains.sh` implementation to use goreleaser tarballs and go-install fallback for `ktn-linter` instead of raw hyphenated binary URLs. These regression-guard tests were failing because they asserted the pre-#372 behavior and needed updating to match the new implementation. This ensures the tests continue to validate the intended behavior and prevent regression to the legacy URL pattern.

## How
- Renamed and updated the "binary-download" test to assert the goreleaser tarball URL pattern (underscores, `.tar.gz` suffix) and `go install` fallback, with a regression guard verifying the legacy hyphenated URL pattern (`ktn-linter-linux-`) is absent
- Rewrote the atomic-install test to assert the two-step flow: `.download.tgz` → extract → `.download` → `mv -f` onto the target, replacing the previous single `.download` temp pattern
- Changes are test-only; no production code modifications

## Risk
**Minimal risk**: This is a test-only change with no production code modifications or public API changes. Tests are updated to match the already-merged implementation (`#372`), not introducing new behavior. No breaking changes, dependencies, security implications, or rollback concerns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kodflow/devcontainer-template/pull/373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->