### PR TITLE
fix(search): make Workflow engine mandatory, not probe-gated

### DIFF
--- a/.devcontainer/images/.claude/commands/search.md
+++ b/.devcontainer/images/.claude/commands/search.md
@@ -218,7 +218,16 @@ Phase 9.0: Generate Context File
 ## Workflow gateway (skills-cleanup C6)
 
 `/search` is a **gateway**, never a monolithic wrap. The local-first gate stays
-OUTSIDE the engine; the workflow only runs for the web complement.
+OUTSIDE the engine; the `research` Workflow is the **mandatory** engine for the
+web complement.
+
+> **MANDATORY — Workflow is not optional.** Whenever the local-first gate does
+> NOT short-circuit (`LOCAL_PARTIAL` / `LOCAL_NONE`), `/search` MUST invoke
+> `Workflow({ name: 'research', … })`. There is **no `primitives.json` gate** on
+> this path: the previous "accelerator, only if present" wording was a bug — the
+> probe never emitted a `Workflow` key, so the gate was unsatisfiable and the
+> engine never ran. Doing the web research inline with ad-hoc `Task`/`WebSearch`
+> calls instead of the Workflow is a **skill violation**.
 
 ```
 /search <query>
@@ -226,9 +235,10 @@ OUTSIDE the engine; the workflow only runs for the web complement.
   ├─ Phase 0  local-first gate (in-skill, NO engine)
   │     Grep/Read ~/.claude/docs/ + docs/*.md
   │     ├─ LOCAL_COMPLETE → early-exit: write .claude/contexts/<slug>.md from local, STOP
-  │     └─ LOCAL_PARTIAL / LOCAL_NONE → compute GAPS, run the workflow below
+  │     │                   (the ONLY path that legitimately skips the Workflow)
+  │     └─ LOCAL_PARTIAL / LOCAL_NONE → compute GAPS, then ALWAYS run the engine ↓
   │
-  ├─ engine (only if Workflow primitive present in primitives.json):
+  ├─ engine (ALWAYS, whenever web complement is needed):
   │     Workflow({ name: 'research', args: { query, gaps, whitelist } })
   │       Scope → Search∥ → Fetch∥ → Verify(3-vote) → Synthesize   # writes NOTHING
   │     returns { context_md, sources, confidence_map }
@@ -237,9 +247,11 @@ OUTSIDE the engine; the workflow only runs for the web complement.
                 merging local findings + the cited workflow report.
 ```
 
-**Fallback (no regression):** if `primitives.json` reports the `Workflow` tool
-`absent`, `/search` falls back to the legacy parallel `Task`-agent path documented
-in `search/parallel.md`. The engine is an accelerator, never a hard dependency.
+**Degraded path (error-recovery only, NOT a routine gate):** the legacy parallel
+`Task`-agent path in `search/parallel.md` is used **only** if the `Workflow` tool
+call itself errors (genuinely unavailable in the runtime). It is a last-resort
+safety net for a broken environment — never the default, and never chosen by
+consulting `primitives.json`. If you fall back, say so explicitly in the output.
 
 **Invariants:** the official-domain whitelist (above) is injected into the
 `research` workflow's Search prompts; the workflow itself never writes disk — the

--- a/.devcontainer/images/.claude/docs/primitives-compat.md
+++ b/.devcontainer/images/.claude/docs/primitives-compat.md
@@ -19,6 +19,20 @@ fallback, `unknown` defers the decision to the calling skill.
 - Fallback: inline polling loop with `sleep` — slower, no event semantics
 - Acceptance test: `TestClaudePrimitiveAvailability_Monitor`
 
+### Workflow
+- Required by: `/search` (web-complement engine — the `research` workflow)
+- Probe: `jq -e '.tools[] | select(.name=="Workflow")' <schema>`
+- **Status is MANDATORY-by-doctrine, NOT gate-by-probe.** `/search` always invokes
+  `Workflow({name:'research', …})` whenever the local-first gate does not
+  short-circuit; it does **not** consult this matrix entry to decide. The probe
+  records availability for diagnostics/`/audit` only. (History: `/search`
+  originally gated on a `primitives.json.Workflow` key that the probe never
+  emitted — an unsatisfiable gate that disabled the engine entirely. The key is
+  now emitted for completeness; the gate was removed.)
+- Fallback: legacy parallel `Task`-agent path in `search/parallel.md` — used ONLY
+  if the `Workflow` tool call itself errors, never as a routine choice.
+- Acceptance test: `TestClaudePrimitiveAvailability_Workflow`
+
 ### Skill
 - Required by: PR1 (4 active chains), PR3 (`/refine` → `/do`)
 - Probe: `jq -e '.tools[] | select(.name=="Skill")' <schema>`

