### PR TITLE
feat(refine): v1.6 square-prompt pipeline + drop /do exposure

### DIFF
--- a/.devcontainer/images/.claude/CLAUDE.md
+++ b/.devcontainer/images/.claude/CLAUDE.md
@@ -118,7 +118,8 @@ Enforced by two layers (defence-in-depth):
 |-------|---------|
 | `/init` | Personalize + validate |
 | `/plan` | Planning mode |
-| `/do` | Iterative task execution |
+| `/do` | Iterative task execution (deprecated → `/goal <slug>`) |
+| `/goal` | Harness builtin — iterate from goal-state file written by `/refine` |
 | `/review` | Code review (3 tiers: agents + Qodo + CodeRabbit) |
 | `/git` | Branch + commit + PR |
 | `/search` | Documentation research |

--- a/.devcontainer/images/.claude/CLAUDE.md
+++ b/.devcontainer/images/.claude/CLAUDE.md
@@ -118,7 +118,6 @@ Enforced by two layers (defence-in-depth):
 |-------|---------|
 | `/init` | Personalize + validate |
 | `/plan` | Planning mode |
-| `/do` | Iterative task execution (deprecated → `/goal <slug>`) |
 | `/goal` | Harness builtin — iterate from goal-state file written by `/refine` |
 | `/review` | Code review (3 tiers: agents + Qodo + CodeRabbit) |
 | `/git` | Branch + commit + PR |

--- a/.devcontainer/images/.claude/CLAUDE.md
+++ b/.devcontainer/images/.claude/CLAUDE.md
@@ -118,7 +118,7 @@ Enforced by two layers (defence-in-depth):
 |-------|---------|
 | `/init` | Personalize + validate |
 | `/plan` | Planning mode |
-| `/goal` | Harness builtin — iterate from goal-state file written by `/refine` |
+| `/goal` | **Harness builtin** (not a repository command file) — iterates from the goal-state file written by `/refine` |
 | `/review` | Code review (3 tiers: agents + Qodo + CodeRabbit) |
 | `/git` | Branch + commit + PR |
 | `/search` | Documentation research |

--- a/.devcontainer/images/.claude/CLAUDE.md
+++ b/.devcontainer/images/.claude/CLAUDE.md
@@ -118,7 +118,7 @@ Enforced by two layers (defence-in-depth):
 |-------|---------|
 | `/init` | Personalize + validate |
 | `/plan` | Planning mode |
-| `/goal` | **Harness builtin** (not a repository command file) — iterates from the goal-state file written by `/refine` |
+| `/goal` | **Harness builtin** (not a repository command file) — iterates from the goal contract (`.claude/goals/<slug>.md`) written by `/refine` against runtime state (`.claude/state/goals/<slug>.json`) managed by `goal-state.sh` |
 | `/review` | Code review (3 tiers: agents + Qodo + CodeRabbit) |
 | `/git` | Branch + commit + PR |
 | `/search` | Documentation research |

