### PR TITLE
fix(devcontainer): point ktn-linter installs at the public mirror

### DIFF
--- a/.devcontainer/features/languages/go/devcontainer-feature.json
+++ b/.devcontainer/features/languages/go/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "go",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "name": "Go Development Environment",
   "description": "Installs Go with common development tools and multi-architecture support",
   "options": {

--- a/.devcontainer/features/languages/go/install.sh
+++ b/.devcontainer/features/languages/go/install.sh
@@ -327,11 +327,17 @@ set -e
 # Release asset is goreleaser-style `ktn-linter_linux_<arch>.tar.gz` containing
 # the binary at the tarball root. The legacy hyphenated raw-binary URL never
 # existed as a published asset — that 404 broke every container build because
-# no go-install fallback was wired (issue #324 follow-up). The `cmd/ktn-linter`
-# fallback covers a Releases-CDN blip or future asset-naming skew.
+# no go-install fallback was wired (issue #324 follow-up).
+# Binaries are served from the public distribution repository: the source
+# repository (kodflow/ktn-linter) is private, so resolving releases there
+# 404s for every unauthenticated container build. No `go install` fallback:
+# the source module is private too, so it would fail on authentication and
+# bury the real cause (a CDN blip, or an asset name that drifted again)
+# under a misleading Go toolchain error. An empty package makes
+# install_go_tool report the download failure itself.
 spawn_tool "ktn-linter" \
-    "https://github.com/kodflow/ktn-linter/releases/latest/download/ktn-linter_linux_${GO_ARCH}.tar.gz" \
-    "github.com/kodflow/ktn-linter/cmd/ktn-linter" \
+    "https://github.com/kodflow/ktn/releases/latest/download/ktn-linter_linux_${GO_ARCH}.tar.gz" \
+    "" \
     "tar.gz"
 
 # Bazel tooling — same release ships both binaries.

--- a/.devcontainer/images/.claude/commands/ktn.md
+++ b/.devcontainer/images/.claude/commands/ktn.md
@@ -435,8 +435,9 @@ prompt: |
     b. local_version = `ktn-linter version 2>/dev/null | head -1` (parse
        `ktn-linter version X.Y.Z`). If output contains "dev" → dev_build=true.
     c. latest_tag = WebFetch
-       https://api.github.com/repos/kodflow/ktn-linter/releases/latest →
-       extract `.tag_name` (strip leading `v`).
+       https://api.github.com/repos/kodflow/ktn/releases/latest →
+       extract `.tag_name` (strip leading `v`). (Public mirror — the source
+       repository kodflow/ktn-linter is private and 404s anonymously.)
 
   STEP 2 — Decide
     - absent → INSTALL
@@ -451,10 +452,11 @@ prompt: |
         ~/.local/bin
         ~/bin
       mkdir -p $target_dir && ensure on $PATH
-      asset_url = https://github.com/kodflow/ktn-linter/releases/download/v{{latest_tag}}/ktn-linter-{{GOOS}}-{{GOARCH}}
-      curl -fsSL "$asset_url" -o /tmp/ktn-linter.new
-      chmod +x /tmp/ktn-linter.new
-      mv /tmp/ktn-linter.new $target_dir/ktn-linter
+      asset_url = https://github.com/kodflow/ktn/releases/download/v{{latest_tag}}/ktn-linter_{{GOOS}}_{{GOARCH}}.tar.gz
+      curl -fsSL "$asset_url" -o /tmp/ktn-linter.tar.gz
+      tar -xzf /tmp/ktn-linter.tar.gz -C /tmp ktn-linter
+      chmod +x /tmp/ktn-linter
+      mv /tmp/ktn-linter $target_dir/ktn-linter
     UPGRADE path:
       Prefer `ktn-linter upgrade` (atomic rename in same dir, ErrDevBuild aware).
       If that fails OR dev_build=true, fall back to INSTALL path with --force semantics.

--- a/.devcontainer/images/.claude/commands/ktn.md
+++ b/.devcontainer/images/.claude/commands/ktn.md
@@ -456,7 +456,11 @@ prompt: |
       curl -fsSL "$asset_url" -o /tmp/ktn-linter.tar.gz
       tar -xzf /tmp/ktn-linter.tar.gz -C /tmp ktn-linter
       chmod +x /tmp/ktn-linter
-      mv /tmp/ktn-linter $target_dir/ktn-linter
+      if [[ $target_dir == /usr/local/bin ]]; then
+        sudo -n mv /tmp/ktn-linter $target_dir/ktn-linter
+      else
+        mv /tmp/ktn-linter $target_dir/ktn-linter
+      fi
     UPGRADE path:
       Prefer `ktn-linter upgrade` (atomic rename in same dir, ErrDevBuild aware).
       If that fails OR dev_build=true, fall back to INSTALL path with --force semantics.

--- a/.devcontainer/images/hooks/lifecycle/sync-toolchains.sh
+++ b/.devcontainer/images/hooks/lifecycle/sync-toolchains.sh
@@ -203,15 +203,21 @@ sync_go() {
     local tool installed upstream major_pin
     # Atomic install for ktn-linter (goreleaser tarball, not a Go module path).
     # Writes to a sibling .download path then renames — protects against a
-    # half-fetched payload if curl is interrupted mid-stream. Falls back to
-    # `go install …/cmd/ktn-linter` if the release CDN 404s (asset-naming
-    # drift) or times out. Returns non-zero only when both paths fail.
+    # half-fetched payload if curl is interrupted mid-stream.
+    #
+    # Binaries are served from the public distribution repository: the
+    # source repository (kodflow/ktn-linter) is private, so resolving
+    # releases there 404s for every unauthenticated container build. No
+    # `go install` fallback either: the source module is private too, so it
+    # would fail on authentication and bury the real cause (a CDN blip, or
+    # an asset name that drifted again) under a misleading Go toolchain
+    # error — better to return non-zero and let the caller say so plainly.
     install_ktn_linter() {
         local target="${GOPATH}/bin/ktn-linter"
         local tmp_tgz="${target}.download.tgz"
         local tmp_bin="${target}.download"
         if curl -fsSL --connect-timeout 10 --max-time 60 \
-                "https://github.com/kodflow/ktn-linter/releases/latest/download/ktn-linter_linux_${GO_ARCH}.tar.gz" \
+                "https://github.com/kodflow/ktn/releases/latest/download/ktn-linter_linux_${GO_ARCH}.tar.gz" \
                 -o "$tmp_tgz" 2>/dev/null \
             && tar -xzf "$tmp_tgz" -C "$(dirname "$tmp_bin")" ktn-linter 2>/dev/null \
             && mv -f "$(dirname "$tmp_bin")/ktn-linter" "$tmp_bin" \
@@ -221,10 +227,6 @@ sync_go() {
             return 0
         fi
         rm -f "$tmp_tgz" "$tmp_bin"
-        if command -v go >/dev/null 2>&1 \
-            && go install "github.com/kodflow/ktn-linter/cmd/ktn-linter@latest" 2>/dev/null; then
-            return 0
-        fi
         return 1
     }
 
@@ -243,8 +245,10 @@ sync_go() {
                 # every container rebuild — `command -v` short-circuited the
                 # install path even when a newer release was available. Mirrors
                 # the GO_TOOL_REPOS pattern (#330) but with direct asset download.
+                # Probes the public mirror, not the (private) source repo — same
+                # reason install_ktn_linter downloads from there.
                 installed=$(installed_tool_version ktn-linter)
-                upstream=$(upstream_latest_version "kodflow/ktn-linter")
+                upstream=$(upstream_latest_version "kodflow/ktn")
                 if [ -z "$upstream" ]; then
                     # Network/rate-limit failure: keep an existing binary, only
                     # install when truly missing (best-effort cold-start path).

--- a/tests/scripts/sync-toolchains.bats
+++ b/tests/scripts/sync-toolchains.bats
@@ -85,15 +85,19 @@ teardown() {
     ! grep -qE 'go install "\$\{?tool\}?@latest"' "$SYNC_SH"
 }
 
-@test "sync_go installs ktn-linter from the goreleaser release tarball (with go install fallback)" {
+@test "sync_go installs ktn-linter from the goreleaser release tarball via the public mirror" {
     # The hyphenated raw-binary URL never existed as a published asset and
     # 404'd every container build (#371). Asset is goreleaser-style:
     # `ktn-linter_linux_<arch>.tar.gz` with the binary at the tarball root.
-    # A `go install …/cmd/ktn-linter` fallback covers CDN blips / asset
-    # rename drift so a single 404 cannot abort the entire Go feature.
-    grep -qF 'github.com/kodflow/ktn-linter/releases/latest/download/ktn-linter_linux_' "$SYNC_SH"
+    # Served from the public mirror (kodflow/ktn): the source repository is
+    # private, so an anonymous container build 404s resolving releases there
+    # — and a `go install` fallback can't rescue that either, since the
+    # source module is private too. No fallback: a failed download is
+    # reported as exactly that.
+    grep -qF 'github.com/kodflow/ktn/releases/latest/download/ktn-linter_linux_' "$SYNC_SH"
     grep -qF '.tar.gz' "$SYNC_SH"
-    grep -qF 'github.com/kodflow/ktn-linter/cmd/ktn-linter@latest' "$SYNC_SH"
+    ! grep -qF 'kodflow/ktn-linter/releases' "$SYNC_SH"
+    ! grep -qF 'go install "github.com/kodflow/ktn-linter/cmd/ktn-linter@latest"' "$SYNC_SH"
     ! grep -qF 'ktn-linter-linux-' "$SYNC_SH"
 }
 
@@ -102,7 +106,7 @@ teardown() {
     # masked a stale volume-cached binary even when a newer release shipped.
     # The new code probes upstream tag and reinstalls on mismatch — symmetric
     # with the GO_TOOL_REPOS path used for golangci-lint/gosec.
-    grep -qF 'upstream_latest_version "kodflow/ktn-linter"' "$SYNC_SH"
+    grep -qF 'upstream_latest_version "kodflow/ktn"' "$SYNC_SH"
     grep -q 'installed=\$(installed_tool_version ktn-linter)' "$SYNC_SH"
     # Drift branch: `elif [ "$installed" != "$upstream" ]` triggers reinstall.
     grep -qE 'elif \[ "\$installed" != "\$upstream" \]' "$SYNC_SH"

--- a/tests/scripts/sync-toolchains.bats
+++ b/tests/scripts/sync-toolchains.bats
@@ -97,8 +97,14 @@ teardown() {
     grep -qF 'github.com/kodflow/ktn/releases/latest/download/ktn-linter_linux_' "$SYNC_SH"
     grep -qF '.tar.gz' "$SYNC_SH"
     ! grep -qF 'kodflow/ktn-linter/releases' "$SYNC_SH"
-    ! grep -qF 'go install "github.com/kodflow/ktn-linter/cmd/ktn-linter@latest"' "$SYNC_SH"
     ! grep -qF 'ktn-linter-linux-' "$SYNC_SH"
+    # Scope the "no go install fallback" guarantee to the whole function body,
+    # not one exact literal — any spelling of a go-install call for any ktn
+    # package inside install_ktn_linter would equally defeat the point (the
+    # module is private, so it can never succeed for an anonymous build).
+    awk '/^    install_ktn_linter\(\) \{/,/^    \}/' "$SYNC_SH" > /tmp/install_ktn_linter_body.$$
+    ! grep -q 'go install' /tmp/install_ktn_linter_body.$$
+    rm -f /tmp/install_ktn_linter_body.$$
 }
 
 @test "sync_go auto-refreshes ktn-linter against upstream (no skip-if-installed)" {


### PR DESCRIPTION
## Why

kodflow/ktn-linter (the source repository) went private. Every consumer here
still resolved release assets and version probes against it — same failure
class these scripts were originally hardened against (issue #324 follow-up),
reintroduced by the privacy change. Tracked upstream at
kodflow/ktn-linter#432 ("same 404 as #428, in the external repo"), which
names this repo explicitly as needing the equivalent fix.

Equivalent (already-merged) fix on the source side:
kodflow/ktn-linter#427.

## What

- `go/install.sh`: release asset URL → `kodflow/ktn` (public mirror). Dropped
  the `go install` fallback — the source module is private too, so it would
  fail on authentication and bury the real cause under a misleading Go
  toolchain error.
- `sync-toolchains.sh`: same URL fix in `install_ktn_linter()`, and the
  `upstream_latest_version` drift probe now queries the mirror instead of the
  private repo's releases API.
- `.claude/commands/ktn.md`: same repo fix for the install/upgrade
  instructions, plus corrected the asset naming — goreleaser
  `ktn-linter_<os>_<arch>.tar.gz`, not the hyphenated raw-binary name that
  has never actually been a published asset.
- `sync-toolchains.bats`: updated the two assertions pinned to the old
  repo/fallback shape.

## Scope note

This repo's copies of these scripts have diverged substantially from
ktn-linter's own (govulncheck, retry/failure-marker handling, upstream
version-drift probing, critical-tool gating — none of that exists in the
source repo's copy). This PR is deliberately narrow: only the wrong-repo /
dead-fallback problem, ported into this repo's existing structure rather
than replacing it wholesale with the source repo's simpler version.

## Verification

No Go/Bazel/bats in the sandbox that authored this. Verified by:
- `bash -n` on both changed shell scripts (syntax only).
- Every `grep` assertion in `sync-toolchains.bats` run by hand against the
  patched script — see the diff, all pass.
- `install.sh`/`ktn.md` changes are mechanical repo-name + asset-name swaps,
  cross-checked against the equivalent, already-merged, CI-verified change
  in kodflow/ktn-linter#427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**What:** Migrates `ktn-linter` installation and version checks from `kodflow/ktn-linter` to the public `kodflow/ktn` mirror.

**Why:** The private repository references and module fallback are invalid for public installation.

**How:** Updates release URLs, archive naming, version probes, documentation, and Bats assertions; removes the `go install` fallback; bumps the Go feature version to `1.2.4`.

**Risk:** This is a supply chain change. Installations now depend on release assets from `kodflow/ktn`, and failed downloads no longer fall back to `go install`. No new dependencies, public API changes, authentication, secrets, or database changes are introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->