### PR TITLE
fix(devcontainer): retry status-line downloads on transient 5xx

### DIFF
--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -38,9 +38,12 @@ ARG RTK_VERSION=v0.38.0
 # curl + successful tar (e.g., empty body extracts cleanly to nothing)
 # would silently produce an image without rtk. Splitting the steps means
 # curl's exit status fails the layer immediately. Hadolint DL4006.
-RUN echo "Installing rtk ${RTK_VERSION}..." && \
+RUN --mount=type=secret,id=github_token \
+    echo "Installing rtk ${RTK_VERSION}..." && \
     RTK_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64-unknown-linux-gnu" || echo "x86_64-unknown-linux-musl") && \
-    curl -fsSL --retry 5 --retry-delay 5 "https://github.com/rtk-ai/rtk/releases/download/${RTK_VERSION}/rtk-${RTK_ARCH}.tar.gz" \
+    GITHUB_TOKEN=$(cat /run/secrets/github_token 2>/dev/null || true) && \
+    RTK_URL=$(curl -fsSL --retry 5 --retry-delay 5 ${GITHUB_TOKEN:+-H "Authorization: token ${GITHUB_TOKEN}"} "https://api.github.com/repos/rtk-ai/rtk/releases/tags/${RTK_VERSION}" | jq -r --arg n "rtk-${RTK_ARCH}.tar.gz" '"'"'.assets[] | select(.name == $n) | .url'"'"') && \
+    curl -fsSL --retry 5 --retry-delay 5 -H "Accept: application/octet-stream" ${GITHUB_TOKEN:+-H "Authorization: token ${GITHUB_TOKEN}"} "$RTK_URL" \
       -o /tmp/rtk.tar.gz && \
     tar xzf /tmp/rtk.tar.gz -C /usr/local/bin rtk && \
     rm -f /tmp/rtk.tar.gz

--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -179,12 +179,12 @@ RUN NODE_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "x64") && \
 # =============================================================================
 RUN ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     mkdir -p ~/.local/bin && \