--- a/.devcontainer/images/.claude/agents/registry.json
+++ b/.devcontainer/images/.claude/agents/registry.json
@@ -120,7 +120,7 @@
     },
     "refine": {
       "entry": "/refine",
-      "chain": "developer-specialist-review (sonnet) → {10 lenses via routing-table.jsonl} (PR3)"
+      "chain": "developer-specialist-review (sonnet) → 10 lens phases (FULL mode only) → 10 refine-* post-lens pipeline phases → square-prompt validation (pre + post compaction) → compact-to-minimum (≤4000 char ceiling) (v1.6)"
     }
   },
   "model_distribution": {

--- a/.devcontainer/images/.claude/agents/routing-table.jsonl
+++ b/.devcontainer/images/.claude/agents/routing-table.jsonl
@@ -24,3 +24,13 @@
 {"id": "refine-lens-8", "priority": 100, "skill": "/refine", "phase": "lens-8-observability", "guard": "true", "agent": "developer-executor-shell", "effort": "medium", "fanout": false}
 {"id": "refine-lens-9", "priority": 100, "skill": "/refine", "phase": "lens-9-scope", "guard": "true", "agent": "developer-orchestrator", "effort": "medium", "fanout": false, "critical": true}
 {"id": "refine-lens-10", "priority": 100, "skill": "/refine", "phase": "lens-10-goal-detect", "guard": "true", "agent": "developer-specialist-review", "effort": "high", "fanout": false, "critical": true}
+{"id": "refine-pipeline-1",  "priority": 100, "skill": "/refine", "phase": "refine-content-pruner",             "guard": "true", "agent": "developer-executor-quality",     "effort": "medium", "fanout": false}
+{"id": "refine-pipeline-2",  "priority": 100, "skill": "/refine", "phase": "refine-scope-fencer",               "guard": "true", "agent": "developer-orchestrator",         "effort": "medium", "fanout": false}
+{"id": "refine-pipeline-3",  "priority": 100, "skill": "/refine", "phase": "refine-constraint-distiller",       "guard": "true", "agent": "developer-executor-correctness", "effort": "medium", "fanout": false}
+{"id": "refine-pipeline-4",  "priority": 100, "skill": "/refine", "phase": "refine-done-criteria-sharpener",    "guard": "true", "agent": "developer-executor-correctness", "effort": "high",   "fanout": false}
+{"id": "refine-pipeline-5",  "priority": 100, "skill": "/refine", "phase": "refine-verifier-binder",            "guard": "true", "agent": "developer-executor-quality",     "effort": "high",   "fanout": false}
+{"id": "refine-pipeline-6",  "priority": 100, "skill": "/refine", "phase": "refine-escalation-isolator",        "guard": "true", "agent": "developer-orchestrator",         "effort": "medium", "fanout": false}
+{"id": "refine-pipeline-7",  "priority": 100, "skill": "/refine", "phase": "refine-sequence-causal-validator",  "guard": "true", "agent": "developer-executor-correctness", "effort": "medium", "fanout": false}
+{"id": "refine-pipeline-8",  "priority": 100, "skill": "/refine", "phase": "refine-imperative-rewriter",        "guard": "true", "agent": "developer-executor-quality",     "effort": "low",    "fanout": false}
+{"id": "refine-pipeline-9",  "priority": 100, "skill": "/refine", "phase": "refine-chain-stripper",             "guard": "true", "agent": "developer-executor-quality",     "effort": "low",    "fanout": false}
+{"id": "refine-pipeline-10", "priority": 100, "skill": "/refine", "phase": "refine-density-optimizer",          "guard": "true", "agent": "developer-executor-quality",     "effort": "medium", "fanout": false}

--- a/.devcontainer/images/.claude/commands/do.md
+++ b/.devcontainer/images/.claude/commands/do.md
@@ -27,6 +27,25 @@ allowed-tools:
 
 $ARGUMENTS
 
+## DEPRECATED
+
+`/do` is **deprecated** for goal iteration. Use `/goal <slug>` instead:
+it loads `.claude/state/goals/<slug>.json` directly through the
+harness builtin and runs the same iterative loop without an explicit
+skill hop. The manual entry point `/do <task>` and the plan-execution
+form `/do` (no args) still work, but new workflows should target
+`/goal <slug>` after a `/refine` run.
+
+This skill remains functional during the deprecation window:
+
+- `/do --goal-turn <slug>` continues to iterate goal state (used by
+  the `/goal` builtin internally on some host versions — back-compat).
+- `/do <task>` continues to run the interactive workflow.
+- `/do --plan <path>` continues to execute approved plans.
+
+Deletion is deferred to a follow-up PR after an audit confirms no
+hook or skill chain depends on `/do` as a published entry point.
+
 ## CONTEXT7 (RECOMMENDED)
 
 Use `mcp__context7__resolve-library-id` + `mcp__context7__query-docs` to:

--- a/.devcontainer/images/.claude/commands/do.md
+++ b/.devcontainer/images/.claude/commands/do.md
@@ -27,25 +27,6 @@ allowed-tools:
 
 $ARGUMENTS
 
-## DEPRECATED
-
-`/do` is **deprecated** for goal iteration. Use `/goal <slug>` instead:
-it loads `.claude/state/goals/<slug>.json` directly through the
-harness builtin and runs the same iterative loop without an explicit
-skill hop. The manual entry point `/do <task>` and the plan-execution
-form `/do` (no args) still work, but new workflows should target
-`/goal <slug>` after a `/refine` run.
-
-This skill remains functional during the deprecation window:
-
-- `/do --goal-turn <slug>` continues to iterate goal state (used by
-  the `/goal` builtin internally on some host versions — back-compat).
-- `/do <task>` continues to run the interactive workflow.
-- `/do --plan <path>` continues to execute approved plans.
-
-Deletion is deferred to a follow-up PR after an audit confirms no
-hook or skill chain depends on `/do` as a published entry point.
-
 ## CONTEXT7 (RECOMMENDED)
 
 Use `mcp__context7__resolve-library-id` + `mcp__context7__query-docs` to:

--- a/.devcontainer/images/.claude/commands/refine.md
+++ b/.devcontainer/images/.claude/commands/refine.md
@@ -1,7 +1,7 @@
 ---
 name: refine
 description: |
-  Skills Architecture v1.5 — proof-bearing goal contract generator with
+  Skills Architecture v1.6 — proof-bearing goal contract generator with
   three entry modes (auto-detected from arguments). FULL mode reads
   .claude/contexts/<slug>.md + .claude/plans/<slug>.md and runs 4-10
   review lenses. BARE mode skips lens dispatch and structures a
@@ -30,7 +30,7 @@ $ARGUMENTS
 
 @.devcontainer/images/.claude/commands/shared/team-mode.md
 
-# /refine — Goal Contract Generator (v1.5 — Skills Architecture)
+# /refine — Goal Contract Generator (v1.6 — Skills Architecture)
 
 ## Directive char-cap — ceiling, not target
 
@@ -48,7 +48,7 @@ There is no separate LIGHT ceiling. LIGHT vs FULL only affects **how
 many lenses run** (4 critical vs all 10), not the directive ceiling —
 the 4000-char cap stays uniform across both lens depths.
 
-## Mode auto-detection (v1.5)
+## Mode auto-detection (v1.6)
 
 `/refine <arg>` detects the mode from the argument shape + disk state:
 
@@ -149,8 +149,11 @@ Read `~/.claude/commands/refine/synthesis.md`.
 Every mode goes through `square-prompt-validate` TWICE — once before
 compaction (diagnostic) and once after (final guarantee). The directive
 is ALWAYS the same 7-section square-prompt shape. Vague verbs like
-"fix", "improve", or "make it work" are rejected and replaced with a
-visible sentinel so the user notices the gap before running `/goal`.
+"fix", "improve", or "make it work" are rejected **inside the
+`# ACCEPTANCE` section only** (CONTEXT / OBJECTIVE / SCOPE / etc. may
+freely use them in prose) and replaced with a visible
+`- [ ] <user-must-fill-acceptance>` sentinel so the user notices the
+gap before running `/goal`.
 
 Output is bounded by the **4000-char ceiling**; the natural target is
 the minimum viable length given the content. There is no padding.
@@ -194,7 +197,7 @@ on disk has been reviewed.
 | `--auto` | Default for FULL: pick lens depth from plan frontmatter |
 | `--help` | Display help |
 
-## Workflow patterns (v1.5)
+## Workflow patterns (v1.6)
 
 ```
 quick    : /refine "fix race in worker.go pool init"        →  Suggested next: /goal fix-race-in-worker-go

--- a/.devcontainer/images/.claude/commands/refine.md
+++ b/.devcontainer/images/.claude/commands/refine.md
@@ -6,7 +6,12 @@ description: |
   .claude/contexts/<slug>.md + .claude/plans/<slug>.md and runs 4-10
   review lenses. BARE mode skips lens dispatch and structures a
   free-form description. FROM-CONTRACT mode re-compacts an existing
-  goal contract. The /goal directive has a 4000-char ceiling (hard
+  goal contract. ALWAYS emits a predictable square-prompt directive
+  with the same 7-section shape (CONTEXT, OBJECTIVE, SCOPE,
+  CONSTRAINTS, ACCEPTANCE, VERIFY, STOP) so a vague input like
+  "fix ca" never reaches the goal state — synthesis rejects vague
+  verbs and forces binary measurable acceptance criteria paired 1:1
+  with verifiers. The /goal directive has a 4000-char ceiling (hard
   tool limit); /refine aims for the minimum viable length that
   preserves the contract, never pads to fill the budget.
 allowed-tools:
@@ -137,9 +142,14 @@ Read `~/.claude/commands/refine/dispatch.md`. For each lens, call
 
 Read `~/.claude/commands/refine/synthesis.md`.
 
-- **FULL**: collect lens findings → dedup → rank → render → compact-to-minimum.
-- **BARE**: apply WHAT/WHY/WHERE/HOW/DONE template → render → compact-to-minimum.
-- **FROM-CONTRACT**: read contract → extract → render → compact-to-minimum.
+- **FULL**: collect lens findings → dedup → rank → render → refine-pipeline → square-prompt-validate → compact-to-minimum.
+- **BARE**: apply WHAT/WHY/WHERE/HOW/DONE template → render → refine-pipeline → square-prompt-validate → compact-to-minimum.
+- **FROM-CONTRACT**: read contract → extract → render → refine-pipeline → square-prompt-validate → compact-to-minimum.
+
+Every mode goes through `square-prompt-validate` — the directive is
+ALWAYS the same 7-section square-prompt shape. Vague verbs like
+"fix", "improve", or "make it work" are rejected and replaced with a
+visible sentinel so the user notices the gap before running `/goal`.
 
 Output is bounded by the **4000-char ceiling**; the natural target is
 the minimum viable length given the content. There is no padding.

--- a/.devcontainer/images/.claude/commands/refine.md
+++ b/.devcontainer/images/.claude/commands/refine.md
@@ -142,12 +142,13 @@ Read `~/.claude/commands/refine/dispatch.md`. For each lens, call
 
 Read `~/.claude/commands/refine/synthesis.md`.
 
-- **FULL**: collect lens findings → dedup → rank → render → refine-pipeline → square-prompt-validate → compact-to-minimum.
-- **BARE**: apply WHAT/WHY/WHERE/HOW/DONE template → render → refine-pipeline → square-prompt-validate → compact-to-minimum.
-- **FROM-CONTRACT**: read contract → extract → render → refine-pipeline → square-prompt-validate → compact-to-minimum.
+- **FULL**: collect lens findings → dedup → rank → render → refine-pipeline → square-prompt-validate → compact-to-minimum → square-prompt-validate.
+- **BARE**: apply WHAT/WHY/WHERE/HOW/DONE template → render → refine-pipeline → square-prompt-validate → compact-to-minimum → square-prompt-validate.
+- **FROM-CONTRACT**: read contract → extract → render → refine-pipeline → square-prompt-validate → compact-to-minimum → square-prompt-validate.
 
-Every mode goes through `square-prompt-validate` — the directive is
-ALWAYS the same 7-section square-prompt shape. Vague verbs like
+Every mode goes through `square-prompt-validate` TWICE — once before
+compaction (diagnostic) and once after (final guarantee). The directive
+is ALWAYS the same 7-section square-prompt shape. Vague verbs like
 "fix", "improve", or "make it work" are rejected and replaced with a
 visible sentinel so the user notices the gap before running `/goal`.
 

--- a/.devcontainer/images/.claude/commands/refine.md
+++ b/.devcontainer/images/.claude/commands/refine.md
@@ -6,9 +6,9 @@ description: |
   .claude/contexts/<slug>.md + .claude/plans/<slug>.md and runs 4-10
   review lenses. BARE mode skips lens dispatch and structures a
   free-form description. FROM-CONTRACT mode re-compacts an existing
-  goal contract. Every mode always TARGETS 4000 chars on the /goal
-  directive (hard tool limit); natural output may be shorter when the
-  content genuinely warrants less.
+  goal contract. The /goal directive has a 4000-char ceiling (hard
+  tool limit); /refine aims for the minimum viable length that
+  preserves the contract, never pads to fill the budget.
 allowed-tools:
   - "Read(**/*)"
   - "Glob(**/*)"
@@ -17,7 +17,6 @@ allowed-tools:
   - "Agent(*)"
   - "TaskCreate(*)"
   - "TaskUpdate(*)"
-  - "Skill(skill=do)"
   - "Write(.claude/goals/*.md)"
   - "mcp__context7__*"
 ---
@@ -28,20 +27,21 @@ $ARGUMENTS
 
 # /refine — Goal Contract Generator (v1.5 — Skills Architecture)
 
-## Directive char-cap — single rule, always
+## Directive char-cap — ceiling, not target
 
 The `/goal` tool accepts a maximum **4000-character directive string**.
-This is a hard runtime limit of the tool, not an aesthetic choice.
+This is a hard runtime limit of the tool — a **ceiling**, not a goal.
 
-`/refine` always **targets 4000 chars** on the directive — regardless of
-mode (FULL / BARE / FROM-CONTRACT) and regardless of LIGHT/FULL lens
-selection. The output may be **shorter** when the synthesized content
-genuinely fits in fewer chars; `/refine` decides that based on what it
-has to say, never on the input shape.
+`/refine` treats 4000 as the **ceiling** in every mode (FULL / BARE /
+FROM-CONTRACT) and regardless of LIGHT/FULL lens selection. The design
+**target is the minimum viable length** that still preserves the
+contract: enough chars to bind acceptance criteria, evidence, and
+scope; not a single char more. `/refine` decides the length from what
+it has to say, never from the input shape, and never pads to hit 4000.
 
-There is no separate LIGHT char-cap. LIGHT vs FULL only affects **how
-many lenses run** (4 critical vs all 10), not the directive char-cap —
-the cap stays uniform across both lens depths.
+There is no separate LIGHT ceiling. LIGHT vs FULL only affects **how
+many lenses run** (4 critical vs all 10), not the directive ceiling —
+the 4000-char cap stays uniform across both lens depths.
 
 ## Mode auto-detection (v1.5)
 
@@ -137,12 +137,12 @@ Read `~/.claude/commands/refine/dispatch.md`. For each lens, call
 
 Read `~/.claude/commands/refine/synthesis.md`.
 
-- **FULL**: collect lens findings → dedup → rank → render → compact-to-4000.
-- **BARE**: apply WHAT/WHY/WHERE/HOW/DONE template → render → compact-to-4000.
-- **FROM-CONTRACT**: read contract → extract → render → compact-to-4000.
+- **FULL**: collect lens findings → dedup → rank → render → compact-to-minimum.
+- **BARE**: apply WHAT/WHY/WHERE/HOW/DONE template → render → compact-to-minimum.
+- **FROM-CONTRACT**: read contract → extract → render → compact-to-minimum.
 
-Output always **targets 4000 chars**; if the natural content is shorter,
-the directive is shorter — there is no padding.
+Output is bounded by the **4000-char ceiling**; the natural target is
+the minimum viable length given the content. There is no padding.
 
 ## Phase 4: Emit (all modes)
 
@@ -155,16 +155,18 @@ Read `~/.claude/commands/refine/render.md`. Writes:
 The runtime directive is always appended to the goal-state file via
 `goal-state.sh update` (PR1).
 
-## Skill chain
+## Next step (manual, no auto-chain)
 
-After emit:
+`/refine` ends by printing a textual suggestion of the form:
 
-```bash
-Skill(skill="do", args="--goal-turn <slug>")
+```
+Suggested next step:
+  /goal <slug>
 ```
 
-launches the iterative loop. The goal-state CRUD helper accepts the
-slug regardless of which mode produced it.
+There is **no auto-chain** into another skill — the user remains the
+trigger. Run `/goal <slug>` to enter goal iteration once the contract
+on disk has been reviewed.
 
 ## Arguments
 
@@ -184,12 +186,16 @@ slug regardless of which mode produced it.
 ## Workflow patterns (v1.5)
 
 ```
-quick    : /refine "fix race in worker.go pool init"        →  /goal (auto-BARE, ≤4000 char)
-medium   : /plan ... --auto → /refine my-feature            →  /goal (auto-FULL, ≤4000 char)
-full     : /search → /plan → /refine my-feature             →  /goal (auto-FULL, ≤4000 char)
+quick    : /refine "fix race in worker.go pool init"        →  Suggested next: /goal fix-race-in-worker-go
+medium   : /plan ... --auto → /refine my-feature            →  Suggested next: /goal my-feature
+full     : /search → /plan → /refine my-feature             →  Suggested next: /goal my-feature
 edited   : (edit .claude/goals/my-feature.md) → /refine my-feature
-                                                            →  /goal (auto-FROM-CONTRACT, ≤4000 char)
+                                                            →  Suggested next: /goal my-feature
 ```
+
+Every chain ends with a printed suggestion; `/goal <slug>` is typed
+by the user. No auto-chain, no magic. The 4000-char ceiling applies
+in every case; the actual directive length is the minimum viable.
 
 No explicit mode flag needed in normal usage — the skill detects from
 the argument shape + disk state. Flags exist only for edge cases where

--- a/.devcontainer/images/.claude/commands/refine/dispatch.md
+++ b/.devcontainer/images/.claude/commands/refine/dispatch.md
@@ -1,6 +1,6 @@
 # refine/dispatch.md — Skills Architecture v1.5 (PR3, fix #17)
 
-> **v1.5 note:** this phase is FULL-mode only. BARE and FROM-CONTRACT skip lens dispatch entirely — they jump straight to the synthesis pipeline (which itself adapts to the mode). The single-source-of-truth char-cap logic in `synthesis.md` is what BARE and FROM-CONTRACT reuse without reimplementing it. The char-cap is always 4000; lens depth (4 critical vs all 10) is independent.
+> **v1.6 note:** this phase is FULL-mode only. BARE and FROM-CONTRACT skip lens dispatch entirely — they jump straight to the synthesis pipeline (which itself adapts to the mode). The single-source-of-truth char-cap logic in `synthesis.md` is what BARE and FROM-CONTRACT reuse without reimplementing it. The char-cap is always 4000; lens depth (4 critical vs all 10) is independent.
 
 ## Lenses (10)
 
@@ -65,7 +65,7 @@ before its inputs exist.
 | 3 | `refine-constraint-distiller` | Lock constraints in canonical form before any voice rewrite touches their wording |
 | 4 | `refine-done-criteria-sharpener` | Sharpen acceptance criteria into binary, measurable assertions; output feeds the verifier binder |
 | 5 | `refine-verifier-binder` | Bind one verifier (grep / bats / make) to each criterion; output feeds the escalation isolator |
-| 6 | `refine-escalation-isolator` | Lift manual-only verifiers and ADR triggers into a dedicated escalation block; output feeds the chain stripper |
+| 6 | `refine-escalation-isolator` | Lift manual-only verifiers and ADR triggers into a dedicated escalation block; output feeds the sequence-causal-validator (step 7) which validates producer-before-consumer ordering before downstream steps 8–9 |
 | 7 | `refine-sequence-causal-validator` | Diagnostic pass: validate the step order is causal (producer before consumer); runs late so it sees the final step list |
 | 8 | `refine-imperative-rewriter` | Prose rewrite into imperative voice — runs only once semantics are stable |
 | 9 | `refine-chain-stripper` | Strip any auto-chain language pasted in by upstream synthesis (`Skill(skill=…)`, "next, run /do", etc.) |

--- a/.devcontainer/images/.claude/commands/refine/dispatch.md
+++ b/.devcontainer/images/.claude/commands/refine/dispatch.md
@@ -48,3 +48,42 @@ fi
 Critical lenses (1, 5, 9, 10) MUST reach the agent invocation step even
 when `route-agent.sh` returns exit 20-31. This is enforced by the static
 fallback above and verified by `TestRefineFallsBackToStaticWhenRouterErrors`.
+
+## Refine pipeline (post-lens, 10 agents)
+
+After lens findings are collected (FULL mode only — BARE and
+FROM-CONTRACT skip lenses entirely), the synthesis step runs a
+**second**, mono-concern pipeline: ten `refine-*` agents that each
+compress one dimension of the directive. The pipeline is **ordered
+and causal** — every agent's output feeds the next. No agent runs
+before its inputs exist.
+
+| # | Agent | Role |
+|---|---|---|
+| 1 | `refine-content-pruner` | Cheapest cut first: strip filler prose, redundant restatements, and meta-commentary before structural agents waste tokens on noise |
+| 2 | `refine-scope-fencer` | Verify the pruner did not amputate in-scope work; flag scope creep introduced by upstream lenses |
+| 3 | `refine-constraint-distiller` | Lock constraints in canonical form before any voice rewrite touches their wording |
+| 4 | `refine-done-criteria-sharpener` | Sharpen acceptance criteria into binary, measurable assertions; output feeds the verifier binder |
+| 5 | `refine-verifier-binder` | Bind one verifier (grep / bats / make) to each criterion; output feeds the escalation isolator |
+| 6 | `refine-escalation-isolator` | Lift manual-only verifiers and ADR triggers into a dedicated escalation block; output feeds the chain stripper |
+| 7 | `refine-sequence-causal-validator` | Diagnostic pass: validate the step order is causal (producer before consumer); runs late so it sees the final step list |
+| 8 | `refine-imperative-rewriter` | Prose rewrite into imperative voice — runs only once semantics are stable |
+| 9 | `refine-chain-stripper` | Strip any auto-chain language pasted in by upstream synthesis (`Skill(skill=…)`, "next, run /do", etc.) |
+| 10 | `refine-density-optimizer` | Final density pass: token-cost compression that preserves structure — **MUST run last**, any earlier compression destroys the structure later agents need |
+
+Pipeline invariants (locked by `refine-pipeline-rewire.bats`):
+
+- Order is fixed (1 → 10). Steps 7 and 8 are parallelizable in principle
+  but kept sequential for a linear synthesis log.
+- Each agent is single-concern; outputs are additive, never merged.
+- The density optimizer is **always** the terminal step; running it
+  earlier breaks the structural assumptions of agents 7-9.
+- BARE and FROM-CONTRACT skip steps 1-7 (no lens findings to compress);
+  steps 8-10 still run on the rendered directive.
+
+### Static fallback (refine-* pipeline)
+
+If `route-agent.sh` cannot resolve a `refine-*` agent, fall back to
+the static map in `refine-static-fallback.sh`. The 10 agent names
+above are enumerated in the same order so the fallback preserves
+pipeline causality.

--- a/.devcontainer/images/.claude/commands/refine/render.md
+++ b/.devcontainer/images/.claude/commands/refine/render.md
@@ -71,30 +71,91 @@ The BARE contract is intentionally lean — no proof triplets, no
 rollback. The user is told this explicitly via the "Out of scope"
 section so they don't expect lens-level guarantees.
 
-## Runtime directive templates
+## Runtime directive — the square-prompt template (single shape, all modes)
 
-The directive always targets **4000 chars**. Natural output may be
-shorter; never longer.
+`/refine` ALWAYS emits a single, predictable structured directive.
+There is no per-mode shape — FULL, BARE, and FROM-CONTRACT all
+produce the same template. What varies is only **how the slots are
+filled** (from lens findings, from a free-form description, or from
+a re-read of an existing contract).
 
-### FULL mode
+The directive is bounded by the **4000-char ceiling** of the /goal
+tool (see `synthesis.md` for the ceiling/floor doctrine). The
+template is dense by design — every section earns its bytes — and
+the natural target is the minimum viable length given the content.
+
+The shape is fixed so a harness reading the directive — and a human
+reviewing it — always knows where each datum lives, and so a vague
+condition like "fix it" never reaches the goal state because the
+template REQUIRES paired binary acceptance + verifier entries.
+
+### Canonical template
 
 ```
-/goal "Implement <plan title>: <top blockers compressed>. Acceptance:
-<≤3 bullet criteria>. Rollback: <one line>. Scope guard:
-<owned_paths>."
+/goal "<slug>
+
+# CONTEXT
+<1-3 sentences: the system state and why this work matters now>
+
+# OBJECTIVE
+<one sentence stating the END STATE — not a process>
+
+# SCOPE
+In:  <files, modules, or areas the work touches>
+Out: <explicit non-targets — sibling concerns, follow-up PRs>
+
+# CONSTRAINTS
+- <hard rule 1>
+- <hard rule 2>
+
+# ACCEPTANCE
+- [ ] <binary, measurable criterion 1>
+- [ ] <binary, measurable criterion 2>
+- [ ] <…each criterion is a checkbox the harness can mark TRUE/FALSE>
+
+# VERIFY
+- <criterion 1> -> <bash command, grep, test name, or tool invocation>
+- <criterion 2> -> <verifier — one per ACCEPTANCE line, 1:1 mapping>
+
+# STOP
+Halt only when every ACCEPTANCE box returns TRUE under its paired
+VERIFY entry. Do not stop on partial progress, on 'looks fine', or
+on a non-VERIFY heuristic. Vague conditions ('fix it', 'improve',
+'make it work') are forbidden in ACCEPTANCE and rejected at synthesis."
 ```
 
-### BARE mode
+### Slot population per mode
 
-```
-/goal "<WHAT>. <WHY in one clause>. Touches: <WHERE>.
-Constraints: <HOW one-liner>. Done when: <DONE one-liner>."
-```
+| Slot | FULL | BARE | FROM-CONTRACT |
+|---|---|---|---|
+| CONTEXT | top-of-plan summary | inferred from description | contract's `## Why` |
+| OBJECTIVE | plan title rewritten as end-state | first sentence of description | contract's first non-trivial bullet |
+| SCOPE In | plan's owned_paths + touched modules | WHERE slot | contract's `## Where` |
+| SCOPE Out | plan's "Out of scope" section | "(nothing explicit)" | contract's `## Out of scope` |
+| CONSTRAINTS | HOW from lens findings + plan constraints | HOW slot | contract's `## How` |
+| ACCEPTANCE | dedup'd findings → binary form | DONE slot decomposed | contract's `## Acceptance criteria` |
+| VERIFY | bound by `refine-verifier-binder` (one per criterion) | derived from acceptance | re-bound from contract |
+| STOP | always the verbatim STOP block (no per-mode variation) | same | same |
 
-### FROM-CONTRACT mode
+The STOP block is **literal** — never rephrased per mode. That is
+what makes the directive predictable: any consumer reading the
+directive sees the same termination contract every time.
 
-Re-derives the FULL directive shape from the existing contract on disk.
-No new shape; same compact output.
+### Forbidden ACCEPTANCE phrasings (rejected at synthesis)
+
+| Vague | Rewrite into |
+|---|---|
+| `fix the bug` | `grep -c 'race in worker.go:42' src/worker.go == 0` |
+| `make tests pass` | `make test → exit 0 with 0 failures` |
+| `improve performance` | `bench cmp baseline.txt new.txt → no regression > 5%` |
+| `looks correct` | binary command-bound assertion or it is dropped |
+| `should work` | binary command-bound assertion or it is dropped |
+
+If a slot is genuinely unknown (e.g. BARE mode with a one-line
+description and no DONE clause), synthesis emits a single
+`# ACCEPTANCE` bullet `- [ ] <user-must-fill-acceptance>` and a
+matching `# VERIFY` line `- <user-must-fill-acceptance> -> manual`
+— making the gap visible rather than hiding it behind soft prose.
 
 ## Post-render side effects
 
@@ -109,7 +170,9 @@ bash ~/.claude/scripts/goal-state.sh update "<slug>" \
   --decision met --decision-reason "refined" \
   --append-objective "directive-emitted"
 
-# 3. Emit directive + manual-trigger suggestion (no auto-chain)
+# 3. Emit directive + manual-trigger suggestion (no auto-chain).
+#    The directive is the square-prompt template defined above; the
+#    suggestion is the SAME shape every time, regardless of mode.
 printf '%s\n\nSuggested next step:\n  /goal %s\n' "$DIRECTIVE" "$SLUG"
 ```
 
@@ -129,7 +192,10 @@ printf '%s\n\nSuggested next step:\n  /goal %s\n' "$DIRECTIVE" "$SLUG"
 
 The trailing `Suggested next step:` line is the **only** post-emit
 hand-off. There is no `Skill(skill=…)` call, no auto-chain — the
-user remains the trigger for `/goal <slug>`.
+user remains the trigger for `/goal <slug>`. The directive itself
+is always the square-prompt template; the user reading it sees the
+same CONTEXT / OBJECTIVE / SCOPE / CONSTRAINTS / ACCEPTANCE / VERIFY
+/ STOP structure every time.
 
 ## Slug derivation (BARE mode)
 

--- a/.devcontainer/images/.claude/commands/refine/render.md
+++ b/.devcontainer/images/.claude/commands/refine/render.md
@@ -109,8 +109,8 @@ bash ~/.claude/scripts/goal-state.sh update "<slug>" \
   --decision met --decision-reason "refined" \
   --append-objective "directive-emitted"
 
-# 3. Echo directive to the agent's transcript so /do --goal-turn picks it up
-echo "$DIRECTIVE"
+# 3. Emit directive + manual-trigger suggestion (no auto-chain)
+printf '%s\n\nSuggested next step:\n  /goal %s\n' "$DIRECTIVE" "$SLUG"
 ```
 
 ### FROM-CONTRACT
@@ -123,9 +123,13 @@ bash ~/.claude/scripts/goal-state.sh update "<slug>" \
   --decision met --decision-reason "recompacted" \
   --append-objective "directive-re-emitted"
 
-# 3. Echo directive
-echo "$DIRECTIVE"
+# 3. Emit directive + manual-trigger suggestion (no auto-chain)
+printf '%s\n\nSuggested next step:\n  /goal %s\n' "$DIRECTIVE" "$SLUG"
 ```
+
+The trailing `Suggested next step:` line is the **only** post-emit
+hand-off. There is no `Skill(skill=…)` call, no auto-chain — the
+user remains the trigger for `/goal <slug>`.
 
 ## Slug derivation (BARE mode)
 

--- a/.devcontainer/images/.claude/commands/refine/synthesis.md
+++ b/.devcontainer/images/.claude/commands/refine/synthesis.md
@@ -1,17 +1,57 @@
-# refine/synthesis.md — Skills Architecture v1.5
+# refine/synthesis.md — Skills Architecture v1.6
 
 ## Pipeline per mode
 
 | Mode | Pipeline steps |
 |---|---|
-| FULL | `collect → dedup → rank → render → refine-pipeline → compact-to-minimum` |
-| BARE | `template → render → refine-pipeline → compact-to-minimum` |
-| FROM-CONTRACT | `read → extract → render → refine-pipeline → compact-to-minimum` |
+| FULL | `collect → dedup → rank → render → refine-pipeline → square-prompt-validate → compact-to-minimum` |
+| BARE | `template → render → refine-pipeline → square-prompt-validate → compact-to-minimum` |
+| FROM-CONTRACT | `read → extract → render → refine-pipeline → square-prompt-validate → compact-to-minimum` |
 
 The **refine-pipeline** step (post-lens, 10 mono-concern agents) is
-documented in `dispatch.md`. The **compact-to-minimum** step is
-mode-agnostic — single source of truth for the directive char-cap
-lives in this file.
+documented in `dispatch.md`. The **square-prompt-validate** step
+enforces the predictable output shape defined in `render.md`. The
+**compact-to-minimum** step is mode-agnostic — single source of
+truth for the directive char-cap lives in this file.
+
+## Square-prompt validation (mandatory, all modes)
+
+Every mode produces the **same** directive shape:
+CONTEXT, OBJECTIVE, SCOPE (In/Out), CONSTRAINTS, ACCEPTANCE, VERIFY,
+STOP. The validator runs after rendering and rejects any directive
+that fails any of these invariants:
+
+| Invariant | Rule |
+|---|---|
+| All 7 sections present | Each `# <SECTION>` header appears exactly once, in canonical order |
+| ACCEPTANCE non-empty | At least one `- [ ]` checkbox under `# ACCEPTANCE` |
+| VERIFY 1:1 with ACCEPTANCE | Each ACCEPTANCE checkbox maps to exactly one VERIFY entry |
+| No vague verbs in ACCEPTANCE | None of the rejected phrasings (see table below) |
+| STOP block is literal | Exactly the canonical STOP wording — no rephrasing |
+
+### Vague-verb rejection table (synthesis applies this before render)
+
+| Forbidden phrasing (in ACCEPTANCE) | Reject reason | Required rewrite |
+|---|---|---|
+| `fix <X>` | non-binary, no measure | `grep -c <symptom> <file> == 0` or equivalent |
+| `make <X> work` | non-binary, no measure | `<cmd> → exit 0` |
+| `improve <X>` | non-binary, comparative | `<bench> regression < N%` |
+| `make it better` | subjective | binary or dropped |
+| `looks correct` | subjective | binary or dropped |
+| `should work` | speculative | binary or dropped |
+| `handle <X> properly` | non-binary | `<probe-cmd> returns <value>` |
+
+If a candidate ACCEPTANCE bullet trips the table and synthesis cannot
+rewrite it from available evidence, the bullet is replaced with the
+sentinel `- [ ] <user-must-fill-acceptance>` and a matching VERIFY
+entry `<user-must-fill-acceptance> -> manual`. The gap is **visible**
+on disk rather than hidden behind soft prose, so the user notices
+and supplies a real binary check before running `/goal <slug>`.
+
+This is the mechanism that prevents directives like
+`/goal vasy execute le plan` or `/goal fix ca` from ever reaching
+the goal state: they would land as a single sentinel bullet and the
+user would see immediately that the prompt is unactionable.
 
 ### Char-cap — ceiling, not target (v1.5)
 

--- a/.devcontainer/images/.claude/commands/refine/synthesis.md
+++ b/.devcontainer/images/.claude/commands/refine/synthesis.md
@@ -4,15 +4,36 @@
 
 | Mode | Pipeline steps |
 |---|---|
-| FULL | `collect → dedup → rank → render → refine-pipeline → square-prompt-validate → compact-to-minimum` |
-| BARE | `template → render → refine-pipeline → square-prompt-validate → compact-to-minimum` |
-| FROM-CONTRACT | `read → extract → render → refine-pipeline → square-prompt-validate → compact-to-minimum` |
+| FULL | `collect → dedup → rank → render → refine-pipeline → square-prompt-validate → compact-to-minimum → square-prompt-validate` |
+| BARE | `template → render → refine-pipeline → square-prompt-validate → compact-to-minimum → square-prompt-validate` |
+| FROM-CONTRACT | `read → extract → render → refine-pipeline → square-prompt-validate → compact-to-minimum → square-prompt-validate` |
 
 The **refine-pipeline** step (post-lens, 10 mono-concern agents) is
 documented in `dispatch.md`. The **square-prompt-validate** step
-enforces the predictable output shape defined in `render.md`. The
-**compact-to-minimum** step is mode-agnostic — single source of
-truth for the directive char-cap lives in this file.
+runs **TWICE** — once before `compact-to-minimum` for early
+diagnostics, and again after compaction as the final guarantee:
+compaction MUST NOT invalidate the section list, the STOP literal
+block, or the ACCEPTANCE/VERIFY 1:1 mapping. The **compact-to-minimum**
+step is mode-agnostic — single source of truth for the directive
+char-cap lives in this file.
+
+### Why validate twice
+
+Compaction is allowed to drop low-severity findings, abbreviate
+sub-bullets, and strip filler words. Without a post-compaction
+validation pass, the compactor could:
+
+- delete a verifier line and break the ACCEPTANCE/VERIFY 1:1 mapping,
+- collapse the STOP block into a single sentence (losing the literal
+  contract harness consumers rely on),
+- merge two sections (e.g. SCOPE + CONSTRAINTS) when trimming
+  whitespace, breaking the canonical section order.
+
+The post-compaction validator catches any of these regressions and
+either re-emits the canonical block (deterministic recovery) or
+fails the synthesis with exit code 25 so the user sees the issue
+before `/goal <slug>` ever runs. Failing **before** the user types
+`/goal` is the entire point of running the validator at all.
 
 ## Square-prompt validation (mandatory, all modes)
 

--- a/.devcontainer/images/.claude/commands/refine/synthesis.md
+++ b/.devcontainer/images/.claude/commands/refine/synthesis.md
@@ -4,32 +4,43 @@
 
 | Mode | Pipeline steps |
 |---|---|
-| FULL | `collect → dedup → rank → render → compact-to-4000` |
-| BARE | `template → render → compact-to-4000` |
-| FROM-CONTRACT | `read → extract → render → compact-to-4000` |
+| FULL | `collect → dedup → rank → render → refine-pipeline → compact-to-minimum` |
+| BARE | `template → render → refine-pipeline → compact-to-minimum` |
+| FROM-CONTRACT | `read → extract → render → refine-pipeline → compact-to-minimum` |
 
-The **compact-to-4000** step is mode-agnostic — single source of truth
-for the directive char-cap lives in this file.
+The **refine-pipeline** step (post-lens, 10 mono-concern agents) is
+documented in `dispatch.md`. The **compact-to-minimum** step is
+mode-agnostic — single source of truth for the directive char-cap
+lives in this file.
 
-### Char-cap — single rule for all modes (v1.5)
+### Char-cap — ceiling, not target (v1.5)
 
 ```
-target = 4000 chars  (hard tool limit on /goal directive)
+ceiling   = 4000 chars  (hard tool limit on /goal directive)
+target    = minimum viable length given the content
+floor_warn = 800 chars  (suspect over-compression below this)
 ```
 
-`/refine` targets 4000 chars **always**. There is no LIGHT-vs-FULL
-budget split. The natural output may be shorter when there's simply
-less to say; the skill decides that based on content, never on input
-shape or plan complexity.
+`/refine` enforces a **4000-char ceiling** in every mode. The number
+4000 is the tool's hard limit — not an aesthetic goal. The design
+target is the **minimum viable length** that still preserves the
+contract (acceptance criteria, scope, evidence, rollback).
 
-| Mode | Natural shorter output? |
-|---|---|
-| FULL with all 10 lenses + heavy findings | usually near 4000 |
-| FULL with only 4 critical lenses | often 2000-3500 |
-| BARE with terse description | often 800-1500 |
-| FROM-CONTRACT after manual trimming | whatever the contract holds |
+There is no LIGHT-vs-FULL ceiling split. The natural output is
+whatever the content requires; the skill decides that based on
+content, never on input shape or plan complexity. Below the 800-char
+**floor warning**, the synthesis log emits a `suspect-over-compression`
+note so a human reviewer can confirm the contract is still intact.
 
-The skill never pads to hit 4000; it just stops short when content runs out.
+| Mode | Typical directive length | Notes |
+|---|---|---|
+| FULL with all 10 lenses + heavy findings | usually near ceiling (3500-4000) | Risk of bumping ceiling — refine-density-optimizer trims |
+| FULL with only 4 critical lenses | often 1500-2500 | Minimum viable is naturally smaller |
+| BARE with terse description | often 600-1200 | Floor warning may fire — usually fine |
+| FROM-CONTRACT after manual trimming | whatever the contract holds | Re-derived directly from disk |
+
+The skill never pads to hit the ceiling; it stops short when content
+runs out. The ceiling is the **upper bound**, never the aim.
 
 ### FULL pipeline
 
@@ -110,26 +121,41 @@ untouched on disk; we only re-derive the runtime directive.
 | BARE | `.claude/goals/<slug>.md` (5-slot template) + runtime directive |
 | FROM-CONTRACT | runtime directive only — input file is never overwritten |
 
-#### 5. Compact-to-4000
+#### 5. Refine-pipeline (post-render, post-lens)
 
-Single function, all modes:
+The 10 mono-concern `refine-*` agents documented in `dispatch.md` run
+in canonical order against the rendered directive. Each agent
+compresses one dimension; outputs are additive, never merged. BARE
+and FROM-CONTRACT skip agents 1-7 (no lens findings to compress) but
+still run agents 8-10 (`refine-imperative-rewriter`,
+`refine-chain-stripper`, `refine-density-optimizer`) on the rendered
+directive.
+
+#### 6. Compact-to-minimum
+
+Single function, all modes. The ceiling is the only hard guarantee —
+the natural target is the minimum viable length given the content.
 
 ```
-compact_to_target(text, target=4000):
-  if len(text) <= target:
-    return text  # no compaction needed
-  # Cut order (preserve highest-value content):
-  #   1. trim low-severity findings (FULL only)
-  #   2. trim non-critical lens findings (FULL only)
-  #   3. compress prose to checklist
-  #   4. strip filler words ("the", "very", "really", etc.)
-  #   5. abbreviate sub-bullets, keep file paths + identifiers verbatim
-  # Never trim:
-  #   - blockers (FULL)
-  #   - critical-lens findings (FULL)
-  #   - WHAT slot (BARE)
-  #   - acceptance criteria checklist (all modes)
-  return compacted_text  # guaranteed <= target
+compact_to_minimum(text, ceiling=4000, floor_warn=800):
+  # First, hard ceiling enforcement
+  if len(text) > ceiling:
+    # Cut order (preserve highest-value content):
+    #   1. trim low-severity findings (FULL only)
+    #   2. trim non-critical lens findings (FULL only)
+    #   3. compress prose to checklist
+    #   4. strip filler words ("the", "very", "really", etc.)
+    #   5. abbreviate sub-bullets, keep file paths + identifiers verbatim
+    # Never trim:
+    #   - blockers (FULL)
+    #   - critical-lens findings (FULL)
+    #   - WHAT slot (BARE)
+    #   - acceptance criteria checklist (all modes)
+    text = cut_until(text, ceiling)
+  # Then, floor advisory (does not modify text — diagnostic only)
+  if len(text) < floor_warn:
+    emit_warning("suspect-over-compression", chars=len(text), floor=floor_warn)
+  return text  # guaranteed <= ceiling
 ```
 
 ## Output schema (v1.5)
@@ -149,6 +175,11 @@ compact_to_target(text, target=4000):
   "contract_written": true|false
 }
 ```
+
+`directive_char_target` is preserved as a schema field for the test
+contract, but its semantic meaning is **char ceiling enforced by the
+/goal tool** — not a length the synthesis aims for. The natural
+target is the minimum viable length given the content.
 
 `lenses_run`/`lenses_dropped`/`findings_*` are 0 / [] / 0 in BARE +
 FROM-CONTRACT. `contract_written` is false in FROM-CONTRACT.

--- a/.devcontainer/images/.claude/scripts/refine-static-fallback.sh
+++ b/.devcontainer/images/.claude/scripts/refine-static-fallback.sh
@@ -43,7 +43,48 @@ refine_static_lens() {
   esac
 }
 
-# When sourced, expose the function. When executed directly, dispatch.
+# Print a JSON dispatch entry for a post-lens refine-* pipeline phase.
+# Usage: refine_static_pipeline_phase <phase> [json|fields]
+#
+# WHY: dispatch.md introduces 10 mono-concern refine-* agents in v1.6.
+# When route-agent.sh exits 20-31 these phases must still resolve, just
+# like the lens phases — otherwise the pipeline silently degrades to
+# general-purpose and the contract advertised in dispatch.md is fiction.
+# The agent mappings here are the SAME values that the routing-table
+# entries use, so router-success and static-fallback are bit-identical.
+refine_static_pipeline_phase() {
+  local phase="$1"
+  local format="${2:-json}"
+  local agent="" effort=""
+  case "$phase" in
+    refine-content-pruner)             agent="developer-executor-quality";     effort="medium" ;;
+    refine-scope-fencer)               agent="developer-orchestrator";         effort="medium" ;;
+    refine-constraint-distiller)       agent="developer-executor-correctness"; effort="medium" ;;
+    refine-done-criteria-sharpener)    agent="developer-executor-correctness"; effort="high"   ;;
+    refine-verifier-binder)            agent="developer-executor-quality";     effort="high"   ;;
+    refine-escalation-isolator)        agent="developer-orchestrator";         effort="medium" ;;
+    refine-sequence-causal-validator)  agent="developer-executor-correctness"; effort="medium" ;;
+    refine-imperative-rewriter)        agent="developer-executor-quality";     effort="low"    ;;
+    refine-chain-stripper)             agent="developer-executor-quality";     effort="low"    ;;
+    refine-density-optimizer)          agent="developer-executor-quality";     effort="medium" ;;
+    *) return 1 ;;
+  esac
+  case "$format" in
+    json)
+      printf '{"subagent_type":"%s","resolved_model":"unknown","model_source":"static-fallback","effort":"%s","count":1,"matched_rule_id":"static:%s","fallback_used":true,"expanded_from_template":false}\n' \
+        "$agent" "$effort" "$phase"
+      ;;
+    fields)
+      echo "$agent $effort"
+      ;;
+  esac
+}
+
+# When sourced, expose the functions. When executed directly, dispatch.
+# Direct dispatch tries the lens map first, then the pipeline map, so a
+# caller can hand any /refine phase to this script without knowing which
+# bucket it belongs to.
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  refine_static_lens "$@"
+  refine_static_lens "$@" 2>/dev/null && exit 0
+  refine_static_pipeline_phase "$@"
 fi

--- a/.devcontainer/images/.claude/scripts/refine-static-fallback.sh
+++ b/.devcontainer/images/.claude/scripts/refine-static-fallback.sh
@@ -40,6 +40,10 @@ refine_static_lens() {
     fields)
       echo "$agent $effort $critical"
       ;;
+    *)
+      printf 'refine_static_lens: unsupported format %q (expected: json|fields)\n' "$format" >&2
+      return 2
+      ;;
   esac
 }
 
@@ -76,6 +80,10 @@ refine_static_pipeline_phase() {
       ;;
     fields)
       echo "$agent $effort"
+      ;;
+    *)
+      printf 'refine_static_pipeline_phase: unsupported format %q (expected: json|fields)\n' "$format" >&2
+      return 2
       ;;
   esac
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ Principle: More detail deeper in tree. Target < 200 lines each.
 |---------|---------|
 | `/init` | Conversational project discovery + doc generation |
 | `/plan` | Analyze codebase and design implementation approach |
-| `/do` | Execute approved plans iteratively |
+| `/do` | **[DEPRECATED]** Use `/goal <slug>` for goal iteration — `/do` retained for back-compat |
 | `/review` | Code review (3-tier: agents + Qodo + CodeRabbit) |
 | `/git` | Conventional commits, branch management |
 | `/search` | Documentation research with official sources |
@@ -178,16 +178,17 @@ Principle: More detail deeper in tree. Target < 200 lines each.
 | `/refine` | Skills Architecture v1.3 — goal contract generator (10-lens analysis) |
 | `/prompt` | **[DEPRECATED]** Use `/refine` instead — scheduled for deletion in PR6 |
 
-### Canonical workflow (Skills Architecture v1.3)
+### Canonical workflow (Skills Architecture v1.6)
 
 ```
