### PR TITLE
fix(ci): make the docker build guard and image names portable

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -34,8 +34,8 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: kodflow/devcontainer-template
-  BASE_IMAGE_NAME: kodflow/devcontainer-base
+  IMAGE_NAME: ${{ github.repository }}
+  BASE_IMAGE_NAME: ${{ github.repository_owner }}/devcontainer-base
 
 jobs:
   # =============================================================================

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -42,8 +42,16 @@ jobs:
   # Base image: stable layers (apt, PPA, Cloud CLIs) — rebuilt weekly
   # =============================================================================
   build-base:
+    # Fork guard. Intent: never burn a fork's Actions minutes (nor fail on its
+    # missing packages:write) with the upstream daily/weekly rebuild. This MUST
+    # stay repository-agnostic: this workflow is copied verbatim into derived
+    # repositories, so a hard-coded `github.repository == '<owner>/<repo>'` is
+    # false by construction downstream and silently skips 100% of the jobs.
+    # `!= true` (not `== false`) is deliberate: any event payload that omits
+    # `repository` yields null and must fail OPEN (build runs) rather than
+    # reintroduce a silent skip.
     if: >-
-      github.repository == 'kodflow/devcontainer-template' && (
+      github.event.repository.fork != true && (
         github.event.schedule == '0 3 * * 0' ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.rebuild_base == 'true') ||
         (github.event_name == 'push' && contains(github.event.head_commit.message, '[base]'))
@@ -114,7 +122,8 @@ jobs:
 
   # Merge base architectures into multi-arch manifest
   merge-base:
-    if: github.repository == 'kodflow/devcontainer-template'
+    # Fork guard — see build-base.
+    if: github.event.repository.fork != true
     runs-on: ubuntu-latest
     needs: build-base
     permissions:
@@ -155,7 +164,7 @@ jobs:
     needs: merge-base
     if: >-
       always() &&
-      github.repository == 'kodflow/devcontainer-template' &&
+      github.event.repository.fork != true &&
       github.event.schedule != '0 3 * * 0' &&
       (needs.merge-base.result == 'success' || needs.merge-base.result == 'skipped') &&
       !failure() && !cancelled()
@@ -329,7 +338,7 @@ jobs:
   merge:
     if: >-
       always() &&
-      github.repository == 'kodflow/devcontainer-template' &&
+      github.event.repository.fork != true &&
       github.event_name != 'pull_request' &&
       needs.build.result == 'success'
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -70,6 +70,15 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
+      # OCI reference names must be lowercase, but github.repository keeps the
+      # repository's real case and the expression syntax has no lowercase
+      # function. Re-export through $GITHUB_ENV, which overrides the
+      # workflow-level default for the remaining steps of this job.
+      - name: Normalise image names to lowercase
+        run: |
+          echo "IMAGE_NAME=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+          echo "BASE_IMAGE_NAME=$(echo "$BASE_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -131,6 +140,15 @@ jobs:
       packages: write
 
     steps:
+      # OCI reference names must be lowercase, but github.repository keeps the
+      # repository's real case and the expression syntax has no lowercase
+      # function. Re-export through $GITHUB_ENV, which overrides the
+      # workflow-level default for the remaining steps of this job.
+      - name: Normalise image names to lowercase
+        run: |
+          echo "IMAGE_NAME=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+          echo "BASE_IMAGE_NAME=$(echo "$BASE_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -182,6 +200,15 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
+      # OCI reference names must be lowercase, but github.repository keeps the
+      # repository's real case and the expression syntax has no lowercase
+      # function. Re-export through $GITHUB_ENV, which overrides the
+      # workflow-level default for the remaining steps of this job.
+      - name: Normalise image names to lowercase
+        run: |
+          echo "IMAGE_NAME=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+          echo "BASE_IMAGE_NAME=$(echo "$BASE_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -348,6 +375,15 @@ jobs:
       packages: write
 
     steps:
+      # OCI reference names must be lowercase, but github.repository keeps the
+      # repository's real case and the expression syntax has no lowercase
+      # function. Re-export through $GITHUB_ENV, which overrides the
+      # workflow-level default for the remaining steps of this job.
+      - name: Normalise image names to lowercase
+        run: |
+          echo "IMAGE_NAME=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+          echo "BASE_IMAGE_NAME=$(echo "$BASE_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
Every job in docker-images.yml was gated on `github.repository == 'kodflow/devcontainer-template'`. That condition is true only in the template repo: every copy inherits a guard that is false by construction, so its scheduled builds skip 100% of their jobs silently and no image is ever produced.

Guard on the fork flag instead — `github.event.repository.fork != true` — which preserves the original intent (never burn a fork's Actions minutes) and evaluates correctly in the source and in every copy. `!= true` rather than `== false` so an absent `github.event.repository` leaves the guard open instead of reproducing the silent skip.

IMAGE_NAME/BASE_IMAGE_NAME were pinned to the template repo the same way, so a copy that starts building would push to the template owner GHCR namespace. Both are now derived from the github context and resolve to the running repository's own namespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**What:** Makes Docker image builds portable across repositories copied from the template.

**Why:** Prevents fork builds and publishes images to the active repository’s GHCR namespace.

**How:** Uses `github.event.repository.fork != true` as the build guard and derives `IMAGE_NAME` and `BASE_IMAGE_NAME` from GitHub repository context. The base-image guard intentionally fails open when repository metadata is absent.

**Risk:** No new dependencies, public API changes, database migrations, or security-sensitive changes. Review GHCR permissions and the intentional fail-open behavior before deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->