### PR TITLE
chore(tidy): clear follow-up loose ends (helm token, GPG doc, codacy/markdownlint config)

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -15,3 +15,9 @@ exclude_paths:
   # Claude agent and command files (Markdown used as prompts)
   - ".claude/**/*.md"
   - ".devcontainer/images/.claude/**/*.md"
+  # Workflow scripts: JS evaluated inside a harness-provided async function
+  # wrapper, so top-level return/await is the runtime contract (not valid
+  # standalone-ESM syntax). node --check validates them; static ESM parsers
+  # (Biome) false-positive on the top-level return.
+  - ".devcontainer/images/.claude/workflows/**"
+  - ".claude/workflows/**"

--- a/.devcontainer/images/.claude/commands/plan/synthesize.md
+++ b/.devcontainer/images/.claude/commands/plan/synthesize.md
@@ -177,10 +177,12 @@ Acceptance criteria are tagged so `/refine` (proof-triplet) and `/goal` know whi
 to run as a gate vs which describe the finished state:
 
 ### Current-state diagnostics
+
 [current-state] commands that reflect the repo NOW (safe to run before implementation)
 - [ ] `test "$(grep -RIn 'legacy-thing' src/ | wc -l)" -eq <N>`
 
 ### Final-state acceptance
+
 [final-state] commands that describe the DONE state (fail until the work lands; never a write-gate)
 - [ ] `! grep -RIn 'legacy-thing' src/`
 - [ ] `test -f <new/file>`

--- a/.devcontainer/images/Dockerfile.base
+++ b/.devcontainer/images/Dockerfile.base
@@ -103,7 +103,7 @@ RUN --mount=type=secret,id=github_token,required=false \
     echo "Installing kubectl ${KUBECTL_LATEST}..." && \
     curl -fsSL "https://dl.k8s.io/release/${KUBECTL_LATEST}/bin/linux/${ARCH}/kubectl" -o /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl && \
-    HELM_LATEST=$(curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: token ${GITHUB_TOKEN}"} "https://api.github.com/repos/helm/helm/releases/latest" | jq -r '.tag_name') && \
+    if [ -n "${GITHUB_TOKEN}" ]; then HELM_LATEST=$(curl -fsSL -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/helm/helm/releases/latest" | jq -r '.tag_name'); else HELM_LATEST=$(curl -fsSL "https://api.github.com/repos/helm/helm/releases/latest" | jq -r '.tag_name'); fi && \
     echo "Installing Helm ${HELM_LATEST}..." && \
     curl -fsSL "https://get.helm.sh/helm-${HELM_LATEST}-linux-${ARCH}.tar.gz" | tar xz -C /tmp && \
     mv /tmp/linux-${ARCH}/helm /usr/local/bin/helm && \

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json",
+  "default": true,
+  "MD013": false,
+  "MD040": false
+}

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -29,6 +29,12 @@ Without a token, the corresponding MCP server does not start. Commands (`/review
 | `OP_SERVICE_ACCOUNT_TOKEN` | 1Password CLI auth for `/secret` |
 | `VPN_CONFIG_REF` | 1Password reference to VPN profile (e.g., `op://VPN/MyVPN/config`) |
 
+### Git signing (optional)
+
+| Variable | Usage |
+|----------|-------|
+| `GPG_SIGNINGKEY` | GPG key id for signed commits. `postCreate.sh::step_gpg_signing` sets `user.signingkey` from it, and enables `commit.gpgsign` only when the secret half of the key is present (so bootstrap never breaks). A preconfigured `git config user.signingkey` is also honored. |
+
 ### Full Example
 
 ```env


### PR DESCRIPTION
Final cleanup so the backlog stays at zero:

- **Dockerfile.base** — helm release lookup header was word-split (`${GITHUB_TOKEN:+-H "..."}`), so the token was never applied; now a properly quoted `-H` when set, anonymous otherwise.
- **configuration.md** — document `GPG_SIGNINGKEY` (follow-up of #366).
- **codacy** — exclude workflow JS: top-level return/await is the harness runtime contract, not standalone-ESM; `node --check` validates them. Silences the Biome false-positive.
- **markdownlint** — add config disabling MD013 (long prompt lines) + MD040 (illustrative bare fences) repo-wide; fix one MD022 heading-spacing spot.

All 411 bats green.