--- a/.devcontainer/images/.claude/scripts/probe-primitives.sh
+++ b/.devcontainer/images/.claude/scripts/probe-primitives.sh
@@ -100,6 +100,7 @@ exitplanmode_schema() {
 
 jq -n \
   --arg monitor              "$(probe_tool Monitor)" \
+  --arg workflow             "$(probe_tool Workflow)" \
   --arg skill                "$(probe_tool Skill)" \
   --arg exitplanmode         "$(probe_tool ExitPlanMode)" \
   --arg enterplanmode        "$(probe_tool EnterPlanMode)" \
@@ -120,6 +121,7 @@ jq -n \
     schema_version: 1,
     probed_at: (now | strftime("%Y-%m-%dT%H:%M:%SZ")),
     Monitor: {status: $monitor},
+    Workflow: {status: $workflow},
     Skill: {status: $skill},
     ExitPlanMode: {status: $exitplanmode, input_schema: $epm_schema},
     EnterPlanMode: {status: $enterplanmode},

--- a/.devcontainer/images/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/images/hooks/lifecycle/postStart.sh
@@ -86,9 +86,9 @@ step_restore_claude_config() {
     # Ensure base directory exists
     mkdir -p "$HOME/.claude"
 
-    # CLEAN commands, scripts, agents and docs to avoid legacy pollution
+    # CLEAN commands, scripts, agents, docs and workflows to avoid legacy pollution
     # Only these directories are managed by the image - sessions/plans are user data
-    rm -rf "$HOME/.claude/commands" "$HOME/.claude/scripts" "$HOME/.claude/agents" "$HOME/.claude/docs"
+    rm -rf "$HOME/.claude/commands" "$HOME/.claude/scripts" "$HOME/.claude/agents" "$HOME/.claude/docs" "$HOME/.claude/workflows"
 
     # Restore commands (fresh copy from image)
     if [ -d "$CLAUDE_DEFAULTS/commands" ]; then
@@ -114,6 +114,14 @@ step_restore_claude_config() {
     if [ -d "$CLAUDE_DEFAULTS/docs" ]; then
         mkdir -p "$HOME/.claude/docs"
         cp -r "$CLAUDE_DEFAULTS/docs/"* "$HOME/.claude/docs/" 2>/dev/null || true
+    fi
+
+    # Restore workflows (Workflow-tool scripts, e.g. research.js - fresh copy from image)
+    # WHY: /search hard-depends on Workflow({name:'research'}); without this the
+    # named workflow is unresolvable at runtime in consumer containers.
+    if [ -d "$CLAUDE_DEFAULTS/workflows" ]; then
+        mkdir -p "$HOME/.claude/workflows"
+        cp -r "$CLAUDE_DEFAULTS/workflows/"* "$HOME/.claude/workflows/" 2>/dev/null || true
     fi
 
     # Restore templates (Documentation and C4 templates - fresh copy from image)


### PR DESCRIPTION
## Root cause

`/search` gated its `research` Workflow on a primitives-matrix key that the probe **never emitted** — `probe-primitives.sh` did not probe `Workflow`. The gate was therefore unsatisfiable, so the engine never ran and searches silently fell back to the legacy `Task`-agent path. Three compounding causes (each sufficient alone): unsatisfiable gate, conditional-by-design vs the "always use Workflow" intent, and the probe never being wired into a lifecycle hook.

## Fix

- **search**: Workflow is now **mandatory** whenever the local-first gate does not short-circuit. No primitives gate on this path. The `Task` path is explicit error-recovery only.
- **postStart**: restore the `workflows` runtime dir so `research` is resolvable in consumer containers (was restoring commands/scripts/agents/docs but not workflows).
- **probe-primitives**: add the missing `Workflow` probe to the availability matrix.
- **compat doc**: document `Workflow` as mandatory-by-doctrine, with the broken-gate history.

## Verify

- `bash -n` clean on probe + postStart; probe emits valid JSON with `Workflow` key; shellcheck clean.
- Runtime copies propagated so the fix is live this session.

Out of scope (noted): `probe-primitives.sh` is still not wired into `postCreate`, so the matrix is never generated — separate latent issue also affecting `/plan` synthesize.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**What**  
Make the Workflow engine mandatory for `/search` command's research operation instead of being conditionally gated by probe results. Updates documentation, adds Workflow detection to the probe, and ensures workflow runtime state is restored on container start.

**Why**  
The previous design had an unsatisfiable gate: `/search` gated its research Workflow on a `primitives-matrix` key that the probe never emitted because `probe-primitives.sh` did not probe for Workflow. This caused the gate condition to fail every time, forcing searches to fall back to a legacy Task-agent path instead of using the intended Workflow engine. Three compounding causes created this issue: the unsatisfiable gate itself, conditional-by-design vs. intended "always use Workflow", and the probe not wired into a lifecycle hook.

**How**  
- **search.md**: Rewritten control flow to make `Workflow({ name: 'research', ... })` mandatory whenever `LOCAL_COMPLETE` does not apply; Task-agent fallback restricted to error recovery only if the Workflow call itself fails.
- **primitives-compat.md**: Added Workflow as a mandatory primitive with probe diagnostic info; clarified probe is for auditing only, not for gating.
- **probe-primitives.sh**: Added probe for Workflow tool and its presence status to generated `primitives.json` output.
- **postStart.sh**: Restored workflows directory from defaults during container start (previously only commands/scripts/agents/docs were restored).

**Risk**  
Low risk of breaking changes given that the previous gate was unsatisfiable—the Workflow was never actually executing, so there are no existing patterns relying on the fallback behavior. No code logic changes, only documentation and configuration. No dependencies, auth/crypto, migrations, or state machine concerns. Note: `probe-primitives.sh` remains unwired into postCreate hooks, so the matrix is never auto-generated during container build (documented as separate latent issue).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kodflow/devcontainer-template/pull/382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->