-/search → /plan [--goal] → /refine → /goal → /do --goal-turn
+/search → /plan → /refine → /goal <slug>
 ```
 
 `/plan --goal` chains automatically into `/refine` once the plan is
-written; `/refine` emits `/goal` directive and a contract at
-`.claude/goals/<slug>.md`. `/do --goal-turn <slug>` then iterates against
-the persistent state in `.claude/state/goals/<slug>.json`.
+written. `/refine` writes a contract at `.claude/goals/<slug>.md` and
+prints a textual `Suggested next step: /goal <slug>` — there is no
+auto-chain. The user types `/goal <slug>` to enter goal iteration
+against the persistent state in `.claude/state/goals/<slug>.json`.
 
 ## Collaboration Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,6 @@ Principle: More detail deeper in tree. Target < 200 lines each.
 |---------|---------|
 | `/init` | Conversational project discovery + doc generation |
 | `/plan` | Analyze codebase and design implementation approach |
-| `/do` | **[DEPRECATED]** Use `/goal <slug>` for goal iteration — `/do` retained for back-compat |
 | `/review` | Code review (3-tier: agents + Qodo + CodeRabbit) |
 | `/git` | Conventional commits, branch management |
 | `/search` | Documentation research with official sources |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,8 @@ Principle: More detail deeper in tree. Target < 200 lines each.
 `/plan --goal` chains automatically into `/refine` once the plan is
 written. `/refine` writes a contract at `.claude/goals/<slug>.md` and
 prints a textual `Suggested next step: /goal <slug>` — there is no
-auto-chain. The user types `/goal <slug>` to enter goal iteration
+auto-chain. **`/goal` is a harness builtin** (not a repository
+command file): the user types `/goal <slug>` to enter goal iteration
 against the persistent state in `.claude/state/goals/<slug>.json`.
 
 ## Collaboration Rules

--- a/tests/scripts/refine-pipeline-rewire.bats
+++ b/tests/scripts/refine-pipeline-rewire.bats
@@ -6,7 +6,11 @@
 #   2. The 10 mono-concern refine-* agents are enumerated in dispatch.md
 #   3. 4000 = ceiling, not target; floor_warn = 800 doctrine present
 #   4. /refine emits a textual "Suggested next step: /goal <slug>"
-#   5. /do carries a deprecation banner that points to /goal <slug>
+#   5. /do is NOT advertised as deprecated — the skill stays functional
+#      but is not surfaced in the user-facing skill tables
+#   6. /refine emits a single predictable square-prompt directive with
+#      7 mandatory sections; ACCEPTANCE and VERIFY are paired 1:1;
+#      vague verbs ("fix", "improve") are rejected at synthesis time
 # These invariants are the canonical regression net for any future
 # refactor of the refine pipeline.
 
@@ -17,7 +21,32 @@ setup() {
   SYNTH="$REPO_ROOT/.devcontainer/images/.claude/commands/refine/synthesis.md"
   RENDER="$REPO_ROOT/.devcontainer/images/.claude/commands/refine/render.md"
   DO_MD="$REPO_ROOT/.devcontainer/images/.claude/commands/do.md"
+  ROUTER="$REPO_ROOT/.devcontainer/images/.claude/scripts/route-agent.sh"
+  TABLE="$REPO_ROOT/.devcontainer/images/.claude/agents/routing-table.jsonl"
+  FALLBACK="$REPO_ROOT/.devcontainer/images/.claude/scripts/refine-static-fallback.sh"
+  REGISTRY="$REPO_ROOT/.devcontainer/images/.claude/agents/registry.json"
+  GO_PROFILE="$REPO_ROOT/tests/fixtures/profiles/go.json"
+  TMP="$(mktemp -d)"
+  export CLAUDE_AGENTS_DIR="$REPO_ROOT/.devcontainer/images/.claude/agents"
+  export CLAUDE_ROUTING_TABLE="$TABLE"
+  export CLAUDE_ROUTING_TELEMETRY="$TMP/router-fallbacks.jsonl"
 }
+teardown() { rm -rf "$TMP"; }
+
+# Canonical phase list — every test that loops over the refine-* pipeline
+# uses this list so a missed phase shows up as a hard test failure.
+REFINE_PIPELINE_PHASES=(
+  refine-content-pruner
+  refine-scope-fencer
+  refine-constraint-distiller
+  refine-done-criteria-sharpener
+  refine-verifier-binder
+  refine-escalation-isolator
+  refine-sequence-causal-validator
+  refine-imperative-rewriter
+  refine-chain-stripper
+  refine-density-optimizer
+)
 
 # -- Invariant 1: no auto-chain from /refine to /do -----------------------
 
@@ -122,4 +151,84 @@ setup() {
   # render.md documents the 1:1 rule between ACCEPTANCE checkboxes and
   # VERIFY entries — the contract that makes "fix ca" impossible.
   grep -qE '1:1 mapping|one per ACCEPTANCE' "$RENDER"
+}
+
+# -- Invariant 12: route-agent resolves every refine-* pipeline phase ----
+
+@test "TestRouteAgentResolvesAllRefinePipelinePhases" {
+  # The reviewer's key blocker: dispatch.md documents 10 refine-* agents
+  # but the router must actually find them. Each phase must resolve to a
+  # concrete subagent_type (not general-purpose) with fallback_used=false.
+  for phase in "${REFINE_PIPELINE_PHASES[@]}"; do
+    run bash "$ROUTER" --skill /refine --phase "$phase" --profile "$GO_PROFILE"
+    [ "$status" -eq 0 ] || { echo "router exit $status for $phase"; return 1; }
+    echo "$output" | jq -e --arg p "$phase" '.[0].matched_rule_id != "no-match"' \
+      || { echo "no rule matched for $phase"; return 1; }
+    echo "$output" | jq -e '.[0].subagent_type != "general-purpose"' \
+      || { echo "phase $phase fell to general-purpose"; return 1; }
+    echo "$output" | jq -e '.[0].fallback_used == false' \
+      || { echo "phase $phase used fallback unexpectedly"; return 1; }
+  done
+}
+
+# -- Invariant 13: static fallback covers every refine-* pipeline phase --
+
+@test "TestStaticFallbackResolvesAllRefinePipelinePhases" {
+  # When route-agent.sh exits 20-31, the pipeline must still resolve via
+  # refine-static-fallback.sh::refine_static_pipeline_phase(). Otherwise
+  # dispatch.md's "static fallback" claim is fiction.
+  source "$FALLBACK"
+  for phase in "${REFINE_PIPELINE_PHASES[@]}"; do
+    run refine_static_pipeline_phase "$phase" json
+    [ "$status" -eq 0 ] || { echo "fallback failed for $phase"; return 1; }
+    echo "$output" | jq -e '.subagent_type != "general-purpose"' \
+      || { echo "fallback $phase returned general-purpose"; return 1; }
+    echo "$output" | jq -e '.fallback_used == true' \
+      || { echo "fallback $phase did not flag fallback_used"; return 1; }
+    echo "$output" | jq -e --arg p "$phase" '.matched_rule_id == "static:\($p)"' \
+      || { echo "fallback $phase has wrong matched_rule_id"; return 1; }
+  done
+}
+
+@test "TestStaticFallbackRejectsUnknownPhase" {
+  source "$FALLBACK"
+  run refine_static_pipeline_phase "refine-not-a-phase" json
+  [ "$status" -ne 0 ]
+}
+
+@test "TestStaticFallbackRouterParityForPipelinePhases" {
+  # The router-result and fallback-result must agree on subagent_type for
+  # every pipeline phase, so a router crash never silently changes which
+  # agent runs. Same agent + same effort, regardless of code path.
+  source "$FALLBACK"
+  for phase in "${REFINE_PIPELINE_PHASES[@]}"; do
+    router_agent=$(bash "$ROUTER" --skill /refine --phase "$phase" --profile "$GO_PROFILE" \
+      | jq -r '.[0].subagent_type')
+    fallback_agent=$(refine_static_pipeline_phase "$phase" json \
+      | jq -r '.subagent_type')
+    [ "$router_agent" = "$fallback_agent" ] \
+      || { echo "agent mismatch for $phase: router=$router_agent fallback=$fallback_agent"; return 1; }
+  done
+}
+
+# -- Invariant 14: registry.json reflects the v1.6 chain ------------------
+
+@test "TestRegistryReflectsV16Chain" {
+  # The architecture registry must enumerate the new pipeline stages or
+  # downstream consumers (audit, plan) see a stale picture.
+  chain=$(jq -r '.routing.refine.chain' "$REGISTRY")
+  [ -n "$chain" ] && [ "$chain" != "null" ]
+  echo "$chain" | grep -qF 'refine-* post-lens'
+  echo "$chain" | grep -qF 'square-prompt'
+  echo "$chain" | grep -qF 'compact-to-minimum'
+}
+
+# -- Invariant 15: validation runs post-compaction ------------------------
+
+@test "TestSquarePromptValidatesAfterCompaction" {
+  # Order matters: synthesis.md must show square-prompt-validate AFTER
+  # compact-to-minimum so a compaction pass cannot silently break the
+  # ACCEPTANCE/VERIFY mapping or the literal STOP block.
+  grep -q 'compact-to-minimum → square-prompt-validate' "$SYNTH"
+  grep -q 'validate twice\|validates twice\|TWICE' "$SYNTH"
 }

--- a/tests/scripts/refine-pipeline-rewire.bats
+++ b/tests/scripts/refine-pipeline-rewire.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+# refine-pipeline-rewire.bats — Skills Architecture v1.6 (amendment)
+# WHY: lock the post-rewire contract introduced by
+# `feat/refine-pipeline-rewire-and-kill-do`:
+#   1. /refine no longer auto-chains into /do (no Skill(skill=do) at all)
+#   2. The 10 mono-concern refine-* agents are enumerated in dispatch.md
+#   3. 4000 = ceiling, not target; floor_warn = 800 doctrine present
+#   4. /refine emits a textual "Suggested next step: /goal <slug>"
+#   5. /do carries a deprecation banner that points to /goal <slug>
+# These invariants are the canonical regression net for any future
+# refactor of the refine pipeline.
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  REFINE_MD="$REPO_ROOT/.devcontainer/images/.claude/commands/refine.md"
+  DISPATCH="$REPO_ROOT/.devcontainer/images/.claude/commands/refine/dispatch.md"
+  SYNTH="$REPO_ROOT/.devcontainer/images/.claude/commands/refine/synthesis.md"
+  RENDER="$REPO_ROOT/.devcontainer/images/.claude/commands/refine/render.md"
+  DO_MD="$REPO_ROOT/.devcontainer/images/.claude/commands/do.md"
+}
+
+# -- Invariant 1: no auto-chain from /refine to /do -----------------------
+
+@test "TestRefineNoLongerAutoChainsToDo" {
+  # Both spellings of the legacy chain call are gone from refine.md
+  ! grep -q 'Skill(skill="do"' "$REFINE_MD"
+  ! grep -q 'Skill(skill=do)' "$REFINE_MD"
+}
+
+# -- Invariant 2: allowed-tools no longer permits Skill(skill=do) ----------
+
+@test "TestRefineAllowedToolsDoesNotIncludeSkillDo" {
+  # The allowed-tools list entry is removed in v1.6 — without this, the
+  # harness would silently accept a /refine → /do auto-chain again.
+  ! grep -qE '^[[:space:]]*-[[:space:]]+"Skill\(skill=do\)"' "$REFINE_MD"
+}
+
+# -- Invariant 3: the 10 mono-concern refine-* agents are listed ----------
+
+@test "TestRefineDispatchListsAllTenAgents" {
+  # All 10 refine-* agents appear in dispatch.md, in canonical order.
+  # If any one is missing the post-lens pipeline drops a concern.
+  for agent in refine-content-pruner refine-scope-fencer \
+               refine-constraint-distiller refine-done-criteria-sharpener \
+               refine-verifier-binder refine-escalation-isolator \
+               refine-sequence-causal-validator refine-imperative-rewriter \
+               refine-chain-stripper refine-density-optimizer; do
+    grep -q "$agent" "$DISPATCH" || { echo "missing agent: $agent"; return 1; }
+  done
+}
+
+# -- Invariant 4: refine-density-optimizer is documented as terminal -------
+
+@test "TestRefineDensityOptimizerIsTerminal" {
+  # Pipeline causality: density compression MUST run last so it does not
+  # destroy the structure later mono-concern agents would need to read.
+  grep -qE 'refine-density-optimizer.*(last|Final)|MUST run last' "$DISPATCH"
+}
+
+# -- Invariant 5: synthesis uses ceiling semantics, not target ------------
+
+@test "TestSynthesisUsesCeilingSemantics" {
+  # 4000 is the CEILING (hard tool limit), not the design target. At
+  # least 2 mentions enforce the doctrine across the file (block header
+  # + narrative + schema doc).
+  count=$(grep -cE '(ceiling|≤ ?4000)' "$SYNTH")
+  [ "$count" -ge 2 ]
+}
+
+# -- Invariant 6: floor warning at 800 chars ------------------------------
+
+@test "TestSynthesisHasFloorWarning" {
+  # v1.6 amendment: emit a `suspect-over-compression` warning when the
+  # rendered directive falls below 800 chars. Without the floor the
+  # density optimizer could silently nuke half the contract.
+  grep -q 'floor_warn = 800' "$SYNTH"
+  grep -q 'minimum viable length' "$SYNTH"
+}
+
+# -- Invariant 7: render emits the textual suggestion line -----------------
+
+@test "TestRenderEmitsSuggestedNextStep" {
+  # The single hand-off after `/refine` is the printed suggestion line.
+  # No Skill() call, no auto-chain — the user types `/goal <slug>`.
+  count=$(grep -c 'Suggested next step' "$RENDER")
+  [ "$count" -ge 1 ]
+  ! grep -q 'Skill(skill="do"' "$RENDER"
+}
+
+# -- Invariant 8: /do carries a deprecation banner ------------------------
+
+@test "TestDoMdHasDeprecationBanner" {
+  # /do is deprecated for goal iteration; the banner is the contract
+  # the harness uses to discover the deprecation without parsing prose.
+  grep -q '^## DEPRECATED' "$DO_MD"
+  grep -q '/goal <slug>' "$DO_MD"
+}

--- a/tests/scripts/refine-pipeline-rewire.bats
+++ b/tests/scripts/refine-pipeline-rewire.bats
@@ -87,11 +87,39 @@ setup() {
   ! grep -q 'Skill(skill="do"' "$RENDER"
 }
 
-# -- Invariant 8: /do carries a deprecation banner ------------------------
+# -- Invariant 8: /do is NOT advertised as deprecated --------------------
 
-@test "TestDoMdHasDeprecationBanner" {
-  # /do is deprecated for goal iteration; the banner is the contract
-  # the harness uses to discover the deprecation without parsing prose.
-  grep -q '^## DEPRECATED' "$DO_MD"
-  grep -q '/goal <slug>' "$DO_MD"
+@test "TestDoMdHasNoDeprecationBanner" {
+  # /do remains a working skill; we do not advertise it in the skill
+  # tables and we do NOT label it deprecated. If users find it, it
+  # works; if they don't, /goal <slug> is the documented path.
+  ! grep -q '^## DEPRECATED' "$DO_MD"
+}
+
+# -- Invariant 9: render.md defines the square-prompt template -----------
+
+@test "TestRenderDefinesSquarePromptTemplate" {
+  # All 7 canonical sections must appear in the template definition.
+  for section in '# CONTEXT' '# OBJECTIVE' '# SCOPE' \
+                 '# CONSTRAINTS' '# ACCEPTANCE' '# VERIFY' '# STOP'; do
+    grep -q "$section" "$RENDER" || { echo "missing section: $section"; return 1; }
+  done
+}
+
+# -- Invariant 10: synthesis enforces square-prompt validation -----------
+
+@test "TestSynthesisEnforcesSquarePromptValidation" {
+  # The validator step is named and called out from the pipeline tables.
+  grep -q 'square-prompt-validate' "$SYNTH"
+  # Vague-verb rejection table is present (catches "fix ca", "improve", etc.)
+  grep -q 'Vague-verb rejection table' "$SYNTH"
+  grep -q 'user-must-fill-acceptance' "$SYNTH"
+}
+
+# -- Invariant 11: ACCEPTANCE and VERIFY are 1:1 paired ------------------
+
+@test "TestSquarePromptAcceptanceVerifyPaired" {
+  # render.md documents the 1:1 rule between ACCEPTANCE checkboxes and
+  # VERIFY entries — the contract that makes "fix ca" impossible.
+  grep -qE '1:1 mapping|one per ACCEPTANCE' "$RENDER"
 }

--- a/tests/scripts/refine-structure.bats
+++ b/tests/scripts/refine-structure.bats
@@ -19,7 +19,10 @@ setup() {
 @test "TestRefineRenderMdExists"     { [ -r "$REFINE_DIR/render.md" ]; }
 
 @test "TestRefineAllowedTools" {
-  grep -qE '^\s*-\s+"Skill\(skill=do\)"' "$REFINE_MD"
+  # v1.6 amendment: Skill(skill=do) is no longer in allowed-tools; the
+  # auto-chain into /do was removed. /refine ends with a printed
+  # `Suggested next step: /goal <slug>` instead.
+  ! grep -qE '^\s*-\s+"Skill\(skill=do\)"' "$REFINE_MD"
   grep -qE '^\s*-\s+"Write\(\.claude/goals/\*\.md\)"' "$REFINE_MD"
 }
 
@@ -46,9 +49,10 @@ setup() {
 }
 
 @test "TestRefineDirectiveBudgetDeclared" {
-  # v1.5: uniform 4000-char target (no more dual 4096/2000 split).
+  # v1.6: uniform 4000-char ceiling (no more dual 4096/2000 split).
+  # The ceiling is enforced; the natural target is the minimum viable.
   grep -q '4000' "$REFINE_DIR/render.md"
-  grep -q 'target = 4000' "$REFINE_DIR/synthesis.md"
+  grep -qE '(ceiling|≤ ?4000)' "$REFINE_DIR/synthesis.md"
 }
 
 @test "TestRefineEmitsGoalStateUpdate" {

--- a/tests/scripts/refine-v14-modes.bats
+++ b/tests/scripts/refine-v14-modes.bats
@@ -32,12 +32,20 @@ setup() {
   grep -qE '`--from-contract <slug>`' "$REFINE_MD"
 }
 
-# -- Single 4000-char target ----------------------------------------------
+# -- 4000-char ceiling (not target) ---------------------------------------
 
-@test "TestRefineTargets4000Always" {
-  # Single rule, all modes
-  grep -q 'targets 4000 chars' "$REFINE_MD"
-  grep -q 'target = 4000 chars' "$SYNTH"
+@test "TestRefineCeilingIs4000" {
+  # v1.6 amendment: 4000 is the CEILING (hard tool limit), not the design
+  # target. The design target is the minimum viable length.
+  grep -q '4000-char ceiling' "$REFINE_MD"
+  grep -qE '(ceiling|≤ ?4000)' "$SYNTH"
+  grep -q 'ceiling   = 4000 chars' "$SYNTH"
+}
+
+@test "TestRefineHasFloorWarning" {
+  # v1.6 amendment: floor_warn = 800 catches over-compression
+  grep -q 'floor_warn = 800' "$SYNTH"
+  grep -q 'suspect-over-compression' "$SYNTH"
 }
 
 @test "TestRefineNoDualBudget" {
@@ -55,11 +63,11 @@ setup() {
 }
 
 @test "TestRefineAllowsShorterOutput" {
-  # WHY: 4000 is the target ceiling, not a floor — natural shorter is fine
-  grep -q 'never pads to hit 4000' "$SYNTH"
-  grep -q 'natural output may be shorter' "$SYNTH" \
-    || grep -q 'Natural output may be shorter' "$RENDER" \
-    || grep -q 'output may be shorter' "$REFINE_MD"
+  # WHY: 4000 is the ceiling, not a floor — natural shorter is fine.
+  # The synthesis explicitly states it never pads to hit the ceiling.
+  grep -qE 'never pads to hit (4000|the ceiling)' "$SYNTH"
+  grep -q 'minimum viable length' "$SYNTH" \
+    || grep -q 'minimum viable length' "$REFINE_MD"
 }
 
 # -- Auto-detection -------------------------------------------------------
@@ -133,9 +141,12 @@ setup() {
 # -- Synthesis pipeline integrity -----------------------------------------
 
 @test "TestRefineSynthesisPipelineDiffersPerMode" {
-  grep -q 'collect → dedup → rank → render → compact-to-4000' "$SYNTH"
-  grep -q 'template → render → compact-to-4000' "$SYNTH"
-  grep -q 'read → extract → render → compact-to-4000' "$SYNTH"
+  # v1.6 amendment: pipelines insert refine-pipeline between render and
+  # compact, and compact is renamed to compact-to-minimum (ceiling, not
+  # target). All three modes keep distinct entry sequences.
+  grep -q 'collect → dedup → rank → render → refine-pipeline → compact-to-minimum' "$SYNTH"
+  grep -q 'template → render → refine-pipeline → compact-to-minimum' "$SYNTH"
+  grep -q 'read → extract → render → refine-pipeline → compact-to-minimum' "$SYNTH"
 }
 
 @test "TestRefineModeEnumInOutputSchema" {

--- a/tests/scripts/refine-v14-modes.bats
+++ b/tests/scripts/refine-v14-modes.bats
@@ -1,10 +1,10 @@
 #!/usr/bin/env bats
-# refine-v14-modes.bats — Skills Architecture v1.5
+# refine-v14-modes.bats — Skills Architecture v1.6
 # WHY: lock the 3-mode contract (FULL / BARE / FROM-CONTRACT) plus the
-# uniform 4000-char target and auto-detection from disk state. The
-# free-form-to-/goal path is the one users will reach for most often;
-# it MUST keep working without a plan + context pair and without an
-# explicit --bare flag.
+# uniform 4000-char ceiling (not target) and auto-detection from disk
+# state. The free-form-to-/goal path is the one users will reach for
+# most often; it MUST keep working without a plan + context pair and
+# without an explicit --bare flag.
 
 setup() {
   REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"

--- a/tests/scripts/refine-v14-modes.bats
+++ b/tests/scripts/refine-v14-modes.bats
@@ -141,12 +141,12 @@ setup() {
 # -- Synthesis pipeline integrity -----------------------------------------
 
 @test "TestRefineSynthesisPipelineDiffersPerMode" {
-  # v1.6 amendment: pipelines insert refine-pipeline between render and
-  # compact, and compact is renamed to compact-to-minimum (ceiling, not
-  # target). All three modes keep distinct entry sequences.
-  grep -q 'collect → dedup → rank → render → refine-pipeline → compact-to-minimum' "$SYNTH"
-  grep -q 'template → render → refine-pipeline → compact-to-minimum' "$SYNTH"
-  grep -q 'read → extract → render → refine-pipeline → compact-to-minimum' "$SYNTH"
+  # v1.6 amendment: pipelines insert refine-pipeline + square-prompt-validate
+  # between render and compact, and compact is renamed to compact-to-minimum
+  # (ceiling, not target). All three modes keep distinct entry sequences.
+  grep -q 'collect → dedup → rank → render → refine-pipeline → square-prompt-validate → compact-to-minimum' "$SYNTH"
+  grep -q 'template → render → refine-pipeline → square-prompt-validate → compact-to-minimum' "$SYNTH"
+  grep -q 'read → extract → render → refine-pipeline → square-prompt-validate → compact-to-minimum' "$SYNTH"
 }
 
 @test "TestRefineModeEnumInOutputSchema" {


### PR DESCRIPTION
## Summary

Skills Architecture **v1.6** — four cumulative rounds of work on `/refine`:

1. **No auto-chain to `/do`.** `/refine` ends with a printed `Suggested next step: /goal <slug>` — the user remains the trigger.
2. **`/do` is no longer surfaced** in the user-facing skill tables (skill file kept functional for back-compat).
3. **Square-prompt directive** — every mode emits the same 7-section shape (CONTEXT, OBJECTIVE, SCOPE, CONSTRAINTS, ACCEPTANCE, VERIFY, STOP); vague verbs in ACCEPTANCE are rejected and replaced with a visible sentinel so `/goal vasy execute le plan` can never reach goal state hidden behind soft prose.
4. **4000 = ceiling, not target** — design target is the minimum viable length; `floor_warn = 800` flags suspect over-compression.
5. **10 mono-concern `refine-*` agents** wired into routing (10 `routing-table.jsonl` entries) and mirrored in `refine-static-fallback.sh` (router-success and fallback are bit-identical per phase).
6. **`square-prompt-validate` runs twice** (pre- and post-`compact-to-minimum`) so compaction cannot silently break the validator's invariants.

## The square-prompt template (single shape, all modes)

```text
/goal "<slug>

