### PR TITLE
chore(ci): bump docker/metadata-action + login-action (consolidates #376, #378)

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -69,7 +69,7 @@ jobs:
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -133,7 +133,7 @@ jobs:
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -180,7 +180,7 @@ jobs:
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -200,7 +200,7 @@ jobs:
       - name: Extract metadata
         if: steps.base-check.outputs.available == 'true'
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -350,7 +350,7 @@ jobs:
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -362,7 +362,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |


### PR DESCRIPTION
Consolidates the two remaining Dependabot bumps into one change (both edit docker-images.yml):

- docker/metadata-action 6.0.0 -> 6.1.0 (supersedes #376)
- docker/login-action 4.1.0 -> 4.2.0 (supersedes #378)

Single CI cycle instead of serial same-file merges. SHA-pinned with version comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What
Updated `docker/login-action` from v4.1.0 to v4.2.0 and `docker/metadata-action` from v6.0.0 to v6.1.0 across six workflow steps in the Docker image CI pipeline, using SHA-pinned references with inline version comments.

## Why
Consolidates two separate Dependabot pull requests (`#376` and `#378`) into a single change, avoiding serial same-file merges and enabling both updates to proceed in a single CI cycle.

## How
Bumped the `uses:` pins in four Docker login steps (build-base, merge-base, build, and merge jobs) and two metadata extraction steps (main image build and manifest merge jobs). All references maintain SHA pinning for reproducibility while adding version comments for clarity.

## Risk
**Supply chain update**: Minor version bumps of widely-used GitHub Actions. Both are patch-minor version increases (4.1.0→4.2.0, 6.0.0→6.1.0) which should maintain backward compatibility. No migration steps or breaking changes expected. These actions are integral to the CI/CD pipeline's container registry authentication and metadata generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kodflow/devcontainer-template/pull/380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->