### PR TITLE
fix(search): close LOCAL_COMPLETE escape hatch so research engine runs

### DIFF
--- a/.devcontainer/images/.claude/commands/search.md
+++ b/.devcontainer/images/.claude/commands/search.md
@@ -227,7 +227,11 @@ web complement.
 > this path: the previous "accelerator, only if present" wording was a bug — the
 > probe never emitted a `Workflow` key, so the gate was unsatisfiable and the
 > engine never ran. Doing the web research inline with ad-hoc `Task`/`WebSearch`
-> calls instead of the Workflow is a **skill violation**.
+> calls instead of the Workflow is a **skill violation** — and so is declaring
+> `LOCAL_COMPLETE` for an internal/codebase topic (no `~/.claude/docs/` match) to
+> dodge the engine. `LOCAL_COMPLETE` is valid ONLY when you can cite the matched
+> validated-doc files; otherwise the engine runs. See `search/local.md`
+> `3_evaluate_coverage` / `anti_escape_hatch`.
 
 ```
 /search <query>
@@ -236,6 +240,10 @@ web complement.
   │     Grep/Read ~/.claude/docs/ + docs/*.md
   │     ├─ LOCAL_COMPLETE → early-exit: write .claude/contexts/<slug>.md from local, STOP
   │     │                   (the ONLY path that legitimately skips the Workflow)
+  │     │                   VALID ONLY if you can CITE the matched ~/.claude/docs/
+  │     │                   files holding the answer. A "100% internal / codebase"
+  │     │                   topic has NO docs entry → it is NEVER LOCAL_COMPLETE.
+  │     │                   Answering from source code / reasoning = GAP, not local.
   │     └─ LOCAL_PARTIAL / LOCAL_NONE → compute GAPS, then ALWAYS run the engine ↓
   │
   ├─ engine (ALWAYS, whenever web complement is needed):
@@ -264,6 +272,9 @@ skill is the sole writer of `.claude/contexts/`.
 | Action | Status |
 |--------|--------|
 | Skip local documentation | **FORBIDDEN** |
+| Declare `LOCAL_COMPLETE` without citing matched `~/.claude/docs/` files | **FORBIDDEN** |
+| Use `LOCAL_COMPLETE` to skip the engine on an internal/codebase topic | **FORBIDDEN** |
+| Skip the `research` Workflow when gate ≠ `LOCAL_COMPLETE` | **FORBIDDEN** |
 | Ignore local/external conflict | **FORBIDDEN** |
 | Prefer external over local without validation | **FORBIDDEN** |
 | Non-official source | **FORBIDDEN** |

--- a/.devcontainer/images/.claude/commands/search/local.md
+++ b/.devcontainer/images/.claude/commands/search/local.md
@@ -22,16 +22,33 @@ local_first:
       output: local_knowledge
 
     3_evaluate_coverage:
+      # "Local" means VALIDATED docs ONLY: ~/.claude/docs/** and the repo's
+      # docs/*.md. Project SOURCE CODE, git history, and your own reasoning are
+      # NOT "local coverage" — answering from them is a GAP, not a short-circuit.
+      # This is the rule #382 enforces: the engine is the DEFAULT; LOCAL_COMPLETE
+      # is the rare exception, never an escape hatch to skip the Workflow.
       rule: |
-        IF local_knowledge covers >= 80% of the query:
+        Let matched_docs = the validated-doc files (~/.claude/docs/**, docs/*.md)
+        that ACTUALLY CONTAIN the answer. You MUST be able to name them.
+
+        IF matched_docs is non-empty AND those files cover >= 80% of the query:
           status = "LOCAL_COMPLETE"
-          → Skip Phase 1-3, go to Phase 6
-        ELSE IF local_knowledge covers >= 40%:
-          status = "LOCAL_PARTIAL"
-          → Continue Phase 0+ for gaps only
+          → write .claude/contexts/<slug>.md from local, STOP (skip the engine)
+          → MUST list matched_docs as evidence in the Phase 1.0 output below
         ELSE:
-          status = "LOCAL_NONE"
-          → Continue normal workflow
+          # Covers: zero matched validated-doc files; the answer would come from
+          # project code / git history / reasoning; only partial doc coverage.
+          status = (matched_docs cover >= 40% of the query) ? "LOCAL_PARTIAL"
+                                                            : "LOCAL_NONE"
+          → compute GAPS, then Workflow({name:'research', ...}) is MANDATORY
+
+      anti_escape_hatch: |
+        A topic being "100% internal to this repo" does NOT make it
+        LOCAL_COMPLETE. Internal/codebase topics have NO entry in ~/.claude/docs/
+        → matched_docs is empty → LOCAL_NONE (or PARTIAL) → the engine MUST run.
+        If you cannot cite validated-doc files that hold the answer, you are NOT
+        LOCAL_COMPLETE. Reading source code to synthesize an answer is exactly the
+        case the engine exists for — run it.
 
   categories_mapping:
     design_patterns: "creational/, structural/, behavioral/"


### PR DESCRIPTION
## Summary

- Tighten the `/search` local-first gate so an internal/codebase topic can no longer be self-classified `LOCAL_COMPLETE` to skip the mandatory `research` Workflow (regression after #382).
- "Local" now means **validated docs only** (patterns KB + repo docs); answering from source code or reasoning is a GAP, not coverage.
- `LOCAL_COMPLETE` requires **citing the matched doc files**; otherwise → `LOCAL_NONE`/`PARTIAL` → engine runs. Adds an `anti_escape_hatch` rule + guardrail rows + gateway note.

## Test plan

- [ ] Rebuild image; run `/search` on a 100%-internal topic → gate resolves `LOCAL_NONE` and the `research` Workflow is invoked.
- [ ] Run `/search` on a topic fully covered by the patterns KB → `LOCAL_COMPLETE` with cited files, engine skipped.