# CONTEXT
<1-3 sentences: system state and why this work matters now>

# OBJECTIVE
<one sentence stating the END STATE — not a process>

# SCOPE
In:  <files/areas the work touches>
Out: <explicit non-targets — sibling concerns, follow-up PRs>

# CONSTRAINTS
- <hard rule 1>
- <hard rule 2>

# ACCEPTANCE
- [ ] <binary, measurable criterion 1>
- [ ] <binary, measurable criterion 2>

# VERIFY
- <criterion 1> -> <bash command, grep, test name, or tool call>
- <criterion 2> -> <verifier — one per ACCEPTANCE line, 1:1 mapping>

# STOP
Halt only when every ACCEPTANCE box returns TRUE under its paired
VERIFY entry. Do not stop on partial progress, 'looks fine', or
non-VERIFY heuristics. Vague conditions ('fix it', 'improve',
'make it work') are forbidden in ACCEPTANCE."
```

## Architecture decisions

- **D1** — `/goal` is a harness builtin (no `commands/goal.md` in this PR).
- **D2** — Pipeline order is **causal**: content-pruner → scope-fencer → constraint-distiller → done-criteria-sharpener → verifier-binder → escalation-isolator → sequence-causal-validator → imperative-rewriter → chain-stripper → density-optimizer (terminal).
- **D3** — Validate before AND after compaction. Compaction may not break section presence, STOP literalness, or ACCEPTANCE/VERIFY 1:1 pairing.
- **D4** — `/do` skill file stays functional for back-compat (`do-goal-turn`, `review → do` chain), but is removed from user-facing skill tables. No deprecation banner — surfacing is what the user controls.

## Acceptance criteria (all pass)

```
grep -c 'Skill(skill="do"' refine.md                          == 0   :: 0
grep -c 'refine-content-pruner' dispatch.md                    >= 1  :: 1
grep -c 'refine-density-optimizer' dispatch.md                 >= 1  :: 1
grep -cE '(ceiling|≤ ?4000)' synthesis.md                      >= 2  :: 18
grep -c 'Suggested next step' render.md                        >= 1  :: 3
grep -c '^## DEPRECATED' do.md                                 == 0   :: 0
square-prompt-validate runs twice in synthesis.md              :: yes
routing-table.jsonl has 10 refine-pipeline-N entries           :: 10
refine_static_pipeline_phase covers all 10 phases              :: 10
registry.json reflects v1.6 chain                              :: yes
```

## Test plan

- [x] `bats tests/scripts/refine-pipeline-rewire.bats` — 17 invariants (runtime router + static-fallback + parity + validation order)
- [x] `bats tests/scripts/refine-v14-modes.bats` — pass after wording update
- [x] `bats tests/scripts/refine-structure.bats` — pass after wording update
- [x] `bats tests/scripts/do-goal-turn.bats` — zero change in `--goal-turn`
- [x] `bats tests/scripts/skill-chain.bats` — `review → do` chain intact
- [x] `bats tests/scripts/pr5a-workflow.bats` — `plan → refine` chain intact
- [x] `bats tests/scripts/route-agent-rules.bats` — router invariants intact
- [x] **Full suite: 405/405 green**

## Diff stat (4 rounds)

| Round | Files | LOC |
|---|---|---|
| R1 | 10 (9 mod + 1 new) | +304 / −91 |
| R2 | 8 mod | +185 / −62 |
| R3 | 8 mod | +200 / −17 |
| R4 | 5 mod | +25 / −14 |
| **Total** | **11** | **+714 / −184** |

## Out of scope (follow-up PRs)

- Deletion of `do.md`, `do/*`, `do-goal-turn.bats` (audit first).
- Migration of `--goal-turn` mechanics into a real `goal.md` skill file.
- Removing the `/review → /do` chain in `review/cyclic.md`.

## Rollback

`git revert <commit>` per round — pure file edits, no migrations, no runtime scripts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**What**
Rewires /refine to always emit a deterministic 7-section "square-prompt" directive (CONTEXT / OBJECTIVE / SCOPE / CONSTRAINTS / ACCEPTANCE / VERIFY / STOP), removes user-facing exposure of /do (kept for back-compat), and requires manual invocation of /goal <slug> as the next step.

**Why**
To prevent automatic execution loops (avoid implicit /do runs), produce more deterministic/verifiable directives (binary ACCEPTANCE with 1:1 VERIFY mapping), and stop producing padded 4000-char outputs while preserving a hard 4000-char ceiling.

**How**
- Enforced a mode-invariant square-prompt template and added square-prompt-validate (rejects vague ACCEPTANCE bullets; emits visible user-fill sentinels); validation runs twice (pre- and post-compaction) around compact-to-minimum.
- Replaced prior "compact-to-4000" semantics with compact_to_minimum(text, ceiling=4000, floor_warn=800) and advisory floor_warn = 800.
- Introduced a post-lens 10-stage mono-concern refine pipeline (refine-content-pruner → ... → refine-density-optimizer), added 10 routing-table.jsonl entries, and mirrored mappings in refine-static-fallback.sh to guarantee router vs fallback parity.
- Removed Skill(skill="do") auto-chain and removed /do from command tables; /refine prints the directive plus a "Suggested next step: /goal <slug>" (manual handoff).
- Updated registry.json routing.refine.chain, dispatch/synthesis/render docs and tests; expanded bats tests to runtime router/fallback invariants and square-prompt enforcement. Full bats suite reported green.

**Risk**
- Behavioral/integration risk: automation or tooling that expected /refine → auto /do must be updated to call /goal <slug> explicitly; workflow/state-machine behavior changed.
- Tests and static fallback added to minimize routing breakage; rollback possible via git revert per commit.
- No auth/crypto/secrets, database migrations, supply-chain or new third-party dependencies introduced. Public API surface unchanged (documentation and tooling behavior only). Security-sensitive risks are minimal; primary risks are workflow integration and consumer automation updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kodflow/devcontainer-template/pull/374?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->