-    SL_TAG=$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/kodflow/status-line/releases/latest) && \
+    SL_TAG=$(curl -fsSLI --retry 3 --retry-delay 2 -o /dev/null -w '%{url_effective}' https://github.com/kodflow/status-line/releases/latest) && \
     SL_TAG=${SL_TAG##*/} && \
     echo "Installing status-line (${SL_TAG})..." && \
-    curl -fsSL "https://github.com/kodflow/status-line/releases/download/${SL_TAG}/status-line-linux-${ARCH}" \
+    curl -fsSL --retry 3 --retry-delay 2 "https://github.com/kodflow/status-line/releases/download/${SL_TAG}/status-line-linux-${ARCH}" \
       -o ~/.local/bin/status-line && \
-    curl -fsSL "https://github.com/kodflow/status-line/releases/download/${SL_TAG}/status-line-linux-${ARCH}.sha256" \
+    curl -fsSL --retry 3 --retry-delay 2 "https://github.com/kodflow/status-line/releases/download/${SL_TAG}/status-line-linux-${ARCH}.sha256" \
       -o /tmp/status-line.sha256 && \
     sed -i "s|status-line-linux-${ARCH}|$HOME/.local/bin/status-line|" /tmp/status-line.sha256 && \
     sha256sum -c /tmp/status-line.sha256 && rm -f /tmp/status-line.sha256 && \

--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -177,10 +177,12 @@ RUN NODE_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "x64") && \
 # =============================================================================
 # User Tools (status-line, xdg-open)
 # =============================================================================
-RUN ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
+RUN --mount=type=secret,id=github_token \
+    ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     mkdir -p ~/.local/bin && \
-    SL_TAG=$(curl -fsSLI --retry 3 --retry-delay 2 -o /dev/null -w '%{url_effective}' https://github.com/kodflow/status-line/releases/latest) && \
-    SL_TAG=${SL_TAG##*/} && \
+    GITHUB_TOKEN=$(cat /run/secrets/github_token 2>/dev/null || true) && \
+    SL_TAG=$(curl -fsSL --retry 3 --retry-delay 2 ${GITHUB_TOKEN:+-H "Authorization: token ${GITHUB_TOKEN}"} "https://api.github.com/repos/kodflow/status-line/releases/latest" | jq -r '.tag_name') && \
+    [ -n "$SL_TAG" ] && [ "$SL_TAG" != "null" ] && \
     echo "Installing status-line (${SL_TAG})..." && \
     curl -fsSL --retry 3 --retry-delay 2 "https://github.com/kodflow/status-line/releases/download/${SL_TAG}/status-line-linux-${ARCH}" \
       -o ~/.local/bin/status-line && \

--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -40,7 +40,7 @@ ARG RTK_VERSION=v0.38.0
 # curl's exit status fails the layer immediately. Hadolint DL4006.
 RUN echo "Installing rtk ${RTK_VERSION}..." && \
     RTK_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64-unknown-linux-gnu" || echo "x86_64-unknown-linux-musl") && \
-    curl -fsSL "https://github.com/rtk-ai/rtk/releases/download/${RTK_VERSION}/rtk-${RTK_ARCH}.tar.gz" \
+    curl -fsSL --retry 5 --retry-delay 5 "https://github.com/rtk-ai/rtk/releases/download/${RTK_VERSION}/rtk-${RTK_ARCH}.tar.gz" \
       -o /tmp/rtk.tar.gz && \
     tar xzf /tmp/rtk.tar.gz -C /usr/local/bin rtk && \
     rm -f /tmp/rtk.tar.gz
@@ -181,12 +181,15 @@ RUN --mount=type=secret,id=github_token \
     ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     mkdir -p ~/.local/bin && \
     GITHUB_TOKEN=$(cat /run/secrets/github_token 2>/dev/null || true) && \
-    SL_TAG=$(curl -fsSL --retry 3 --retry-delay 2 ${GITHUB_TOKEN:+-H "Authorization: token ${GITHUB_TOKEN}"} "https://api.github.com/repos/kodflow/status-line/releases/latest" | jq -r '.tag_name') && \
+    SL_RELEASE=$(curl -fsSL --retry 5 --retry-delay 5 ${GITHUB_TOKEN:+-H "Authorization: token ${GITHUB_TOKEN}"} "https://api.github.com/repos/kodflow/status-line/releases/latest") && \
+    SL_TAG=$(printf '%s' "$SL_RELEASE" | jq -r '.tag_name') && \
     [ -n "$SL_TAG" ] && [ "$SL_TAG" != "null" ] && \
     echo "Installing status-line (${SL_TAG})..." && \
-    curl -fsSL --retry 3 --retry-delay 2 "https://github.com/kodflow/status-line/releases/download/${SL_TAG}/status-line-linux-${ARCH}" \
+    SL_BIN_URL=$(printf '%s' "$SL_RELEASE" | jq -r --arg n "status-line-linux-${ARCH}" '.assets[] | select(.name == $n) | .url') && \
+    SL_SHA_URL=$(printf '%s' "$SL_RELEASE" | jq -r --arg n "status-line-linux-${ARCH}.sha256" '.assets[] | select(.name == $n) | .url') && \
+    curl -fsSL --retry 5 --retry-delay 5 -H "Accept: application/octet-stream" ${GITHUB_TOKEN:+-H "Authorization: token ${GITHUB_TOKEN}"} "$SL_BIN_URL" \
       -o ~/.local/bin/status-line && \
-    curl -fsSL --retry 3 --retry-delay 2 "https://github.com/kodflow/status-line/releases/download/${SL_TAG}/status-line-linux-${ARCH}.sha256" \
+    curl -fsSL --retry 5 --retry-delay 5 -H "Accept: application/octet-stream" ${GITHUB_TOKEN:+-H "Authorization: token ${GITHUB_TOKEN}"} "$SL_SHA_URL" \
       -o /tmp/status-line.sha256 && \
     sed -i "s|status-line-linux-${ARCH}|$HOME/.local/bin/status-line|" /tmp/status-line.sha256 && \
     sha256sum -c /tmp/status-line.sha256 && rm -f /tmp/status-line.sha256 && \

--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -42,7 +42,7 @@ RUN --mount=type=secret,id=github_token \
     echo "Installing rtk ${RTK_VERSION}..." && \
     RTK_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64-unknown-linux-gnu" || echo "x86_64-unknown-linux-musl") && \
     GITHUB_TOKEN=$(cat /run/secrets/github_token 2>/dev/null || true) && \
-    RTK_URL=$(curl -fsSL --retry 5 --retry-delay 5 ${GITHUB_TOKEN:+-H "Authorization: token ${GITHUB_TOKEN}"} "https://api.github.com/repos/rtk-ai/rtk/releases/tags/${RTK_VERSION}" | jq -r --arg n "rtk-${RTK_ARCH}.tar.gz" '"'"'.assets[] | select(.name == $n) | .url'"'"') && \
+    RTK_URL=$(curl -fsSL --retry 5 --retry-delay 5 ${GITHUB_TOKEN:+-H "Authorization: token ${GITHUB_TOKEN}"} "https://api.github.com/repos/rtk-ai/rtk/releases/tags/${RTK_VERSION}" | jq -r --arg n "rtk-${RTK_ARCH}.tar.gz" '.assets[] | select(.name == $n) | .url') && \
     curl -fsSL --retry 5 --retry-delay 5 -H "Accept: application/octet-stream" ${GITHUB_TOKEN:+-H "Authorization: token ${GITHUB_TOKEN}"} "$RTK_URL" \
       -o /tmp/rtk.tar.gz && \
     tar xzf /tmp/rtk.tar.gz -C /usr/local/bin rtk && \

--- a/.devcontainer/images/Dockerfile
+++ b/.devcontainer/images/Dockerfile
@@ -38,10 +38,9 @@ ARG RTK_VERSION=v0.38.0
 # curl + successful tar (e.g., empty body extracts cleanly to nothing)
 # would silently produce an image without rtk. Splitting the steps means
 # curl's exit status fails the layer immediately. Hadolint DL4006.
-RUN --mount=type=secret,id=github_token \
+RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN \
     echo "Installing rtk ${RTK_VERSION}..." && \
     RTK_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64-unknown-linux-gnu" || echo "x86_64-unknown-linux-musl") && \
-    GITHUB_TOKEN=$(cat /run/secrets/github_token 2>/dev/null || true) && \
     RTK_URL=$(curl -fsSL --retry 5 --retry-delay 5 ${GITHUB_TOKEN:+-H "Authorization: token ${GITHUB_TOKEN}"} "https://api.github.com/repos/rtk-ai/rtk/releases/tags/${RTK_VERSION}" | jq -r --arg n "rtk-${RTK_ARCH}.tar.gz" '.assets[] | select(.name == $n) | .url') && \
     curl -fsSL --retry 5 --retry-delay 5 -H "Accept: application/octet-stream" ${GITHUB_TOKEN:+-H "Authorization: token ${GITHUB_TOKEN}"} "$RTK_URL" \
       -o /tmp/rtk.tar.gz && \
@@ -180,10 +179,9 @@ RUN NODE_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "x64") && \
 # =============================================================================
 # User Tools (status-line, xdg-open)
 # =============================================================================
-RUN --mount=type=secret,id=github_token \
+RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN \
     ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     mkdir -p ~/.local/bin && \
-    GITHUB_TOKEN=$(cat /run/secrets/github_token 2>/dev/null || true) && \
     SL_RELEASE=$(curl -fsSL --retry 5 --retry-delay 5 ${GITHUB_TOKEN:+-H "Authorization: token ${GITHUB_TOKEN}"} "https://api.github.com/repos/kodflow/status-line/releases/latest") && \
     SL_TAG=$(printf '%s' "$SL_RELEASE" | jq -r '.tag_name') && \
     [ -n "$SL_TAG" ] && [ "$SL_TAG" != "null" ] && \

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -325,8 +325,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             CACHE_BUST_DYNAMIC=${{ steps.cachebust.outputs.value }}
-          secrets: |
-            github_token=${{ secrets.GITHUB_TOKEN }}
           cache-from: type=gha,scope=build-${{ steps.platform.outputs.pair }}
 
       # Push events: Build and push by digest

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -325,6 +325,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             CACHE_BUST_DYNAMIC=${{ steps.cachebust.outputs.value }}
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
           cache-from: type=gha,scope=build-${{ steps.platform.outputs.pair }}
 
       # Push events: Build and push by digest
@@ -339,6 +341,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             CACHE_BUST_DYNAMIC=${{ steps.cachebust.outputs.value }}
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
           cache-from: type=gha,scope=build-${{ steps.platform.outputs.pair }}
           cache-to: type=gha,mode=max,scope=build-${{ steps.platform.outputs.pair }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true


### PR DESCRIPTION
GitHub intermittently returns 503 on release endpoints (observed on tonight's scheduled-build reruns). The status-line tag resolution and both asset downloads had no `--retry`, so a single transient error failed the whole image build. Add `--retry 3 --retry-delay 2` to the three curls, matching the pattern already used for the CodeRabbit installer download.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**What:** Updates devcontainer image downloads to use authenticated GitHub API requests, retries, and architecture-specific status-line assets.

**Why:** Reduces image build failures caused by transient GitHub 5xx responses during tag resolution and asset downloads.

**How:** Resolves the status-line release through the GitHub Releases API, uses an anonymous fallback for local builds, passes `GITHUB_TOKEN` as a BuildKit secret, and retries GitHub, Bazelisk, and yq downloads up to five times with five-second delays while preserving checksum verification.

**Risk:** Adds security-sensitive token handling to Docker builds. The token must remain a BuildKit secret and must not be written to image layers or logs. No public API, database, or migration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->