### PR TITLE
chore(test): verify the post-commit gate rejects attribution

### DIFF
--- a/.post-commit-proof
+++ b/.post-commit-proof
@@ -1,0 +1,1 @@
+proof that the post-commit gate rejects an attributed commit


### PR DESCRIPTION
**Throwaway PR — will be closed and its branch deleted as soon as the check reports.**

Its single commit deliberately carries `Co-authored-by: Claude <noreply@anthropic.com>`.
The purpose is to prove, on the real repository and with the ruleset active,
that the `post-commit` gate goes red on an attributed commit and that the
merge is therefore blocked — the guarantee the local `--no-verify`-skippable
hook never provided.

Expected: `post-commit` fails, the merge is blocked, nothing here is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**What:** Added `.post-commit-proof` to document the post-commit gate test.

**Why:** The commit tests rejection of a `Co-authored-by: Claude <noreply@anthropic.com>` attribution.

**How:** Added one documentation line without changing exported entities or runtime code.

**Risk:** No dependencies, public API changes, security-sensitive code, or migration steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->