### PR TITLE
fix(devcontainer): harden CodeRabbit installer and status-line downloads

### DIFF
--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -145,8 +145,10 @@ USER vscode
 # hadolint ignore=DL4006
 RUN mkdir -p "$HOME/.local/bin" && \
     for attempt in 1 2 3 4 5; do \
-      curl -fsSL --retry 3 --retry-delay 2 https://cli.coderabbit.ai/install.sh -o /tmp/cr-install.sh || true; \
-      sh /tmp/cr-install.sh || true; \
+      rm -f /tmp/cr-install.sh; \
+      if curl -fsSL --retry 3 --retry-delay 2 https://cli.coderabbit.ai/install.sh -o /tmp/cr-install.sh; then \
+        sh /tmp/cr-install.sh || true; \
+      fi; \
       if [ -x "$HOME/.local/bin/coderabbit" ]; then \
         echo "CodeRabbit CLI installed (attempt $attempt)" >&2; \
         rm -f /tmp/cr-install.sh; \
@@ -177,10 +179,12 @@ RUN NODE_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "x64") && \
 # =============================================================================
 RUN ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     mkdir -p ~/.local/bin && \
-    echo "Installing status-line (latest)..." && \
-    curl -fsSL "https://github.com/kodflow/status-line/releases/latest/download/status-line-linux-${ARCH}" \
+    SL_TAG=$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/kodflow/status-line/releases/latest) && \
+    SL_TAG=${SL_TAG##*/} && \
+    echo "Installing status-line (${SL_TAG})..." && \
+    curl -fsSL "https://github.com/kodflow/status-line/releases/download/${SL_TAG}/status-line-linux-${ARCH}" \
       -o ~/.local/bin/status-line && \
-    curl -fsSL "https://github.com/kodflow/status-line/releases/latest/download/status-line-linux-${ARCH}.sha256" \
+    curl -fsSL "https://github.com/kodflow/status-line/releases/download/${SL_TAG}/status-line-linux-${ARCH}.sha256" \
       -o /tmp/status-line.sha256 && \
     sed -i "s|status-line-linux-${ARCH}|$HOME/.local/bin/status-line|" /tmp/status-line.sha256 && \
     sha256sum -c /tmp/status-line.sha256 && rm -f /tmp/status-line.sha256 && \


### PR DESCRIPTION
Two hardening fixes on the image Dockerfile, mirroring the review feedback on the downstream sync PRs (kodflow/view#10, kodflow/mngt.making.codes#3):

- **CodeRabbit installer**: remove any stale `/tmp/cr-install.sh` before each retry and only execute the installer when the download succeeded. Previously a leftover file from a failed attempt could be re-executed.
- **status-line**: resolve the release tag once (via the `releases/latest` redirect) and download both the binary and its `.sha256` from that same tag. Previously each download resolved `latest` independently, so a release published in between produced a checksum mismatch and failed the build.

Applying it here keeps the template as the source of truth so the next sync does not reintroduce the issues.