### PR TITLE
feat(commands): add /issues:fixer continuous issue-triage loop

### DIFF
--- a/.devcontainer/images/.claude/CLAUDE.md
+++ b/.devcontainer/images/.claude/CLAUDE.md
@@ -133,6 +133,7 @@ Enforced by two layers (defence-in-depth):
 | `/update` | DevContainer update |
 | `/feature` | Feature tracking (RTM) |
 | `/improve` | Docs QA |
+| `/issues:fixer` | Continuous issue-triage loop (60s, never stops) |
 
 ### Skill Classification
 

--- a/.devcontainer/images/.claude/commands/issues/fixer.md
+++ b/.devcontainer/images/.claude/commands/issues/fixer.md
@@ -1,0 +1,134 @@
+---
+name: issues:fixer
+description: |
+  Continuous issue-triage loop. Every 60s, never stops: pulls the repo's open
+  issues, triages each (legitimate -> fix in a workflow + PR; false-positive ->
+  reply & close; unclear -> ask for info & wait; duplicate -> link & close),
+  then re-arms itself for the next minute. A self-rescheduling watchdog that
+  keeps the issue tracker triaged and moving without supervision.
+allowed-tools:
+  - "Bash(git:*)"
+  - "Bash(gh:*)"
+  - "mcp__github__*"
+  - "Read(**/*)"
+  - "Glob(**/*)"
+  - "Grep(**/*)"
+  - "Write(**/*)"
+  - "Edit(**/*)"
+  - "Task(*)"
+  - "TaskCreate(*)"
+  - "TaskUpdate(*)"
+  - "TaskList(*)"
+  - "ScheduleWakeup(*)"
+  - "Workflow(*)"
+---
+
+# /issues:fixer — continuous issue triage & fix loop
+
+A never-ending, minute-by-minute loop that keeps the repository's issue tracker
+triaged and moving. Each **tick** pulls the open issues, decides what each one
+is, acts, and re-schedules itself 60 seconds out. **It does not stop on its
+own** — only an explicit user cancellation ends it.
+
+This command is deliberately *thin and conservative*: it reads, classifies, and
+either dispatches a fix, asks a question, or closes a non-issue. It never
+auto-merges, never touches another repo, and never closes anything it is unsure
+about.
+
+## Cadence & lifetime (non-negotiable)
+
+- **Every 60 seconds.** At the **end of every tick** — success, no-op, or
+  partial — re-arm with:
+  `ScheduleWakeup(delaySeconds: 60, prompt: "/issues:fixer", reason: "issue-triage tick")`.
+  60s is the runtime floor; it keeps each tick short so the loop never drifts
+  into a long-running job.
+- **Never stops.** Always re-arm, even when nothing changed. Omitting the
+  re-arm is the *only* way the loop dies, so only do that if the user explicitly
+  asks to stop.
+- **One tick = one pass.** Do exactly one triage pass, re-arm, end the turn.
+  Never `sleep`-spin or busy-wait inside a tick.
+- **Do NOT use a recurring cron** (`* * * * *`) for this. Recurring cron jobs
+  auto-expire after 7 days; the self-`ScheduleWakeup` loop has no such cap and
+  is the correct "never stops" mechanism.
+
+## Scope & tools
+
+- Operate **only** on the current repository's own issues. Resolve `owner/repo`
+  from `git remote get-url origin`. Never act on another repo's tracker.
+- Prefer the GitHub MCP tools (`mcp__github__*`); fall back to `gh` only when MCP
+  is unavailable.
+
+## Each tick
+
+### 1. Pull
+List open issues, e.g.
+`gh issue list --state open --json number,title,body,labels,author,comments,updatedAt,assignees`.
+
+### 2. Filter to triage targets
+Skip an issue when it is already settled or waiting:
+- carries `triaged-accepted` (a fix PR is open/linked) -> **skip**;
+- carries `triaged-wontfix` or is closed -> **skip**;
+- carries `needs-info` -> **skip _unless_** the author has commented since the
+  label was applied (then re-triage with the new information);
+- has a **human** maintainer label or assignee -> **skip** (never override a
+  human triage decision).
+
+Process at most **5 issues per tick** so a backlog burst can't make a tick long;
+`log()` how many were deferred to the next tick.
+
+### 3. Classify
+Put each remaining issue into **exactly one** bucket:
+
+| Bucket | Signal | Action |
+|---|---|---|
+| **Legitimate & actionable** | A real bug or in-scope feature with enough detail to act on (repro, expected-vs-actual, or a clear ask) | Label `triaged-accepted`; dispatch the **fix workflow** (step 4). |
+| **False-positive / invalid** | Not a real defect — misuse, works-as-designed, out-of-scope, or unreproducible by design | Comment **why**, citing the file/function/behaviour; close; label `triaged-wontfix`. |
+| **Needs info** | Plausible but underspecified — no repro, ambiguous ask, missing version/logs | Comment with **specific** questions; label `needs-info`; leave open; move on. |
+| **Duplicate** | Same root cause as an existing issue | Comment linking the canonical issue; close as duplicate. |
+
+### 4. Fix workflow (for `triaged-accepted`)
+Run a `Workflow` that:
+1. **reproduces / locates** the cause (parallel readers over the relevant code),
+2. **implements** the fix on a `fix/issue-<N>-<slug>` branch (or `feat/…` for a
+   feature),
+3. **opens a PR** with `Closes #<N>`, a summary of the change, and how it was
+   verified. **Never auto-merge** — CI and human review gate the merge.
+4. **comments** on the issue linking the PR.
+
+Match the project's own conventions (branch prefixes, commit format, test
+commands) — read `CLAUDE.md`/`AGENTS.md`/`Makefile` first.
+
+### 5. Re-arm (always)
+`ScheduleWakeup(60, "/issues:fixer", "issue-triage tick")`.
+
+## Triage discipline
+
+- **Conservative on close.** Only close clear false-positives and duplicates.
+  When genuinely unsure -> `needs-info`, never close.
+- **Cite evidence.** Every false-positive reply names the file / function /
+  documented behaviour that makes it a non-issue, so the author can challenge a
+  wrong call.
+- **Respect humans.** Never relabel, reassign, or close an issue a maintainer
+  has already touched.
+- **One reply per state change.** Don't re-ask the same question every tick — the
+  `needs-info` label is the "already asked, waiting" marker.
+- **Idempotent.** Re-running a tick must not double-post a comment, double-apply
+  a label, or open a second PR for the same issue.
+
+## Labels
+
+`triaged-accepted`, `needs-info`, `triaged-wontfix` (plus GitHub's native
+duplicate/closed state). Create a label on first use if it does not exist.
+
+## Per-tick summary
+
+End each tick with one terse line so the unattended loop stays auditable:
+
+```
+tick: <N> open · <A> accepted · <F> closed(false-positive) · <I> needs-info · <D> duplicate · <K> deferred
+```
+
+## Stopping
+
+The loop only ends when the user explicitly says to stop (e.g. "stop
+/issues:fixer"). On that, do a final pass if asked, then **do not re-arm**.


### PR DESCRIPTION
## What

Adds a new namespaced command **`/issues:fixer`** — a self-rescheduling watchdog that keeps a repository's issue tracker triaged and moving **without supervision**.

Each **tick** (every 60 s, never stops):
1. **Pull** the repo's open issues (GitHub MCP, `gh` fallback).
2. **Triage** each into exactly one bucket:
   - **Legitimate & actionable** → label `triaged-accepted` + dispatch a fix **Workflow** that reproduces, fixes on a branch, and opens a PR with `Closes #N` (**never auto-merges** — CI + human review gate it).
   - **False-positive / invalid** → reply **citing the file/function/behaviour** that makes it a non-issue, then close (`triaged-wontfix`).
   - **Needs info** → ask **specific** questions, label `needs-info`, leave open, wait.
   - **Duplicate** → link the canonical issue, close.
3. **Re-arm** via `ScheduleWakeup(60s)` → loops forever (no 7-day cron expiry).

## Design choices

- **Self-`ScheduleWakeup` loop, not cron.** Recurring cron jobs auto-expire after 7 days; the self-reschedule has no cap → satisfies the "never stops" requirement.
- **Conservative & idempotent.** Only closes clear false-positives/duplicates; when unsure → `needs-info`. Skips already-settled or human-triaged issues; re-running a tick never double-posts, double-labels, or opens a second PR.
- **Bounded ticks.** Caps at 5 issues/tick so a backlog burst can't make a tick long; defers the rest to the next minute.
- **Scope-locked.** Operates only on the current repo's own issues (resolved from `git remote`).

## Files

- `.devcontainer/images/.claude/commands/issues/fixer.md` — the command.
- `.devcontainer/images/.claude/CLAUDE.md` — registered in the skills table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## `/issues:fixer` – Continuous Self-Rescheduling Issue Triage Watchdog

**What**

Introduces a new namespaced command (`/issues:fixer`) that implements a never-stopping, self-rescheduling watchdog for continuous GitHub issue triage. Unlike standard cron jobs that auto-expire after 7 days, this command runs on a 60-second loop indefinitely, triaging open issues into four buckets and taking automated action until explicitly stopped.

**Why**

Standard cron-based automation is limited to 7-day expiration windows, making it unsuitable for persistent background triage work. This self-rescheduling pattern (via `ScheduleWakeup(delaySeconds: 60)`) provides indefinite uptime while keeping processing bounded and tick-duration short.

**How**

The implementation spans two files:
- **`.devcontainer/images/.claude/commands/issues/fixer.md`** (134 lines): Complete triage workflow specification defining:
  - 60-second tick cadence with mandatory re-arm (no cron; uses `ScheduleWakeup`)
  - Four-bucket triage logic: **legitimate → fix Workflow + PR** | **false-positive → comment + close** | **unclear → ask questions + label** | **duplicate → link + close**
  - Idempotency guarantees (skip already-triaged, prevent duplicate comments/labels/PRs)
  - Per-tick processing capped at 5 issues to prevent long-running ticks
  - Fix workflow steps: reproduce, implement, open PR with `Closes `#N``, never auto-merge
  - Discipline rules: cite evidence for closures, respect human maintainers, conservative closing
  - Three custom labels: `triaged-accepted`, `needs-info`, `triaged-wontfix`
- **`.devcontainer/images/.claude/CLAUDE.md`** (+1 line): Skill registration in command table

On each tick:
1. Retrieves open issues via GitHub MCP tools (`mcp__github__*`), falling back to `gh` CLI
2. Filters and classifies issues (skipping human-maintained, already-triaged, or needs-info without new author comments)
3. Dispatches fix Workflows for actionable bugs, or posts questions/closes invalid issues
4. Re-arms itself for the next 60-second tick

**Risk**

- **Concurrency/State Management**: Idempotency relies entirely on label-based state tracking; label presence/absence must be consistent across ticks. No transactional safety for concurrent re-arming.
- **GitHub API Rate Limiting**: Multiple MCP/`gh` calls per tick accumulate; bounded processing (5 issues/tick) mitigates but does not eliminate risk during high-volume bursts.
- **Workflow Dispatch**: Automatically creates fix PRs; safety depends on project CI validation + mandatory human review (PRs never auto-merge by design).
- **Issue Scope**: Operates only on the repository's own issues (scope resolved via `git remote`); no cross-repo access.

**No breaking changes, new dependencies, or auth/crypto modifications. Purely additive documentation.** Emphasizes conservative defaults: requires evidence for closures, respects human-applied labels, and enforces idempotency to prevent duplicate actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->